### PR TITLE
inst_root.ycp: Fix encoding to UTF-8

### DIFF
--- a/src/inst_root.ycp
+++ b/src/inst_root.ycp
@@ -32,7 +32,7 @@
  *
  * After all the password is crypted and written into the user_settings.
  *
- * Authors:     Klaus Kämpf <kkaempf@suse.de>
+ * Authors:     Klaus KÃ¤mpf <kkaempf@suse.de>
  *
  * $Id$
  */


### PR DESCRIPTION
Without this, Ruby translation of this file won't work.
