### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/clients/inst_auth.rb
+++ b/src/clients/inst_auth.rb
@@ -465,7 +465,7 @@ module Yast
         )
       end
       UI.CloseDialog
-      ret == :ok ? selected : nil
+      ret == :ok ? deep_copy(selected) : nil
     end
   end
 end

--- a/src/clients/inst_user_first.rb
+++ b/src/clients/inst_user_first.rb
@@ -791,7 +791,7 @@ module Yast
         )
       end
       UI.CloseDialog
-      ret == :ok ? selected : nil
+      ret == :ok ? deep_copy(selected) : nil
     end
 
     # Dialog for expert user settings: authentication method as well

--- a/src/include/users/ldap_dialogs.rb
+++ b/src/include/users/ldap_dialogs.rb
@@ -586,7 +586,7 @@ module Yast
           end
         end
       end
-      result == :next ? ret : nil
+      result == :next ? deep_copy(ret) : nil
     end
 
     # Dialog for administering User & Group specific LDAP settigns


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
