### PR TITLE
BNC#863612 YaST reports Cannot find client ldap/routines.rb

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 13 11:01:33 UTC 2014 - varkoly@suse.com
+
+- BNC#863612 YaST reports Cannot find client ldap/routines.rb 
+- 3.1.9
+
+-------------------------------------------------------------------
 Wed Feb 12 11:53:03 UTC 2014 - jreidinger@suse.com
 
 - fix namespace collision leading to error message in installation

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/users/ldap_dialogs.rb
+++ b/src/include/users/ldap_dialogs.rb
@@ -37,8 +37,6 @@ module Yast
       Yast.import "Users"
       Yast.import "Wizard"
 
-      Yast.include include_target, "ldap/routines.rb"
-
       textdomain "users"
     end
 
@@ -905,7 +903,7 @@ module Yast
               Ops.set(ppolicy, "modified", "added")
               Ops.set(ppolicy, "pwdAttribute", "userPassword")
               Ops.set(ppolicy, "objectClass", ["pwdPolicy", "namedObject"])
-              Ops.set(ppolicy, "cn", get_cn(dn))
+              Ops.set(ppolicy, "cn", Ldap.get_cn(dn))
               Ops.set(write_ppolicies, dn, ppolicy)
             else
               pp = {}


### PR DESCRIPTION
The routines written in ldap/routines.rb now will be provided by Ldap.rb.
