### PR TITLE
- do not encrypt already crypted password of imported user

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 25 11:27:14 CET 2014 - jsuchome@suse.cz
+
+- do not encrypt already crypted password of imported user
+  (bnc#869798)
+- 3.1.18
+
+-------------------------------------------------------------------
 Mon Mar 17 10:59:37 UTC 2014 - ckornacker@suse.com
 
 - fix exception on missing yast2-auth-client module (bnc#868437)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.17
+Version:        3.1.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_user_first.rb
+++ b/src/clients/inst_user_first.rb
@@ -398,6 +398,7 @@ module Yast
           @to_import.each do |name|
             u = @imported_users.fetch(name, {})
             u["__imported"] = true
+            u["encrypted"] = true
             create_users << u
           end
 


### PR DESCRIPTION
Do not encrypt already crypted password of imported user: the original solution was lost during the second-stage removal.

  (bnc#869798)
