### PR TITLE
- enable changing of cn value if LDAP user is not saved yet

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 20 10:44:41 CET 2014 - jsuchome@suse.cz
+
+- enable changing of cn value if LDAP user is not saved yet
+  (bnc#904645)
+- 3.1.35
+
+-------------------------------------------------------------------
 Thu Oct 16 12:31:21 CEST 2014 - jsuchome@suse.cz
 
 - fix calling auth client (bnc#901419)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.34
+Version:        3.1.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1145,7 +1145,8 @@ module Yast
                 givenname = ""
               end
             end
-            if cn == "" &&
+            # enable changing of cn value only if LDAP user is not saved yet (bnc#904645)
+            if (cn == "" || action == "added") &&
                 # no substitution when editing: TODO bug 238282
                 (what == "edit_user" ||
                   !# cn should not be substitued:


### PR DESCRIPTION
  (bnc#904645)
- 3.1.35

SLE12 version of https://github.com/yast/yast-users/pull/63
