### PR TITLE
Fix users import

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Mar  5 11:04:17 UTC 2016 - igonzalezsosa@suse.com
+
+- Do not include inst-sys users when cloning the configuration
+  after the installation (bnc#965852)
+- 3.1.41.2
+
+-------------------------------------------------------------------
 Thu Feb 18 14:00:19 CET 2016 - schubi@suse.de
 
 - Do not crash autoinstallation if the home directory of a user is

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.41.1
+Version:        3.1.41.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6154,7 +6154,7 @@ sub Import {
     # remove cache entries (#50265)
     UsersCache->ResetCache ();
 
-    my $error_msg = Mode->test () ? "" : $self->ReadLocal ();
+    my $error_msg = (Mode->test() || Stage->initial()) ? "" : $self->ReadLocal ();
     if ($error_msg) {
 	return 0;
     }

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6154,6 +6154,7 @@ sub Import {
     # remove cache entries (#50265)
     UsersCache->ResetCache ();
 
+    # Avoid to read local users during 1st stage (bnc#965852)
     my $error_msg = (Mode->test() || Stage->initial()) ? "" : $self->ReadLocal ();
     if ($error_msg) {
 	return 0;

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5887,7 +5887,7 @@ sub ImportUser {
 
     if ($uid == -1 || Stage->initial()) {
 	# Check for existence of this user (and change it with given values).
-  # During 1st stage we simply match by username (bnc#965852).
+	# During 1st stage we simply match by username (bnc#965852).
 	my %existing 	= %{$self->GetUserByName ($username, "")};
 	if (%existing) {
 	
@@ -5911,7 +5911,7 @@ sub ImportUser {
 		$cn eq "") {
 		$cn		= $existing{"cn"} || "";
 	    }
-	    if ($gid == -1) {
+	    if ($gid == -1 || Stage->initial()) {
 		$gid		= $existing{"gidNumber"};
 	    }
 	    %ret	= (
@@ -6001,8 +6001,9 @@ sub ImportGroup {
 	$gid		= $group{"gid"} if (!defined $gid);
 	$gid		= -1 if (!defined $gid);
     }
-    if ($gid == -1) {
-	# check for existence of this group (and change it with given values)
+    if ($gid == -1 || Stage->initial()) {
+	# Check for existence of this group (and change it with given values).
+	# During 1st stage we simply match by groupname (bnc#965852).
 	my $existing 	= $self->GetGroupByName ($groupname, "");
 	if (ref ($existing) eq "HASH" && %{$existing}) {
 	    $gid	= $existing->{"gidNumber"};

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5885,8 +5885,9 @@ sub ImportUser {
 	}
     }
 
-    if ($uid == -1) {
-	# check for existence of this user (and change it with given values)
+    if ($uid == -1 || Stage->initial()) {
+	# Check for existence of this user (and change it with given values).
+  # During 1st stage we simply match by username (bnc#965852).
 	my %existing 	= %{$self->GetUserByName ($username, "")};
 	if (%existing) {
 	


### PR DESCRIPTION
This patch fixes users import during autoinstallation. It's related to [bsc#965852](https://bugzilla.suse.com/show_bug.cgi?id=965852).

The original problem is that before doing the import, all local users (inst-sys users) were read, so inst-sys users where merged with imported ones. In this stage, we should ignore inst-sys users. That's not a problem during autoupgrade, as long as users are not modified/created in that scenario.