### PR TITLE
Fix users import when an entry in /etc/shadow is missing

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Thu May  5 12:32:39 UTC 2016 - igonzalezsosa@suse.com
 
-- Fix users import when an entry in /etc/shadow is missing
-  (bsc#978648)
+- Fix users import when entries for all non-system users are missing in
+  /etc/shadow (bsc#978648)
 - 3.1.48
 
 -------------------------------------------------------------------

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  5 12:32:39 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix users import when an entry in /etc/shadow is missing
+  (bsc#978648)
+- 3.1.48
+
+-------------------------------------------------------------------
 Thu Apr  7 08:49:13 UTC 2016 - igonzalezsosa@suse.com
 
 - Does not set empty passwords fields in /etc/shadow during

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.47
+Version:        3.1.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/UsersSimple.pm
+++ b/src/modules/UsersSimple.pm
@@ -956,7 +956,7 @@ sub GetImportedUsers {
     if (defined $imported_users{$type} && ref($imported_users{$type}) eq "HASH")
     {
 	%ret 	= %{$imported_users{$type}};
-	next if (!defined $imported_shadow{$type});
+	return \%ret if (!defined $imported_shadow{$type});
 	# add the shadow data into each user map
 	foreach my $username (keys %ret) {
 	    next if (!defined $imported_shadow{$type}{$username});


### PR DESCRIPTION
* Fixes [bsc#978648](https://bugzilla.suse.com/show_bug.cgi?id=978648).