### PR TITLE
Don't write authorized_keys if it's not  a regular file

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -3,6 +3,7 @@ Tue Sep 20 15:10:23 UTC 2016 - igonzalezsosa@suse.com
 
 - Prevent a potential security issue if the target authorized_keys
   file is not a regular file (related to FATE#319471)
+- Fix authorized_keys section of AutoYaST schema
 - 3.1.59
 
 -------------------------------------------------------------------

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 20 15:10:23 UTC 2016 - igonzalezsosa@suse.com
+
+- Prevent a potential security issue if authorized_keys file is
+  not a regular file (FATE#319471)
+- 3.1.59
+
+-------------------------------------------------------------------
 Fri Sep 16 09:03:32 UTC 2016 - igonzalezsosa@suse.com
 
 - Add support to specify SSH authorized keys in the profile

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Sep 20 15:10:23 UTC 2016 - igonzalezsosa@suse.com
 
-- Prevent a potential security issue if authorized_keys file is
-  not a regular file (FATE#319471)
+- Prevent a potential security issue if the target authorized_keys
+  file is not a regular file (related to FATE#319471)
 - 3.1.59
 
 -------------------------------------------------------------------

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.58
+Version:        3.1.59
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/users.rnc
+++ b/src/autoyast-rnc/users.rnc
@@ -35,8 +35,9 @@ user_defaults =
     umask?
   }
 
+# by default, AutoYaST exports list entries as 'listentry'
 authorized_key =
-  element authorized_key { text }
+  element authorized_key { text } | element listentry { text }
 
 authorized_keys =
   element authorized_keys {

--- a/src/lib/users/ssh_authorized_keys_file.rb
+++ b/src/lib/users/ssh_authorized_keys_file.rb
@@ -41,6 +41,9 @@ module Yast
       # @return [Pathname,String] Path to the file
       attr_reader :path
 
+      # authorized_keys exists but it's not a regular file
+      class NotRegularFile < StandardError; end
+
       # Constructor
       #
       # @param path [Pathname,String] Path to the file
@@ -107,7 +110,11 @@ module Yast
       #
       # @return [Boolean] +true+ if file was written; +false+ otherwise.
       def save
-        SCR.Execute(Path.new(".target.bash"), "umask 0077 && touch #{path}")
+        if FileUtils::Exists(path)
+          raise NotRegularFile unless FileUtils::IsFile(path)
+        else
+          SCR.Execute(Path.new(".target.bash"), "umask 0077 && touch #{path}")
+        end
         content = keys.join("\n") + "\n"
         SCR.Write(Path.new(".target.string"), path, content)
       end

--- a/src/modules/SSHAuthorizedKeys.rb
+++ b/src/modules/SSHAuthorizedKeys.rb
@@ -52,20 +52,28 @@ module Yast
       Report.Warning(
         # TRANSLATORS: '%s' is a directory path
         format(_("Home directory '%s' does not exist\n" \
-                 "so authorized keys will not be written."), e.directory)
+                 "so authorized keys will not be written."), e.path)
       )
     rescue Users::SSHAuthorizedKeyring::NotRegularSSHDirectory => e
       log.warn(e.message)
       Report.Warning(
         # TRANSLATORS: '%s' is a directory path
-        format(_("'%s' exists but it is not a directory. It may\n" \
+        format(_("'%s' exists but it is not a directory. It might be\n" \
                  "a security issue so authorized keys will not\n" \
-                 "be written."), e.directory)
+                 "be written."), e.path)
+      )
+    rescue Users::SSHAuthorizedKeyring::NotRegularAuthorizedKeysFile => e
+      log.warn(e.message)
+      Report.Warning(
+        # TRANSLATORS: '%s' is a directory path
+        format(_("'%s' exists but it is not a file. It might be\n" \
+                 "a security issue so authorized keys will not\n" \
+                 "be written."), e.path)
       )
     rescue Users::SSHAuthorizedKeyring::CouldNotCreateSSHDirectory => e
       log.warn(e.message)
       Report.Warning(
-        Message.UnableToCreateDirectory(e.directory) + "\n" +
+        Message.UnableToCreateDirectory(e.path) + "\n" +
           _("Authorized keys will not be written.")
       )
     end


### PR DESCRIPTION
Fix a potential security issue in #113 (writing to authorized_keys when it's not a file).