### PR TITLE
Speedup build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ script:
     - make -f Makefile.cvs
     - make
     - sudo make install
-    - make check
-
+    - Y2BASE_Y2DIR=$(pwd)/testsuite make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-perl-bindings yast2-core-dev yast2-ldap yast2-perl-bindings yast2-security libcrack2-dev doxygen libdigest-sha1-perl" -g "rspec:3.3.0 yast-rake gettext"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-perl-bindings yast2-core-dev yast2-perl-bindings yast2-security libcrack2-dev doxygen libdigest-sha1-perl" -g "rspec:3.3.0 yast-rake gettext"
 script:
     - rake check:syntax
     - rake check:pot

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 21 13:25:22 UTC 2016 - mvidner@suse.com
+
+- Do not require yast2-ldap for build time tests (bsc#999203).
+- 3.1.59
+
+-------------------------------------------------------------------
 Fri Sep 16 09:03:32 UTC 2016 - igonzalezsosa@suse.com
 
 - Add support to specify SSH authorized keys in the profile

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.58
+Version:        3.1.59
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -46,19 +46,7 @@ Requires:       perl-gettext
 Requires:       yast2-country
 Requires:       yast2-pam
 Requires:       yast2-security
-Obsoletes:      y2c_users
-Obsoletes:      y2t_inst-user
-Obsoletes:      y2t_users
-Obsoletes:      yast2-config-users
-Obsoletes:      yast2-trans-inst-user
-Obsoletes:      yast2-trans-users
 Obsoletes:      yast2-users-devel-doc
-Provides:       y2c_users
-Provides:       y2t_inst-user
-Provides:       y2t_users
-Provides:       yast2-config-users
-Provides:       yast2-trans-inst-user
-Provides:       yast2-trans-users
 Conflicts:      autoyast2 < 3.1.92
 # older storage uses removed deprecated method, see https://github.com/yast/yast-storage/pull/187
 Conflicts:      yast2-storage < 3.1.75

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -33,7 +33,6 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2-ldap >= 3.1.2
 BuildRequires:  yast2-perl-bindings
 BuildRequires:  yast2-security
 BuildRequires:  yast2-testsuite
@@ -78,6 +77,8 @@ This package provides GUI for maintenance of linux users and groups.
 %yast_build
 
 %install
+# make testsuite/modules/Ldap.rb visible
+export Y2BASE_Y2DIR=`pwd`/testsuite
 %yast_install
 
 %files

--- a/src/modules/UsersLDAP.pm
+++ b/src/modules/UsersLDAP.pm
@@ -1144,7 +1144,7 @@ sub ConvertMap {
     if (!defined $data->{"uidNumber"}) {
 	@internal	= @group_internal_keys;
     }
-    foreach my $key (keys %{$data}) {
+    foreach my $key (sort keys %{$data}) {
 	my $val	= $data->{$key};
 	if (contains (\@internal, $key, 1)) {
 	    next;

--- a/testsuite/modules/Ldap.rb
+++ b/testsuite/modules/Ldap.rb
@@ -1,0 +1,9 @@
+require "yast"
+module Yast
+  # This exists because it is hard to use RSpec mocks for code
+  # that goes through Perl (like UsersLdap.pm)
+  class LdapClass < Module
+    Builtins.y2milestone("Using a mock Ldap module")
+  end
+  Ldap = LdapClass.new
+end

--- a/testsuite/tests/ConvertMap.out
+++ b/testsuite/tests/ConvertMap.out
@@ -23,9 +23,9 @@ Dump	==========================================================
 Dump	--------- user (removed 'org_user' submap):
 Dump	 $["dn":"uid=test2,ou=people,dc=suse,dc=cz", "encrypted":true, "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/csh", "modified":"edited", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "org_uid":"test2", "org_uidnumber":11111, "plugins":["UsersPluginLDAPAll"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}qqqqq", "what":"edit_user"]
 Read	.ldap.schema.at $["name":"gecos"] $["usage":1]
+Read	.ldap.schema.at $["name":"gidNumber"] $["usage":1]
 Read	.ldap.schema.at $["name":"uid"] $["usage":1]
 Read	.ldap.schema.at $["name":"uidNumber"] $["usage":1]
-Read	.ldap.schema.at $["name":"gidNumber"] $["usage":1]
 Return	$["gecos":"test", "gidNumber":"100", "loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "uid":"test2", "uidNumber":"11111", "userPassword":"{crypt}qqqqq"]
 Dump	--------- converted :
 Dump	 $["gecos":"test", "gidNumber":"100", "loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "uid":"test2", "uidNumber":"11111", "userPassword":"{crypt}qqqqq"]

--- a/testsuite/tests/ConvertMap.out
+++ b/testsuite/tests/ConvertMap.out
@@ -1,24 +1,31 @@
 Dump	==========================================================
 Dump	--------- user (loginshell is changed):
 Dump	 $["dn":"uid=test2,ou=people,dc=suse,dc=cz", "encrypted":true, "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/csh", "modified":"edited", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top"], "org_uid":"test2", "org_uidnumber":11111, "org_user":$["dn":"uid=test2,ou=people,dc=suse,dc=cz", "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/bash", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}IVj2W92x/IuFs"], "plugins":["UsersPluginLDAPAll"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}IVj2W92x/IuFs", "what":"edit_user"]
+Read	.ldap.schema.at $["name":"loginShell"] $["usage":1]
 Return	$["loginShell":"/bin/csh"]
 Dump	--------- converted :
 Dump	 $["loginShell":"/bin/csh"]
 Dump	==========================================================
 Dump	--------- user (new password):
 Dump	 $["dn":"uid=test2,ou=people,dc=suse,dc=cz", "encrypted":true, "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/csh", "modified":"edited", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top"], "org_uid":"test2", "org_uidnumber":11111, "org_user":$["dn":"uid=test2,ou=people,dc=suse,dc=cz", "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/bash", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}IVj2W92x/IuFs"], "plugins":["UsersPluginLDAPAll"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"qqqqq", "what":"edit_user"]
+Read	.ldap.schema.at $["name":"userPassword"] $["usage":1]
 Return	$["loginShell":"/bin/csh", "userPassword":"{crypt}qqqqq"]
 Dump	--------- converted :
 Dump	 $["loginShell":"/bin/csh", "userPassword":"{crypt}qqqqq"]
 Dump	==========================================================
 Dump	--------- user (new object class):
 Dump	 $["dn":"uid=test2,ou=people,dc=suse,dc=cz", "encrypted":true, "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/csh", "modified":"edited", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "org_uid":"test2", "org_uidnumber":11111, "org_user":$["dn":"uid=test2,ou=people,dc=suse,dc=cz", "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/bash", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}qqqqq"], "plugins":["UsersPluginLDAPAll"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}qqqqq", "what":"edit_user"]
+Read	.ldap.schema.at $["name":"objectClass"] $["usage":1]
 Return	$["loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"]]
 Dump	--------- converted :
 Dump	 $["loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"]]
 Dump	==========================================================
 Dump	--------- user (removed 'org_user' submap):
 Dump	 $["dn":"uid=test2,ou=people,dc=suse,dc=cz", "encrypted":true, "gecos":"test", "gidNumber":100, "grouplist":$["audio":1], "groupname":"users", "loginShell":"/bin/csh", "modified":"edited", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "org_uid":"test2", "org_uidnumber":11111, "plugins":["UsersPluginLDAPAll"], "type":"ldap", "uid":"test2", "uidNumber":11111, "userPassword":"{crypt}qqqqq", "what":"edit_user"]
+Read	.ldap.schema.at $["name":"gecos"] $["usage":1]
+Read	.ldap.schema.at $["name":"uid"] $["usage":1]
+Read	.ldap.schema.at $["name":"uidNumber"] $["usage":1]
+Read	.ldap.schema.at $["name":"gidNumber"] $["usage":1]
 Return	$["gecos":"test", "gidNumber":"100", "loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "uid":"test2", "uidNumber":"11111", "userPassword":"{crypt}qqqqq"]
 Dump	--------- converted :
 Dump	 $["gecos":"test", "gidNumber":"100", "loginShell":"/bin/csh", "objectClass":["inetOrgPerson", "posixAccount", "shadowAccount", "top", "sambaSamAccount"], "uid":"test2", "uidNumber":"11111", "userPassword":"{crypt}qqqqq"]

--- a/testsuite/tests/ConvertMap.rb
+++ b/testsuite/tests/ConvertMap.rb
@@ -21,6 +21,7 @@ module Yast
         },
         "ldap"    => {
           "schema" => {
+            "at" => { "usage" => 1 },
             "oc" => {
               "may" => [
                 "gidNumber",


### PR DESCRIPTION
[bsc#999203](https://bugzilla.suse.com/show_bug.cgi?id=999203)

Most importantly, this breaks the critical path link between yast2-users and yast2-network (users no longer BuildRequire ldap which Requires network)

Total build time for this package on my machine decreases from 69s to 63s

The number of buildrequired packages decreases from 255 to 227:

```
[    2s] deleting curl
[    2s] deleting device-mapper
[    2s] deleting elfutils
[    2s] deleting libaio1
[    2s] deleting libasm1
[    2s] deleting libdevmapper-event1_03
[    2s] deleting libdevmapper1_03
[    2s] deleting libdw1
[    2s] deleting libldapcpp1
[    2s] deleting libmetalink3
[    2s] deleting libparted0
[    3s] deleting libstorage-ruby
[    3s] deleting libstorage7
[    3s] deleting lsscsi
[    3s] deleting parted
[    3s] deleting ruby2.2-rubygem-ruby-dbus
[    3s] deleting suse-module-tools
[    3s] deleting thin-provisioning-tools
[    3s] deleting udev-mini
[    3s] deleting unzip
[    3s] deleting yast2-country-data
[    3s] deleting yast2-ldap
[    3s] deleting yast2-network
[    3s] deleting yast2-packager
[    4s] deleting yast2-proxy
[    4s] deleting yast2-storage
[    4s] deleting yast2-transfer
[    4s] deleting yast2-xml
```