### PR TITLE
Fix the invocation of authentication configuration instance.

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 11 12:10:21 UTC 2016 - hguo@suse.com
+
+- Fix the invocation of authentication configuration instance
+  (bsc#1000749).
+- 3.1.58
+
+-------------------------------------------------------------------
 Fri Sep  2 15:16:37 CEST 2016 - schubi@suse.de
 
 - AutoYaST: Ignore Users without UID while checking for duplicate

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.57
+Version:        3.1.58
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/users/widgets.rb
+++ b/src/include/users/widgets.rb
@@ -2326,12 +2326,12 @@ Continue anyway?"))
         ret = Summary.NotConfigured
       elsif client == "sssd"
         begin
-          Yast.import "AuthClient"
-        rescue NameError
+          require 'auth/authconf.rb'
+        rescue LoadError
           ret = _("<b>yast2-auth-client module not installed</b>")
         else
-          AuthClient.Read
-          ret = AuthClient.Summary
+          ::Auth::AuthConfInst.read_all
+          ret = ::Auth::AuthConfInst.summary_text
         end
       elsif client == "nis"
         WFM.CallFunction("nis_auto", ["Read"])


### PR DESCRIPTION
Bump version to 3.1.62 for bsc#1000749.

Replaces #117 