### PR TITLE
Users::PasswordWidget: allow horizontal layout (FATE#322328)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 20 15:28:22 UTC 2017 - mvidner@suse.com
+
+- Password widget: a compact layout, do not steal focus (FATE#322328)
+- 3.1.57.5
+
+-------------------------------------------------------------------
 Wed Dec 14 14:35:57 UTC 2016 - jreidinger@suse.com
 
 - Separate root password widget and keyboard layout test widget

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.57.4
+Version:        3.1.57.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/users/dialogs/inst_root_first.rb
+++ b/src/lib/users/dialogs/inst_root_first.rb
@@ -71,7 +71,7 @@ module Yast
         VStretch(),
         HSquash(
           VBox(
-            ::Users::PasswordWidget.new,
+            ::Users::PasswordWidget.new(focus: true),
             VSpacing(2.4),
             ::UI::Widgets::KeyboardLayoutTest.new
           )

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -38,9 +38,11 @@ module Users
     #
     # If `little_space` is `true`, the helpful label is omitted
     # and the password fields are laid out horizontally.
-    def initialize(little_space: false)
+    # @param focus [Boolean] if set, then widget set focus to first password input field
+    def initialize(little_space: false, focus: false)
       textdomain "users"
       @little_space = little_space
+      @focus = focus
     end
 
     def contents
@@ -78,7 +80,7 @@ module Users
     def init
       # focus on first password, so user can immediately write. Also does not
       # break openQA current test
-      Yast::UI.SetFocus(Id(:pw1))
+      Yast::UI.SetFocus(Id(:pw1)) if @focus
       current_password = Yast::UsersSimple.GetRootPassword
       return if !current_password || current_password.empty?
 

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -30,30 +30,49 @@ Yast.import "Report"
 Yast.import "UsersSimple"
 
 module Users
+  # The widget contains 2 password input fields
+  # to type and retype the password
   class PasswordWidget < CWM::CustomWidget
-    def initialize
+    # If `little_space` is `false` (the default), the widget will
+    # use a vertical layout, and include a "don't forget this" label.
+    #
+    # If `little_space` is `true`, the helpful label is omitted
+    # and the password fields are laid out horizontally.
+    def initialize(little_space: false)
       textdomain "users"
+      @little_space = little_space
     end
 
     def contents
-      VBox(
-        # advise users to remember their new password
-        Left(Label(_("Do not forget what you enter here."))),
-        VSpacing(0.8),
-        Password(
-          Id(:pw1),
-          Opt(:hstretch),
-          # Label: get password for user root
-          _("&Password for root User")
-        ),
-        VSpacing(0.8),
-        Password(
-          Id(:pw2),
-          Opt(:hstretch),
-          # Label: get same password again for verification
-          _("Con&firm Password")
-        )
+      pw1 = Password(
+        Id(:pw1),
+        Opt(:hstretch),
+        # Label: get password for user root
+        _("&Password for root User")
       )
+      pw2 = Password(
+        Id(:pw2),
+        Opt(:hstretch),
+        # Label: get same password again for verification
+        _("Con&firm Password")
+      )
+
+      if @little_space
+        HBox(
+          pw1,
+          HSpacing(1),
+          pw2
+        )
+      else
+        VBox(
+          # advise users to remember their new password
+          Left(Label(_("Do not forget what you enter here."))),
+          VSpacing(0.8),
+          pw1,
+          VSpacing(0.8),
+          pw2
+        )
+      end
     end
 
     def init

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -16,13 +16,26 @@ describe Users::PasswordWidget do
     expect(subject.contents).to be_a(Yast::Term)
   end
 
-  it "initializes password to current value" do
-    pwd = "paranoic"
-    allow(Yast::UsersSimple).to receive(:GetRootPassword).and_return(pwd)
-    expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw1), :Value, pwd)
-    expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw2), :Value, pwd)
+  context "initialization" do
+    it "initializes password to current value" do
+      pwd = "paranoic"
+      allow(Yast::UsersSimple).to receive(:GetRootPassword).and_return(pwd)
+      expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw1), :Value, pwd)
+      expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw2), :Value, pwd)
 
-    subject.init
+      subject.init
+    end
+
+    it "sets focus to first widget if focus: parameter set to object" do
+      expect(Yast::UI).to receive(:SetFocus).with(Id(:pw1))
+      subject = described_class.new(focus: true)
+      subject.init
+    end
+
+    it "does not modify focus without focus: parameter" do
+      expect(Yast::UI).to_not receive(:SetFocus).with(Id(:pw1))
+      subject.init
+    end
   end
 
   context "validation" do


### PR DESCRIPTION
- https://github.com/yast/yast-installation/pull/487
- https://fate.suse.com/322328

If `little_space` is `false` (the default), the widget will use a vertical layout, and include a "don't forget this" label.

If `little_space` is `true`, the helpful label is omitted

Also, do not steal the keyboard focus: originally we put it in so that openQA can start typing the password right away, but the layout will work differently in the CaaSP all-in-one dialog so we need a way to disable it.

~~TODO: version, changes, dependencies~~