### PR TITLE
Root password

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 23 14:20:59 UTC 2018 - jreidinger@suse.com
+
+- Fix import of RootPassword if user is specified in autoyast
+  profile (bsc#1081958)
+- 4.0.4
+
+-------------------------------------------------------------------
 Thu Mar  1 09:36:25 UTC 2018 - mvidner@suse.com
 
 - Fixed removing the password expiration date (bsc#1080125)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6304,8 +6304,8 @@ sub Import {
 	    my $pw = Linuxrc->InstallInf ("RootPassword");
 	    if (defined $pw){
 
-		$root_user{"userPassword"}	=
-		    $self->CryptPassword ($pw, "system");
+		y2milestone ("updating root password from install.inf");
+		$root_user{"userPassword"} = $pw;
 
 		$users{"system"}{"root"}		= \%root_user;
 		$shadow{"system"}{"root"} = $self->CreateShadowMap(\%root_user);

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6307,7 +6307,7 @@ sub Import {
                 $users_modified	= 1;
 
 		y2milestone ("updating root password from install.inf");
-		$root_user{"userPassword"} = $pw;
+		$root_user{"userPassword"} = $self->CryptPassword ($pw, "system");
 
 		$users{"system"}{"root"}		= \%root_user;
 		$shadow{"system"}{"root"} = $self->CreateShadowMap(\%root_user);

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6308,6 +6308,8 @@ sub Import {
 
 		y2milestone ("updating root password from install.inf");
 		$root_user{"userPassword"} = $self->CryptPassword ($pw, "system");
+                # mark that password is already encrypted, so it does not encrypt twice (bsc#1081958)
+		$root_user{"encrypted"} = 1;
 
 		$users{"system"}{"root"}		= \%root_user;
 		$shadow{"system"}{"root"} = $self->CreateShadowMap(\%root_user);

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6303,6 +6303,8 @@ sub Import {
 
 	    my $pw = Linuxrc->InstallInf ("RootPassword");
 	    if (defined $pw){
+                # ensure that even if no user is defined, root will be written
+                $users_modified	= 1;
 
 		y2milestone ("updating root password from install.inf");
 		$root_user{"userPassword"} = $pw;


### PR DESCRIPTION
version that works for my testing as alternative for #155 

tested manually with users and without users in autoyast profile and in the end also testing customer case where he specify for root defaults, but without password and have there encrypted false which result in his problem.