### PR TITLE
read ssh keys from root user only if the user exists (bsc#1112119, bsc#1107456)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 19 13:54:28 UTC 2018 - snwint@suse.com
+
+- read ssh keys from root user only if the user exists (bsc#1112119,
+  bsc#1107456)
+- 3.2.17
+
+-------------------------------------------------------------------
 Mon Jun  4 14:04:17 UTC 2018 - jreidinger@suse.com
 
 - Fix import of RootPassword if user is specified in autoyast

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.2.16
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/UsersPasswd.pm
+++ b/src/modules/UsersPasswd.pm
@@ -307,8 +307,8 @@ sub read_authorized_keys {
     }
 
     # Read authorized keys also from root's home (bsc#1066342)
-    my %root_user = %{$users{"system"}{"root"}};
-    SSHAuthorizedKeys->read_keys($root_user{"homeDirectory"});
+    # 'root' user may not always exist (bsc#1112119, bsc#1107456)
+    SSHAuthorizedKeys->read_keys($users{system}{root}{homeDirectory}) if $users{system}{root};
 }
 
 # actually read /etc/passwd and save into internal structure


### PR DESCRIPTION
When working with NIS 'root' is typically not included.

This is https://github.com/yast/yast-users/pull/166 but for sle12-sp4.