### PR TITLE
Fix import of RootPassword if user is specified in autoyast profile (bsc#1081958)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 29 13:06:39 UTC 2018 - snwint@suse.com
+
+- Fix import of RootPassword if user is specified in autoyast
+  profile (bsc#1081958)
+- 3.2.15.2
+
+-------------------------------------------------------------------
 Thu Oct 18 09:59:25 UTC 2018 - snwint@suse.com
 
 - read ssh keys from root user only if the user exists (bsc#1112119,

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6371,9 +6371,13 @@ sub Import {
 
 	    my $pw = Linuxrc->InstallInf ("RootPassword");
 	    if (defined $pw){
+                # ensure that even if no user is defined, root will be written
+                $users_modified	= 1;
 
-		$root_user{"userPassword"}	=
-		    $self->CryptPassword ($pw, "system");
+		y2milestone ("updating root password from install.inf");
+		$root_user{"userPassword"} = $self->CryptPassword ($pw, "system");
+                # mark that password is already encrypted, so it does not encrypt twice (bsc#1081958)
+		$root_user{"encrypted"} = 1;
 
 		$users{"system"}{"root"}		= \%root_user;
 		$shadow{"system"}{"root"} = $self->CreateShadowMap(\%root_user);


### PR DESCRIPTION
This is a backport of https://github.com/yast/yast-users/pull/156.