### PR TITLE
Run also "rake pot" at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-cpp
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-users-image yast-travis-cpp
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e COVERAGE=1 -e CI=1 yast-users-image rake test:unit
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-users-image rake pot


### PR DESCRIPTION
- Run also `rake pot` at Travis to check for possible translation issues (e.g. missing textdomain)
- Here we use the `yast-travis-cpp` script which does not run the pot check