### PR TITLE
Allow system role to default to no local user

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 21 17:34:57 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Allow system role to default to no local user (Fate#326447)
+- 4.0.10
+
+-------------------------------------------------------------------
 Fri Nov  9 08:01:15 UTC 2018 - igonzalezsosa@suse.com
 
 - Add public keys handling support in an installed system

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -57,8 +57,8 @@ Requires:       yast2-perl-bindings >= 2.18.0
 # this forces using yast2-ldap with correct LDAP object names (fate#303596)
 Requires:       yast2-ldap >= 3.1.2
 
-# UI::Widgets
-Requires:       yast2 >= 3.2.8
+# ProductFeatures::GetBooleanFeatureWithFallback
+Requires:       yast2 >= 4.1.35
 # cryptsha256, cryptsha516
 Requires:       yast2-core >= 2.21.0
 

--- a/src/lib/users/dialogs/inst_user_first.rb
+++ b/src/lib/users/dialogs/inst_user_first.rb
@@ -87,6 +87,12 @@ module Yast
       init_user_attributes
     end
 
+    def run
+      # Fate #326447: Allow system role to default to no local user
+      return :auto unless enable_local_users?
+      super
+    end
+
     # UI sends events as user types the full name
     def full_name_handler
       # reenable suggestion
@@ -219,6 +225,15 @@ module Yast
       Yast.import "Progress"
       Yast.import "Report"
       Yast.import "UsersSimple"
+      Yast.import "ProductFeatures"
+    end
+
+    # Check if creating local users is enabled (default) or disabled in the
+    # control.xml file during the installation.
+    #
+    # @return Boolean
+    def enable_local_users?
+      ProductFeatures::GetBooleanFeatureWithFallback("globals", "enable_local_users", true)
     end
 
     # Initializes the instance variables used to configure a new user

--- a/src/lib/users/dialogs/inst_user_first.rb
+++ b/src/lib/users/dialogs/inst_user_first.rb
@@ -88,8 +88,11 @@ module Yast
     end
 
     def run
-      # Fate #326447: Allow system role to default to no local user
-      return :auto unless enable_local_users?
+      if !enable_local_users?
+        reset
+        # Fate #326447: Allow system role to default to no local user
+        return :auto
+      end
       super
     end
 
@@ -234,6 +237,17 @@ module Yast
     # @return Boolean
     def enable_local_users?
       ProductFeatures::GetBooleanFeatureWithFallback("globals", "enable_local_users", true)
+    end
+
+    # Reset things to properly support switching between a system role with
+    # local users and one without: Clear any user already entered including his
+    # password and make sure the password of this user will not be used as the
+    # root password, but the root password dialog will be shown.
+    def reset
+      @user = {}
+      @password = nil
+      @use_pw_for_root = false
+      set_users_list([])
     end
 
     # Initializes the instance variables used to configure a new user


### PR DESCRIPTION
## Trello

https://trello.com/c/PAVZthmL

## Changes

Skip creating a first local user during installation if `enable_local_user` is set to `false` in the `global` section in `control.xml`.

## Sample control.xml snippet

```XML
      <system_role>
        <id>sample_role</id>
        <globals>
          <enable_local_users config:type="boolean">false</enable_local_users>
        </globals>
        <software>
          <default_patterns>x11 base</default_patterns>
        </software>
        <order config:type="integer">123</order>
      </system_role>
```

## Going back and forth in the workflow

There is one challenge when going back and forth in the workflow and changing the system role between one that allows to create local users and another that does not: 

If at first a role is chosen that does allow local users **and** the user even leaves the "use this password for root" checkbox checked (which is the default), we need to make sure that both things are reset properly when the user goes back and selects another system role that does **not** enable creating local users. The collected data for that new user account need to be deleted, and we have to clear the flag that might skip the root password dialog as well as the flag that indicates that the password of the first user (which now will not be created after all) will not be used as the root password.

## How to test this

I used a custom _control.xml_ file that had the `<enable_local_users>` entry with _false_ for the GNOME desktop system role (see XML snippet above) and no such flag for the others, so simply choosing GNOME should skip the user creation dialog (but force showing the root password dialog!), and choosing KDE or any other system role should show the user creation dialog, and if "use this password for root" is checked, the root password dialog should not be shown.

It is important to check that this is consistent when going back and forth in the workflow and switching between those system roles.

## Related PRs

https://github.com/yast/yast-installation/pull/764
https://github.com/yast/yast-installation-control/pull/73
https://github.com/yast/yast-yast2/pull/867