### PR TITLE
Allow to create the user home as a Btrfs subvolume

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 11 09:38:24 UTC 2019 - dgonzalez@suse.com
+
+- Allow to create the user home directory as Btrfs subvolume
+  (fate#316134).
+- 4.1.7
+
+-------------------------------------------------------------------
 Fri Jan 11 10:05:50 UTC 2019 - igonzalezsosa@suse.com
 
 - Fixed call to renamed method (bsc#1121473).

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -719,28 +719,12 @@ module Yast
         end
 
         browse = VBox(
-          Label(""),
-          # button label
-          PushButton(Id(:browse), Opt(:key_F6), _("B&rowse...")),
-          action != "edited" ? Empty() : Label("")
+          VSpacing(1),
+          PushButton(Id(:browse), Opt(:key_F6), _("B&rowse..."))
         )
 
         home_w = VBox(
-          # textentry label
           InputField(Id(:home), Opt(:hstretch), _("&Home Directory"), home),
-          action != "edited" ?
-            Empty() :
-            HBox(
-              HSpacing(),
-              Left(
-                CheckBox(
-                  Id(:move_home),
-                  # check box label
-                  _("&Move to New Location"),
-                  create_home
-                )
-              )
-            )
         )
         new_user_term = action != "added" ?
           VBox() :
@@ -770,7 +754,6 @@ module Yast
                 )
               ) :
               VSpacing(0),
-            VSpacing(0.5),
             HBox(
               text_mode ? Empty() : HSpacing(1),
               HWeight(
@@ -789,6 +772,7 @@ module Yast
                   Top(
                     VBox(
                       HBox(home_w, browse),
+                      move_to_new_location_checkbox(action, create_home),
                       new_user_term,
                       HBox(
                         HSpacing(),
@@ -796,16 +780,19 @@ module Yast
                       ),
                     )
                   ),
+                  VSpacing(1),
                   additional_data,
+                  text_mode ? Empty() : HSpacing(1),
                   Top(edit_shell),
-                  Top(edit_defaultgroup),
                   VStretch()
                 )
               ),
-              text_mode ? Empty() : HSpacing(2),
+              HSpacing(2),
               HWeight(
                 2,
                 VBox(
+                  VSpacing(0.5),
+                  edit_defaultgroup,
                   VSpacing(0.5),
                   MultiSelectionBox(
                     Id(:grouplist),
@@ -825,7 +812,6 @@ module Yast
               ),
               text_mode ? Empty() : HSpacing(1)
             ),
-            VSpacing(0.5)
           ),
           HSpacing(1)
         )
@@ -1886,6 +1872,23 @@ module Yast
         Users.SetStartDialog("users")
       end
       ret
+    end
+
+    def move_to_new_location_checkbox(action, checked)
+      return Empty() if action != "edited"
+
+      HBox(
+        HSpacing(),
+        Left(
+          CheckBox(Id(:move_home), _("&Move to New Location"), checked)
+        )
+      )
+    end
+
+    def btrfs_label
+      # TRANSLATORS: label for the checkbox that allows to create the user home directory as a
+      # Btrfs subvolume
+      _("Create a Separate Btrfs Subvolume for the Home Directory")
     end
 
     # Returns clean path

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1782,6 +1782,14 @@ module Yast
           UI.ReplaceWidget(:tabContents, get_details_term.call)
           Wizard.SetHelpText(EditUserDetailsDialogHelp(user_type, what))
 
+          UI.ChangeWidget(Id(:btrfs_subvolume), :Enabled, btrfs_available?)
+
+          if what == "edit_user"
+            UI.ChangeWidget(Id(:btrfs_subvolume), :Enabled, false)
+            # Show the value for the current home directory/subvolume
+            UI.ChangeWidget(Id(:btrfs_subvolume), :Value, btrfs_subvolume?(org_home))
+          end
+
           if do_not_edit
             UI.ChangeWidget(Id(:uid), :Enabled, false)
             UI.ChangeWidget(Id(:home), :Enabled, false)
@@ -1789,6 +1797,7 @@ module Yast
             UI.ChangeWidget(Id(:shell), :Enabled, false)
             UI.ChangeWidget(Id(:defaultgroup), :Enabled, false)
             UI.ChangeWidget(Id(:browse), :Enabled, false)
+            UI.ChangeWidget(Id(:btrfs_subvolume), :Enabled, false)
           end
           if user_type == "ldap" && !Ldap.file_server
             UI.ChangeWidget(Id(:browse), :Enabled, false)
@@ -1804,8 +1813,6 @@ module Yast
             UI.ChangeWidget(Id(:mode), :InputMaxLength, 3)
           end
           UI.ChangeWidget(Id(:shell), :Value, shell)
-          UI.ChangeWidget(Id(:btrfs_subvolume), :Enabled, what == "add_user" && btrfs_available?)
-          UI.ChangeWidget(Id(:btrfs_subvolume), :Value, what == "edit_user" && btrfs_subvolume?(home))
 
           current = ret
         end

--- a/src/include/users/helps.rb
+++ b/src/include/users/helps.rb
@@ -437,12 +437,13 @@ module Yast
           Users.GetLoginDefaults.fetch("skel", "")
         )
 
+        btrfs_option_label = _("Create as Btrfs Subvolume")
         # TRANSLATORS: help text for the Btrfs subvolume checkbox
         helptext << _(
-          "<p><b>Btrfs subvolume</b> option allows to create the user home " \
+          "<p><b>%s</b> option allows to create the user home " \
           "as a subvolume instead of a plain directory whenever " \
           "there is a Btrfs filesystem available.</p>"
-        )
+        ) % btrfs_option_label
       else
         # help text for Move to new location checkbox
         helptext << _(

--- a/src/include/users/helps.rb
+++ b/src/include/users/helps.rb
@@ -381,145 +381,116 @@ module Yast
 
 
     # Help for EditUserDetailsDialog.
-    # @param [String] user_type type of edited user (local/system/ldap/nis)
+    #
+    # @param [String] user_type type of added/edited user (local/system/ldap/nis)
     # @param [String] what what to do with a user (add_user/edit_user)
+    #
     # @return [String] help text
     def EditUserDetailsDialogHelp(user_type, what)
-      # help text 1/8
-      helptext = Ops.add(
-        Ops.add(
-          Ops.add(
-            _("<p>\nAdditional user data includes:\n</p>"),
-            # help text 2/8, %1 is number
-            Builtins.sformat(
-              _(
-                "<p>\n" +
-                  "<b>User ID (uid):</b>\n" +
-                  "Each user is known to the system by a unique number,\n" +
-                  "the user ID. For normal users, you should use\n" +
-                  "a UID larger than %1 because the smaller UIDs are used\n" +
-                  "by the system for special purposes and pseudo logins.\n" +
-                  "</p>\n"
-              ),
-              UsersCache.GetMaxUID("system")
-            )
-          ),
-          # help text 3/8
-          _(
-            "<p>\n" +
-              "If you change the UID of an existing user, the rights of the files\n" +
-              "this user owns must be changed. This is done automatically\n" +
-              "for the files in the user's home directory, but not for files \n" +
-              "located elsewhere.</p>\n"
-          )
-        ),
-        # help text 4/8
+      helptext = ""
+
+      helptext << _("<p>\nAdditional user data includes:\n</p>")
+      # TRANSLATORS: %1 is a number
+      helptext << Builtins.sformat(
         _(
-          "<p>\n" +
-            "<b>Home Directory:</b>\n" +
-            "The home directory of the user. Normally this is\n" +
-            "/home/username. \n" +
-            "To select an existing directory, click <b>Browse</b>.\n" +
-            "</p>\n"
-        )
+          "<p>\n" \
+          "<b>User ID (uid):</b>\n" \
+          "Each user is known to the system by a unique number,\n" \
+          "the user ID. For normal users, you should use\n" \
+          "a UID larger than %1 because the smaller UIDs are used\n" \
+          "by the system for special purposes and pseudo logins.\n" \
+          "</p>\n"
+        ),
+        UsersCache.GetMaxUID("system")
       )
+      helptext << _(
+        "<p>\n" \
+        "If you change the UID of an existing user, the rights of the files\n" \
+        "this user owns must be changed. This is done automatically\n" \
+        "for the files in the user's home directory, but not for files \n" \
+        "located elsewhere.</p>\n"
+      )
+      helptext << _(
+        "<p>\n" \
+        "<b>Home Directory:</b>\n" \
+        "The home directory of the user. Normally this is\n" \
+        "/home/username. \n" \
+        "To select an existing directory, click <b>Browse</b>.\n" \
+        "</p>\n"
+      )
+
       if what == "add_user"
         # help text for user's home directory mode
-        helptext = Ops.add(
-          helptext,
-          _(
-            "<p>Optionally, set the <b>Home Directory Permission Mode</b> for this user's home directory different from the default.</p>"
-          )
+        helptext << _(
+          "<p>Optionally, set the <b>Home Directory Permission Mode</b> " \
+          "for this user's home directory different from the default.</p>"
         )
 
-        defaults = Users.GetLoginDefaults
-        helptext = Ops.add(
-          helptext,
-          # alternate helptext 4.5/8; %1 is directory (e.g. '/etc/skel')
-          Builtins.sformat(
-            _(
-              "<p>To create only an empty home directory,\n" +
-                "check <b>Empty Home</b>. Otherwise, the new home directory\n" +
-                "is created from the default skeleton (%1).</p>\n"
-            ),
-            Ops.get_string(defaults, "skel", "")
-          )
+        # help text for an empty home option
+        # TRANSLATORS: %1 is a path to directory (e.g. '/etc/skel')
+        helptext << Builtins.sformat(
+          _(
+            "<p>To create only an empty home directory,\n" \
+            "check <b>Empty Home</b>. Otherwise, the new home directory\n" \
+            "is created from the default skeleton (%1).</p>\n"
+          ),
+          Users.GetLoginDefaults.fetch("skel", "")
         )
 
-        helptext = Ops.add(
-          helptext,
-          # TRANSLATORS: help text for the Btrfs subvolume checkbox
-          _(
-            "<p><b>Btrfs subvolume</b> option allows to create the user home " \
-            "as a subvolume instead of a plain directory whenever " \
-            "there is a Btrfs filesystem available.</p>"
-          )
+        # TRANSLATORS: help text for the Btrfs subvolume checkbox
+        helptext << _(
+          "<p><b>Btrfs subvolume</b> option allows to create the user home " \
+          "as a subvolume instead of a plain directory whenever " \
+          "there is a Btrfs filesystem available.</p>"
         )
       else
         # help text for Move to new location checkbox
-        helptext = Ops.add(
-          helptext,
-          _(
-            "<p>If changing the location of a user's home directory, move the contents of the current directory with <b>Move to New Location</b>, activated by default. Otherwise a new home directory is created without any of the existing data.</p>"
-          )
+        helptext << _(
+          "<p>If changing the location of a user's home directory, move the contents " \
+          "of the current directory with <b>Move to New Location</b>, activated by default. " \
+          "Otherwise a new home directory is created without any of the existing data.</p>"
         )
       end
 
       if user_type == "ldap"
-        helptext = Ops.add(
-          helptext,
-          # alternate helptext 5/8
-          _(
-            "<p>\n" +
-              "The home directory of an LDAP user can be changed only on the\n" +
-              "file server.</p>"
-          )
+        helptext << _(
+          "<p>\n" \
+          "The home directory of an LDAP user can be changed only on the\n" \
+          "file server.</p>"
         )
       elsif user_type == "system" || user_type == "local"
-        helptext = Ops.add(
-          helptext,
-          # alternate helptext 5/8
-          _(
-            "<p><b>Additional Information:</b>\n" +
-              "Some additional user data could be set here. This field may contain up to\n" +
-              "three parts, separated by commas. The standard usage is to write\n" +
-              "<i>office</i>,<i>work phone</i>,<i>home phone</i>. This information is \n" +
-              "shown when you use the <i>finger</i> command on this user.</p>\n"
-          )
+        helptext << _(
+          "<p><b>Additional Information:</b>\n" \
+          "Some additional user data could be set here. This field may contain up to\n" \
+          "three parts, separated by commas. The standard usage is to write\n" \
+          "<i>office</i>,<i>work phone</i>,<i>home phone</i>. This information is \n" \
+          "shown when you use the <i>finger</i> command on this user.</p>\n"
         )
       end
 
-      # help text 6/8
-      helptext = Ops.add(
-        Ops.add(
-          Ops.add(
-            helptext,
-            _(
-              "<p>\n" +
-                "<b>Login Shell:</b>\n" +
-                "The login shell (command interpreter) for the user.\n" +
-                "Select a shell from the list of all shells installed\n" +
-                "on your system.\n" +
-                "</p>"
-            )
-          ),
-          # help text 7/8
-          _(
-            "<p>\n" +
-              "<b>Default Group:</b>\n" +
-              "The primary group to which the user belongs. Select one group\n" +
-              "from the list of all groups existing on your system.\n" +
-              "</p>"
-          )
-        ),
-        # help text 8/8
-        _(
-          "<p>\n" +
-            "<b>Additional Groups:</b>\n" +
-            "Select additional groups in which the user should be a member.\n" +
-            "</p>\n"
-        )
+      helptext << _(
+        "<p>\n" \
+        "<b>Login Shell:</b>\n" \
+        "The login shell (command interpreter) for the user.\n" \
+        "Select a shell from the list of all shells installed\n" \
+        "on your system.\n" \
+        "</p>"
       )
+
+      helptext << _(
+        "<p>\n" \
+        "<b>Default Group:</b>\n" \
+        "The primary group to which the user belongs. Select one group\n" \
+        "from the list of all groups existing on your system.\n" \
+        "</p>"
+      )
+      helptext << _(
+        "<p>\n" \
+        "<b>Additional Groups:</b>\n" \
+        "Select additional groups in which the user should be a member.\n" \
+        "</p>\n"
+      )
+
       helptext
     end
 

--- a/src/include/users/helps.rb
+++ b/src/include/users/helps.rb
@@ -445,6 +445,16 @@ module Yast
             Ops.get_string(defaults, "skel", "")
           )
         )
+
+        helptext = Ops.add(
+          helptext,
+          # TRANSLATORS: help text for the Btrfs subvolume checkbox
+          _(
+            "<p><b>Btrfs subvolume</b> option allows to create the user home " \
+            "as a subvolume instead of a plain directory whenever " \
+            "there is a Btrfs filesystem available.</p>"
+          )
+        )
       else
         # help text for Move to new location checkbox
         helptext = Ops.add(

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -3030,26 +3030,33 @@ sub AddUser {
     # ----------------------------------------------------------------
 
     # now copy the data to map of current user
-    foreach my $key (keys %data) {
-	if ($key eq "create_home" || $key eq "encrypted" ||
-	    $key eq "chown_home" ||
-	    $key eq "delete_home" || $key eq "no_skeleton" ||
-      $key eq "btrfs_subvolume" ||
-	    $key eq "disabled" || $key eq "enabled") {
-	    $user_in_work{$key}	= YaST::YCP::Boolean ($data{$key});
-	}
-	elsif ($key eq "userPassword" && (defined $data{$key}) &&
-	    # crypt password only once
-	    !bool ($data{"encrypted"}))
-	{
-	    $user_in_work{$key} = $self->CryptPassword ($data{$key}, $type);
-	    $user_in_work{"encrypted"}	= YaST::YCP::Boolean (1);
-	    $user_in_work{"text_userpassword"} = $data{$key};
-	}
-	else {
-	    $user_in_work{$key}	= $data{$key};
-	}
+    foreach my $key ( keys %data ) {
+        if (   $key eq "create_home"
+            || $key eq "encrypted"
+            || $key eq "chown_home"
+            || $key eq "delete_home"
+            || $key eq "no_skeleton"
+            || $key eq "btrfs_subvolume"
+            || $key eq "disabled"
+            || $key eq "enabled" )
+        {
+            $user_in_work{$key} = YaST::YCP::Boolean( $data{$key} );
+        }
+        elsif (
+               $key eq "userPassword"
+            && ( defined $data{$key} )
+            && !bool( $data{"encrypted"} )    # crypt password only once
+          )
+        {
+            $user_in_work{$key} = $self->CryptPassword( $data{$key}, $type );
+            $user_in_work{"encrypted"}         = YaST::YCP::Boolean(1);
+            $user_in_work{"text_userpassword"} = $data{$key};
+        }
+        else {
+            $user_in_work{$key} = $data{$key};
+        }
     }
+
     $user_in_work{"type"}	= $type;
     $user_in_work{"what"}	= "add_user";
 

--- a/src/modules/UsersRoutines.pm
+++ b/src/modules/UsersRoutines.pm
@@ -69,17 +69,6 @@ my $btrfs = "/usr/sbin/btrfs";
 ##-------------------------------------------------------------------------
 ##----------------- helper routines ---------------------------------------
 
-sub valid_btrfs {
-    my $path       = shift;
-    my $dirname    = dirname($path);
-    my $cmd        = "/usr/bin/stat -f --format %T $dirname";
-    my %cmd_output = %{ SCR->Execute( ".target.bash_output", $cmd ) };
-
-    chomp(%cmd_output);
-
-    return ( $cmd_output{"stdout"} eq "btrfs" );
-}
-
 sub btrfs_subvolume {
     my $path = shift;
     my $cmd  = "$btrfs subvolume show $path";
@@ -122,12 +111,6 @@ sub CreateHome {
 
     # Create the home as btrfs subvolume
     if ($use_btrfs) {
-        if (!valid_btrfs($home)) {
-            y2error("Error to create '$home' as btrfs subvolume in a not valid btrfs filesystem");
-
-            return 0;
-        }
-
         my $cmd = "btrfs subvolume create $home";
         my %cmd_out = %{ SCR->Execute( ".target.bash_output", $cmd ) };
         my $stderr = $cmd_out{"stderr"} || "";

--- a/src/modules/UsersRoutines.pm
+++ b/src/modules/UsersRoutines.pm
@@ -32,7 +32,7 @@ use YaST::YCP qw(:LOGGING);
 
 our %TYPEINFO;
 
- 
+
 ##------------------------------------
 ##------------------- global imports
 
@@ -95,20 +95,22 @@ BEGIN { $TYPEINFO{CreateHome} = ["function",
 }
 sub CreateHome {
 
-    my $self	= shift;
+    my $self = shift;
     my ( $skel, $home, $use_btrfs ) = @_;
 
-    # create a path to new home directory, if not exists
-    my $home_path = substr ($home, 0, rindex ($home, "/"));
-    if (length($home_path) and !%{SCR->Read (".target.stat", $home_path)}) {
-	SCR->Execute (".target.mkdir", $home_path);
+    # Create a path to new home directory, if not exists
+    my $home_path = substr( $home, 0, rindex( $home, "/" ) );
+    if ( length($home_path) and !%{ SCR->Read( ".target.stat", $home_path ) } )
+    {
+        SCR->Execute( ".target.mkdir", $home_path );
     }
-    my %stat	= %{SCR->Read (".target.stat", $home)};
+
+    my %stat = %{ SCR->Read( ".target.stat", $home ) };
     if (%stat) {
-        if ($home ne "/var/lib/nobody") {
-	    y2error ("$home directory already exists: no mkdir");
-	}
-	return 0;
+        if ( $home ne "/var/lib/nobody" ) {
+            y2error("$home directory already exists: no mkdir");
+        }
+        return 0;
     }
 
     # Create the home as btrfs subvolume
@@ -132,7 +134,7 @@ sub CreateHome {
     # or as a plain directory
     else {
         if ( !SCR->Execute( ".target.mkdir", $home ) ) {
-            y2error("Error creating $home");
+            y2error("Error creating '$home'");
 
             return 0;
         }
@@ -140,12 +142,16 @@ sub CreateHome {
 
     # Now copy the skeleton
     if ( $skel ne "" && %{ SCR->Read( ".target.stat", $skel ) } ) {
-        my $cmd = sprintf( "/usr/bin/cp -r '%s/.' '%s'", String->Quote($skel), String->Quote($home) );
+        my $cmd = sprintf(
+            "/usr/bin/cp -r '%s/.' '%s'",
+            String->Quote($skel),
+            String->Quote($home)
+        );
         my %cmd_out = %{ SCR->Execute( ".target.bash_output", $cmd ) };
         my $stderr = $cmd_out{"stderr"} || "";
 
         if ( $stderr ne "" ) {
-            y2error( "error calling $cmd: ", $stderr );
+            y2error( "Error calling $cmd: $stderr" );
             return 0;
         }
 

--- a/src/modules/UsersRoutines.pm
+++ b/src/modules/UsersRoutines.pm
@@ -83,6 +83,7 @@ sub CreateHome {
     my $self	= shift;
     my $skel	= $_[0];
     my $home	= $_[1];
+    my $btrfs	= $_[2];
 
     # create a path to new home directory, if not exists
     my $home_path = substr ($home, 0, rindex ($home, "/"));

--- a/test/dialogs_test.rb
+++ b/test/dialogs_test.rb
@@ -19,6 +19,34 @@ describe "Yast::UsersDialogsInclude" do
     allow(Yast).to receive(:import).with("LdapPopup")
   end
 
+  describe "#cleanpath" do
+    it "returns sanitized path" do
+      expect(subject.cleanpath("/home/user/")).to eq("/home/user")
+    end
+
+    context "when nil value is given" do
+      it "returns empty string" do
+        expect(subject.cleanpath(nil)).to eq("")
+      end
+    end
+
+    context "when empty string is given" do
+      it "returns empty string" do
+        expect(subject.cleanpath(nil)).to eq("")
+      end
+    end
+
+    context "when something is wrong" do
+      before do
+        allow(Pathname).to receive(:new).and_raise
+      end
+
+      it "returns empty string" do
+        expect(subject.cleanpath(nil)).to eq("")
+      end
+    end
+  end
+
   describe "#valid_btrfs_path?" do
     let(:local_execution) { double }
     let(:dirname) { "/home" }

--- a/test/dialogs_test.rb
+++ b/test/dialogs_test.rb
@@ -19,6 +19,37 @@ describe "Yast::UsersDialogsInclude" do
     allow(Yast).to receive(:import).with("LdapPopup")
   end
 
+  describe "#valid_btrfs_path?" do
+    let(:local_execution) { double }
+    let(:dirname) { "/home" }
+    let(:user_home) { "#{dirname}/user" }
+    let(:user_home_pathname) { double("Pathname", dirname: dirname) }
+
+    before do
+      allow(Pathname).to receive(:new).with(user_home).and_return(user_home_pathname)
+      allow(Yast::Execute).to receive(:locally!).and_return(local_execution)
+      allow(local_execution).to receive(:stdout)
+        .with("/usr/bin/stat", any_args, dirname)
+        .and_return(filesystem)
+    end
+
+    context "when given path is on Btrfs filesystem" do
+      let(:filesystem) { "btrfs\n" }
+
+      it "returns true" do
+        expect(subject.valid_btrfs_path?(user_home)).to eq(true)
+      end
+    end
+
+    context "when given path is not on Btrfs filesystem" do
+      let(:filesystem) { "nfs\n" }
+
+      it "returns false" do
+        expect(subject.valid_btrfs_path?(user_home)).to eq(false)
+      end
+    end
+  end
+
   describe "#btrfs_available?" do
     let(:local_execution) { double }
 

--- a/testsuite/tests/AddGroup.out
+++ b/testsuite/tests/AddGroup.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/AddUser.out
+++ b/testsuite/tests/AddUser.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/BuildAdditional.out
+++ b/testsuite/tests/BuildAdditional.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/DeleteUser.out
+++ b/testsuite/tests/DeleteUser.out
@@ -1,3 +1,4 @@
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/DeleteUserCryptedDir.out
+++ b/testsuite/tests/DeleteUserCryptedDir.out
@@ -1,3 +1,4 @@
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"
@@ -33,6 +34,7 @@ Execute	.target.bash "/usr/bin/cp '/etc/shadow' '/etc/shadow.YaST2save'" 0
 Write	.target.string "/etc/shadow" "at:!:13636:0:99999:7:::\nbin:*:13636::::::\ndaemon:*:13636::::::\nmail:*:13636::::::\nnobody:*:13636::::::\nroot:password:13636::::::\nuucp:*:13636::::::\n+::0:0:0::::\n" true
 Execute	.target.bash "/usr/sbin/nscd -i passwd" 0
 Read	.target.stat "/home/hh" $["isdir":true]
-Execute	.target.bash_output "/usr/bin/rm -rf '/home/hh'" $["exit":0]
+Execute	.target.bash "/usr/sbin/btrfs subvolume show /home/hh" 0
+Execute	.target.bash_output "/usr/sbin/btrfs subvolume delete -C '/home/hh'" $["exit":0]
 Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custom_users":["local"], "dont_warn_when_nisserver_notdes":false, "dont_warn_when_uppercase":false] true
 Return	

--- a/testsuite/tests/EditUser.out
+++ b/testsuite/tests/EditUser.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/EditUsersGroups.out
+++ b/testsuite/tests/EditUsersGroups.out
@@ -1,3 +1,4 @@
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/Import.out
+++ b/testsuite/tests/Import.out
@@ -1,5 +1,6 @@
 Dump	local user names:
 Dump	 []
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/Read.out
+++ b/testsuite/tests/Read.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 0
 Read	.etc.default.useradd."groups" 0

--- a/testsuite/tests/SelectUser.out
+++ b/testsuite/tests/SelectUser.out
@@ -1,4 +1,5 @@
 Dump	==========================================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupAdd.out
+++ b/testsuite/tests/YaPIGroupAdd.out
@@ -2,6 +2,7 @@ Dump	==========================================================
 Return	nil
 Return	nil
 Dump	============ add new group 'gg': ==========================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"
@@ -23,6 +24,7 @@ Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custo
 Return	
 Dump	============ add new group 'gg' - done ====================
 Dump	============ add new group 'gg2' with first userlist as list ==
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"
@@ -44,6 +46,7 @@ Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custo
 Return	
 Dump	============ add new group 'gg2' - done ====================
 Dump	============ add new group 'gg3' with first userlist as map ==
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"
@@ -65,6 +68,7 @@ Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custo
 Return	
 Dump	============ add new group 'gg3' - done ====================
 Dump	============ add new group 'gg4' with non existent user ==
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"
@@ -81,6 +85,7 @@ Execute	.target.bash_output "/usr/bin/echo 'gg4' | /usr/bin/grep '^[[:alpha:]_][
 Return	User hh2 does not exist.
 Dump	============ add new group 'gg4' - done ====================
 Dump	============ add new group 'root' (groupname conflict): ======
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" nil
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupDelete.out
+++ b/testsuite/tests/YaPIGroupDelete.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ delete non-existent group: ==================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupGet.out
+++ b/testsuite/tests/YaPIGroupGet.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ get group 'us': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupMemberAdd.out
+++ b/testsuite/tests/YaPIGroupMemberAdd.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	================ (add user) =======================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupMemberDelete.out
+++ b/testsuite/tests/YaPIGroupMemberDelete.out
@@ -3,6 +3,7 @@ Dump	================ (no user) =======================
 Return	No user was specified.
 Dump	================ done ============================
 Dump	================ (bad user) ======================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupModify.out
+++ b/testsuite/tests/YaPIGroupModify.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ edit non-existing group 'gg': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupsGet.out
+++ b/testsuite/tests/YaPIGroupsGet.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ get local groups =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIGroupsGetByUser.out
+++ b/testsuite/tests/YaPIGroupsGetByUser.out
@@ -3,6 +3,7 @@ Dump	============ get groups (no user) ===================
 Return	$[]
 Dump	============ get done ============================
 Dump	============ get groups (wrong user) ===================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserAdd.out
+++ b/testsuite/tests/YaPIUserAdd.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ add new user 'jj': ==========================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserDelete.out
+++ b/testsuite/tests/YaPIUserDelete.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ delete non-existent user: ==================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserDisable.out
+++ b/testsuite/tests/YaPIUserDisable.out
@@ -1,6 +1,7 @@
 Dump	==========================================================
 Return	nil
 Dump	============ disable LDAP user 'jj': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserEnable.out
+++ b/testsuite/tests/YaPIUserEnable.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ enable local user 'hh': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserFeatureAdd.out
+++ b/testsuite/tests/YaPIUserFeatureAdd.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ edit user 'hh': ==================================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserGet.out
+++ b/testsuite/tests/YaPIUserGet.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ get local user 'hh': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUserModify.out
+++ b/testsuite/tests/YaPIUserModify.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ edit non-existing user 'jj': =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"

--- a/testsuite/tests/YaPIUsersGet.out
+++ b/testsuite/tests/YaPIUsersGet.out
@@ -1,5 +1,6 @@
 Dump	==========================================================
 Dump	============ get local users =====================
+Read	.etc.default.useradd."btrfs_subvolume" 0
 Read	.etc.default.useradd."expire" 0
 Read	.etc.default.useradd."group" 100
 Read	.etc.default.useradd."groups" "audio,video"


### PR DESCRIPTION
## Feature

Allow to create the user home as a  Btrfs subvolume

* Fate: https://fate.suse.com/316134
* Jira: https://jira.suse.de/browse/SLE-4193
* Trello: https://trello.com/c/RFslodad/2726-sles15-sp1-p2-bug-1119276-misleading-indication-in-yast-module-service-manager

## TODO

- [x] Show the "Btrfs subvolume" checkbox
- [x] Disable the checkbox when editing a user (only there for consistency, in "read-only" mode)
- [x] Display an error when trying to use a not valid Btrfs path
- [x] Add help text
- [x] Create a home directory as Btrfs subvolume when required, using `btrfs subvolume create`
- [x] Delete a Btrfs subvolume home  using `btrfs subvolume delete -C` 
- [ ] Unit tests (?)
- [x] Perform some refactorizations / improvements

## Testing

* A lot of manual test done.

## Screenshots

![ncurses_yast_user_add_btrfs_subvolume](https://user-images.githubusercontent.com/1691872/52554372-880c2e00-2dde-11e9-8c73-9644fcddcd37.png)

You can see more screenshots in the comments linked below, although some of them could be outdated.

- [the first implementation](#issuecomment-461089855)
- [with layout improvements](#issuecomment-461395036)