### PR TITLE
- don't copy skel files for system users (bsc#1130158)

### DIFF
--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4475,9 +4475,17 @@ sub Write {
 		if ($user_mod eq "imported" || $user_mod eq "added") {
 		    y2usernote ("User '$username' created");
 
+                    # *** FIXME ***
+                    #
+                    # Using FileUtils->GetSize() to decide on an empty
+                    # directory is fundamentally WRONG.
+                    #
+                    # YaST basically uses the size value stat() returns. That
+                    # value is meaningless for directories.
+                    #
 		    if ($user_mod eq "imported" && FileUtils->GetSize ($home) > 0) {
 			# Directory already exists AND is not empty
-			y2milestone ("home directory $home of user $username already exists");
+			y2milestone ("home directory $home of user $username already exists and is not empty");
 			next;
 		    }
 		    if (bool ($user{"no_skeleton"})) {

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -42,6 +42,10 @@ use Digest::MD5;
 use Digest::SHA1 qw(sha1);
 use Data::Dumper;
 
+$Data::Dumper::Sortkeys = 1;
+$Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 1;
+
 our %TYPEINFO;
 
 # If YaST UI (Qt,ncurses) should be used. When this is off, some helper
@@ -4466,6 +4470,8 @@ sub Write {
 		$chown_home	        = 1 if (!defined $chown_home);
 		my $skel	        = $useradd_defaults{"skel"};
 
+		y2milestone ("User = ", Dumper(\%user));
+
 		if ($user_mod eq "imported" || $user_mod eq "added") {
 		    y2usernote ("User '$username' created");
 
@@ -5774,7 +5780,7 @@ sub ImportUser {
     if (!defined ($username)) {
 	$username	= $user->{"uid"}	|| "";
     }
-    y2debug("Username=$username");
+    y2milestone("Username=$username");
 
     my $uid		= $user->{"uidNumber"};
     if (!defined $uid) {
@@ -5947,6 +5953,13 @@ sub ImportUser {
     my @authorized_keys = ();
     $ret{"authorized_keys"} = \@authorized_keys;
   }
+
+    # AutoYaST-imported users don't go through AddUser(). This means we have
+    # to replicate some of that logic here:
+    #
+    #   - don't copy skel files for system users (bsc#1130158)
+    #
+    $ret{no_skeleton} ||= 1 if $ret{type} eq "system";
 
     return \%ret;
 }


### PR DESCRIPTION
This patch fixes three issues:

1. autoyast imported system users still got a copy of /etc/skel, which is nonsense and can break things
2. the decision on whether to touch a home dir at all is based on whether the home dir is empty or not - but the implementation of the detection of this situation was wrong
3. added more logging as the current log verbosity is really insufficient

Some more remarks:

The observed behavior differed between xfs (or ext4) and btrfs due to point 2. above. E.g. stat(DIR) returns 0 for empty btrfs directories while it is !=0 for empty xfs dirs.

Note that there is even a user `rtkit` that has `/proc` as home dir. As `stat("/proc")` gives 0, the old code tried to modify all `/proc` entries.