### PR TITLE
Offer autologin only if a display manager that supports it is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.opensuse.org/yast/head/containers/yast-cpp:latest
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --non-interactive in --force-resolution --no-recommends \
   cracklib-devel \
   perl-Digest-SHA1 \
   perl-X500-DN \

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 16 14:27:28 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Offer autologin only if a display manager that supports it is
+  installed (bsc#1128385)
+- 4.1.13
+
+-------------------------------------------------------------------
 Mon Apr 15 13:57:04 CEST 2019 - schubi@suse.de
 
 - AY creating user: Improved checking of already existing home

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -3,7 +3,7 @@ Tue Apr 16 14:27:28 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Offer autologin only if a display manager that supports it is
   installed (bsc#1128385)
-- 4.1.13
+- 4.2.0
 
 -------------------------------------------------------------------
 Mon Apr 15 13:57:04 CEST 2019 - schubi@suse.de

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.1.13
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -46,7 +46,7 @@ Requires:       perl-gettext
 Requires:       yast2-country
 
 # Autologin.supported?
-Requires:       yast2-pam >= 4.1.1
+Requires:       yast2-pam >= 4.2.0
 
 Requires:       yast2-security
 Obsoletes:      yast2-users-devel-doc

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -44,7 +44,10 @@ Requires:       perl-Digest-SHA1
 Requires:       perl-X500-DN
 Requires:       perl-gettext
 Requires:       yast2-country
-Requires:       yast2-pam
+
+# Autologin.supported?
+Requires:       yast2-pam >= 4.1.1
+
 Requires:       yast2-security
 Obsoletes:      yast2-users-devel-doc
 Conflicts:      autoyast2 < 3.1.92

--- a/src/lib/users/dialogs/inst_user_first.rb
+++ b/src/lib/users/dialogs/inst_user_first.rb
@@ -232,6 +232,7 @@ module Yast
       Yast.import "Report"
       Yast.import "UsersSimple"
       Yast.import "ProductFeatures"
+      Yast.import "Autologin"
     end
 
     # Check if creating local users is enabled (default) or disabled in the
@@ -341,7 +342,11 @@ module Yast
 
     def refresh
       WIDGETS.values.flatten.each do |w|
-        UI.ChangeWidget(Id(w), :Enabled, WIDGETS[action].include?(w))
+        enable = WIDGETS[action].include?(w)
+        if w == :autologin && enable && !Autologin.supported?
+          enable = false
+        end
+        UI.ChangeWidget(Id(w), :Enabled, enable)
       end
     end
 
@@ -653,9 +658,20 @@ module Yast
             @use_pw_for_root
           )
         ),
-        # checkbox label
-        Left(CheckBox(Id(:autologin), _("&Automatic Login"), @autologin))
+        Left(autologin_checkbox)
       ]
+    end
+
+    def autologin_checkbox
+      # checkbox label
+      label = _("&Automatic Login")
+
+      if Autologin.supported?
+        CheckBox(Id(:autologin), label, @autologin)
+      else
+        @autologin = false
+        CheckBox(Id(:autologin), Opt(:disabled), label, false)
+      end
     end
 
     def import_qty_widget


### PR DESCRIPTION
# Trello

https://trello.com/c/VVM2ib4G/

# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1128385 (openSUSE)
https://bugzilla.suse.com/show_bug.cgi?id=1060173 (SLES)

# Related PR

https://github.com/yast/yast-pam/pull/13

# Problem

During installation and later in the installed system, "autologin" is offered even if it doesn't make sense and if it can't even work: If a user selects the "server" role or some other package combination that does not provide X11 or Wayland or, in general, a graphical login, the "Autologin" checkbox is available.

Selecting that option has no effect in that case.

# Fix

Don't only rely on the control.xml file that has a parameter if that should be offered at all; also check if the capability is available, i.e. if a display manager (login manager) that supports that feature is or will be installed.

`Autologin.supported?` from the _yast2-pam_ package (see related PR https://github.com/yast/yast-pam/pull/13) provides that information.


# Test

## Installed System

- Start "yast2 users" and

  - Check /var/log/YaST2/y2log for "Autologin is supported" or "Autologin is not supported"
  - On the main dialog of the users module, check the "Expert Options" menu whether or not there is a menu entry "Login Settings" (this is only about autologin)

You might need to modify the package list in `/usr/share/YaST2/modules/Autologin.rb` to test the other case.


## inst-sys

- Start the installation
- Select system role "Server" (or another role without graphical desktop)
- Continue to the "Create First User" dialog
- Check if the "Autologin" checkbox in that dialog is really disabled

- Go back to the role selection
- Select another role, this time _with_ a graphical desktop
- Continue to the "Create First User" dialog
- Check if the "Autologin" checkbox is enabled now

## Screenshots (inst-sys)

### System Role "Server (text mode)" Selected

![inst-first-user-server-role](https://user-images.githubusercontent.com/11538225/56218491-60974300-6065-11e9-948d-a07b3385ebef.png)

### System Role "GNOME Desktop" Selected

![inst-first-user-gnome-role](https://user-images.githubusercontent.com/11538225/56218521-6ab94180-6065-11e9-8712-70eb11439cc9.png)
