### PR TITLE
Merge SLE-15-SP1 into master

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 16 14:13:03 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Fix the user creation in the installed systems, obeying the
+  decision about creating the user's home as a plain directory
+  or as a Btrfs subvolume (bsc#1134970).
+- 4.2.1
+
+-------------------------------------------------------------------
 Tue Apr 16 14:27:28 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Offer autologin only if a display manager that supports it is

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4483,7 +4483,7 @@ sub Write {
 
 		my %user	        = %{$modified_users{$type}{$username}};
 		my $home 	        = $user{"homeDirectory"} || "";
-		my $use_btrfs_subvolume = $user{"btrfs_subvolume"} || 0;
+		my $use_btrfs_subvolume = bool($user{"btrfs_subvolume"});
 		my $uid		        = $user{"uidNumber"} || 0;
 		my $command 	        = "";
 		my $user_mod 	        = $user{"modified"} || "no";


### PR DESCRIPTION
PR to sync changes introduced in #206 

> **Problem**
>
> The user creation does not respect the desired behavior: to create the user's home as a plain directory (default) or as a Btrfs subvolume (ticking the "Create as Btrfs Subvolume" option added in 4.1.7). Instead, it is always - in an installed system - trying to create a Btrfs subvolume (unsuccessfully when the chosen path is no in a Btrfs filesystem).
>
>    https://bugzilla.suse.com/show_bug.cgi?id=1134970
>    https://trello.com/c/GuqA45nj
>    Related to #195


> **Solution**
> 
> To initialize the $use_btrfs_subvolume"variable properly, using the bool subroutine mentioned above.
