### PR TITLE
Fixed unit test: skip Package::Installed() call (bsc#1138668)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 19 07:39:49 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed failing old testsuite: do not depend on the environment,
+  skip nscd restart in Mode.test() (bsc#1138668)
+- 4.2.3
+
+-------------------------------------------------------------------
 Fri May 31 12:42:14 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4597,7 +4597,7 @@ sub Write {
     }
 
     # remove the passwd cache for nscd (bug 24748, 41648)
-    if (!$write_only && Package->Installed ("nscd")) {
+    if (!$write_only && !Mode->test() && Package->Installed ("nscd")) {
 	if ($nscd_passwd) {
 	    my $cmd	= "/usr/sbin/nscd -i passwd";
 	    SCR->Execute (".target.bash", $cmd);

--- a/testsuite/tests/EditUser.out
+++ b/testsuite/tests/EditUser.out
@@ -35,7 +35,6 @@ Read	.target.stat "/home/hh" $["isdir":true]
 Execute	.target.bash_output "/usr/bin/chown -R 501:100 '/home/hh'" $["stdout":"hh"]
 Execute	.target.bash "/usr/bin/cp '/etc/shadow' '/etc/shadow.YaST2save'" 0
 Write	.target.string "/etc/shadow" "at:!:13636:0:99999:7:::\nbin:*:13636::::::\ndaemon:*:13636::::::\nmail:*:13636::::::\nnobody:*:13636::::::\nroot:password:13636::::::\nuucp:*:13636::::::\nhh:heslo:13727:0:99999:7:::\n+::0:0:0::::\n" true
-Execute	.target.bash "/usr/sbin/nscd -i passwd" 0
 Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custom_users":["local"], "dont_warn_when_nisserver_notdes":false, "dont_warn_when_uppercase":false] true
 Return	
 Return	nil
@@ -63,6 +62,5 @@ Read	.target.stat "/home/hh" $[]
 Read	.target.stat "/new/home/hh" $[]
 Execute	.target.bash "/usr/bin/cp '/etc/shadow' '/etc/shadow.YaST2save'" 0
 Write	.target.string "/etc/shadow" "at:!:13636:0:99999:7:::\nbin:*:13636::::::\ndaemon:*:13636::::::\nmail:*:13636::::::\nnobody:*:13636::::::\nroot:password:13636::::::\nuucp:*:13636::::::\nhh:heslo:13727:0:99999:7:::\n+::0:0:0::::\n" true
-Execute	.target.bash "/usr/sbin/nscd -i passwd" 0
 Return	
 Dump	==========================================================

--- a/testsuite/tests/YaPIGroupAdd.out
+++ b/testsuite/tests/YaPIGroupAdd.out
@@ -18,7 +18,6 @@ Execute	.target.bash_output "/usr/bin/echo 'gg' | /usr/bin/grep '^[[:alpha:]_][[
 Execute	.target.bash "/usr/bin/cp '/etc/group' '/etc/group.YaST2save'" 0
 Write	.target.string "/etc/group" "audio:x:17:ii\nnobody:x:65533:\nroot:x:0:\ngg:x:1000:\nusers:x:100:\n+:::\n" true
 Execute	.target.bash_output "/usr/bin/diff -U 1 '/etc/group.YaST2save' '/etc/group'" $["stdout":"gg"]
-Execute	.target.bash "/usr/sbin/nscd -i group" 0
 Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custom_users":["local"], "dont_warn_when_nisserver_notdes":false, "dont_warn_when_uppercase":false] true
 Return	
 Dump	============ add new group 'gg' - done ====================
@@ -39,7 +38,6 @@ Execute	.target.bash_output "/usr/bin/echo 'gg2' | /usr/bin/grep '^[[:alpha:]_][
 Execute	.target.bash "/usr/bin/cp '/etc/group' '/etc/group.YaST2save'" 0
 Write	.target.string "/etc/group" "audio:x:17:ii\nnobody:x:65533:\nroot:x:0:\ngg:x:1000:\ngg2:x:1001:hh\nusers:x:100:\n+:::\n" true
 Execute	.target.bash_output "/usr/bin/diff -U 1 '/etc/group.YaST2save' '/etc/group'" $["stdout":"gg2"]
-Execute	.target.bash "/usr/sbin/nscd -i group" 0
 Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custom_users":["local"], "dont_warn_when_nisserver_notdes":false, "dont_warn_when_uppercase":false] true
 Return	
 Dump	============ add new group 'gg2' - done ====================
@@ -60,7 +58,6 @@ Execute	.target.bash_output "/usr/bin/echo 'gg3' | /usr/bin/grep '^[[:alpha:]_][
 Execute	.target.bash "/usr/bin/cp '/etc/group' '/etc/group.YaST2save'" 0
 Write	.target.string "/etc/group" "audio:x:17:ii\nnobody:x:65533:\nroot:x:0:\ngg:x:1000:\ngg2:x:1001:hh\ngg3:x:1002:hh,ii\nusers:x:100:\n+:::\n" true
 Execute	.target.bash_output "/usr/bin/diff -U 1 '/etc/group.YaST2save' '/etc/group'" $["stdout":"gg3"]
-Execute	.target.bash "/usr/sbin/nscd -i group" 0
 Write	.target.ycp "/var/lib/YaST2/users.ycp" $["custom_groups":["local"], "custom_users":["local"], "dont_warn_when_nisserver_notdes":false, "dont_warn_when_uppercase":false] true
 Return	
 Dump	============ add new group 'gg3' - done ====================


### PR DESCRIPTION
## Problem

- Failing old test suite
```
[   92s]  Write	.target.string "/etc/shadow" "at:!:13636:0:99999:7:::\nbin:*:13636::::::\ndaemon:*:13636::::::\nmail:*:13636::::::\nnobody:*:13636::::::\nroot:password:13636::::::\nuucp:*:13636::::::\nhh:heslo:13727:0:99999:7:::\n+::0:0:0::::\n" true
[   92s] -Execute	.target.bash "/usr/sbin/nscd -i passwd" 0
[   92s]  Return
```

- It turned out that it depends whether the `nscd` package is installed during the RPM build or not

## Fix

- Check `Mode.test` and do not check for the package presence in that case
- 4.2.3