### PR TITLE
hide all password fields in log (bsc#1141017)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 11 09:52:50 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- hide all password fields in log (bsc#1141017)
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Jun 19 07:39:49 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed failing old testsuite: do not depend on the environment,

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4569,10 +4569,20 @@ sub Write {
 		    SSHAuthorizedKeys->write_keys($home, $user{"authorized_keys"});
 		}
 
-		my $save_passwd = $user{"userPassword"};
-		$user{"userPassword"} = "*****"; # Reset before logging
+                my %saved_passwords;
+
+                # hide passwords for logging
+                for my $pw (qw (userPassword text_userpassword)) {
+                    $saved_passwords{$pw} = $user{$pw};
+                    $user{$pw} = "*****";
+                }
+
 		y2milestone ("User = ", Dumper(\%user));
-		$user{"userPassword"} = $save_passwd;
+
+		# restore
+		for my $pw (keys %saved_passwords) {
+		    $user{$pw} = $saved_passwords{$pw};
+		}
 	    }
 	}
     }


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1141017

User password shows up in log.

### Solution

Hide all password fields: `text_userpassword` and `userPassword`.