### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM yastdevel/cpp:sle12-sp5
 
 
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --non-interactive in --force-resolution --no-recommends \
   cracklib-devel \
   perl-Digest-SHA1 \
+  perl-X500-DN \
   yast2 \
   yast2-ldap \
   yast2-perl-bindings \


### PR DESCRIPTION
Installing the `perl-X500-DN` package in the Docker image which provides the
`X500::DN` module required to successfully perform the new [Perl syntax
check](https://github.com/yast/docker-yast-ruby/commit/7dd9c8cab22fa7f7d516d9664c091f19e06673be).