### PR TITLE
[Backport] Do not log passwords

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 14 14:22:25 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not log passwords (bsc#1141017).
+- 4.1.14
+
+-------------------------------------------------------------------
 Thu May 16 14:13:03 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Fix the user creation in the installed systems, obeying the

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.1.13
+Version:        4.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4569,10 +4569,20 @@ sub Write {
 		    SSHAuthorizedKeys->write_keys($home, $user{"authorized_keys"});
 		}
 
-		my $save_passwd = $user{"userPassword"};
-		$user{"userPassword"} = "*****"; # Reset before logging
+                my %saved_passwords;
+
+                # hide passwords for logging
+                for my $pw (qw (userPassword text_userpassword)) {
+                    $saved_passwords{$pw} = $user{$pw};
+                    $user{$pw} = "*****";
+                }
+
 		y2milestone ("User = ", Dumper(\%user));
-		$user{"userPassword"} = $save_passwd;
+
+		# restore
+		for my $pw (keys %saved_passwords) {
+		    $user{$pw} = $saved_passwords{$pw};
+		}
 	    }
 	}
     }


### PR DESCRIPTION
## Problem

The user password is being leak in the YaST logs from `4.1.12`.

## Solution

Do not log the password (backport of https://github.com/yast/yast-users/pull/210)

## Test

Tested manually via DUD, the password is now hidden.

```
linux-qotp:~ # zgrep text_ /var/log/YaST2/*
/var/log/YaST2/y2log-1.gz:  'text_userpassword' => '*****',
/var/log/YaST2/yast-installation-logs.tar.xz:Binary file (standard input) matches
```

![Screenshot_sle15sp2_2019-08-14_16:30:12](https://user-images.githubusercontent.com/1691872/63034244-d6df7100-beb0-11e9-9cc3-da598ac9c04f.png)


---

Related to https://github.com/yast/yast-users/pull/202, https://github.com/yast/yast-users/pull/203, and https://github.com/yast/yast-users/pull/210