### PR TITLE
Do not copy the skeleton files for system users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM yastdevel/cpp:sle12-sp2
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+RUN zypper --non-interactive in --force-resolution --no-recommends \
   cracklib-devel \
   perl-Digest-SHA1 \
+  perl-X500-DN \
   yast2 \
   yast2-ldap \
   yast2-perl-bindings \

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 19 12:10:54 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not copy the skeleton files for system users (bsc#1130158,
+  bsc#1143205).
+- 3.1.57.8
+
+-------------------------------------------------------------------
 Tue Mar  7 13:49:49 UTC 2017 - jreidinger@suse.com
 
 - do not ask again for already approved weak password second

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        3.1.57.7
+Version:        3.1.57.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5959,6 +5959,14 @@ sub ImportUser {
 	$ret{"shadowLastChange"} eq "") {
 	$ret{"shadowLastChange"}	= LastChangeIsNow ();
     }
+
+    # AutoYaST-imported users don't go through AddUser(). This means we have
+    # to replicate some of that logic here:
+    #
+    #   - don't copy skel files for system users (bsc#1130158)
+    #
+    $ret{no_skeleton} ||= 1 if $ret{type} eq "system";
+
     return \%ret;
 }
 


### PR DESCRIPTION
## Problem

AutoYaST is copying the skeleton files for imported system users.

## Solution

Replicate some [logic already available in the `AddUser()` subroutine](https://github.com/yast/yast-users/blob/ab9ee6011240adeebbfab72230d32502a02a03c4/src/modules/Users.pm#L3111-L3113), which is not used for the AutoYaST imported users.

> A fix originally proposed for SLE-15[1][2] to solve bsc#1130158 and now
> backported to SLE-12 to solve bsc#1143205.
> 
> [1] https://github.com/yast/yast-users/pull/202
> [2] https://github.com/yast/yast-users/pull/202/commits/937fe2b9b1abd95f7b4bec9eafd40089236f1949

## Test

* Tested manually, via _dud_

## Screenshot

<p align="center">The <em>pulseaudio</em> directory is empty, as expected</p>
 
![Screenshot_sles12-sp4_2019-08-19_13:21:38](https://user-images.githubusercontent.com/1691872/63266195-44abe400-c287-11e9-8b2d-5a4ac172b438.png)


