### PR TITLE
Request confirmation for aborting in the root password dialog

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 12 19:35:07 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Request confirmation for aborting in the dialog for setting the
+  root password (bsc#1165506)
+- 4.2.10
+
+-------------------------------------------------------------------
 Tue Feb  4 14:14:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark users as WSL capable module (bsc#1162650) 

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/dialogs/inst_root_first.rb
+++ b/src/lib/users/dialogs/inst_root_first.rb
@@ -24,6 +24,7 @@ require "users/widgets/inst_root_first"
 
 Yast.import "Mode"
 Yast.import "UsersSimple"
+Yast.import "Popup"
 
 module Yast
   # This library provides a simple dialog for setting new password for the
@@ -50,6 +51,11 @@ module Yast
     # Returns a UI widget-set for the dialog
     def contents
       VBox(Y2Users::Widgets::InstRootFirst.new)
+    end
+
+    # Request confirmation for aborthing the dialog
+    def abort_handler
+      Yast::Popup.ConfirmAbort(:painless)
     end
 
   private

--- a/test/lib/users/dialogs/inst_root_first_test.rb
+++ b/test/lib/users/dialogs/inst_root_first_test.rb
@@ -41,4 +41,11 @@ describe Yast::InstRootFirstDialog do
       end
     end
   end
+
+  describe "#abort_handler" do
+    it "requests confirmation for aborting the process" do
+      expect(Yast::Popup).to receive(:ConfirmAbort)
+      subject.abort_handler
+    end
+  end
 end


### PR DESCRIPTION
## Problem

During an installation or firstboot configuration, the dialog for setting the root password abort immediately when  the `Abort` button is pressed. It should request an abort confirmation before abort.

- https://trello.com/c/xZvv9fNN/1698-leap152-p3-1165506-installer-obeys-the-abort-button-without-any-confirmation-only-when-on-roots-password-screen
- https://bugzilla.suse.com/show_bug.cgi?id=1165506

## Solution

Added the popup for confirming the abort.

## Screenshots

![AbortRootPasswordSetting](https://user-images.githubusercontent.com/7056681/76560850-f7e56000-6499-11ea-979f-b4c3e399f191.png)
