### PR TITLE
Use new krb5 sbin path 

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 14 15:06:32 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Use available kadmin.local binary (either at /usr/lib/mit/sbin
+  or /usr/sbin).
+- Related to bsc#1174078.
+- 4.3.4
+
+-------------------------------------------------------------------
 Mon Jun 29 15:28:01 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Honor the 'target' argument when cloning the system. If it is

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/UsersPluginKerberos.pm
+++ b/src/modules/UsersPluginKerberos.pm
@@ -79,6 +79,18 @@ sub contains {
     return 0;
 }
 
+# internal function:
+# check the path of kadmin.local binary
+#
+# Note that the lastest kbr5 package provides the kadmin.local binary at /usr/sbin,
+# but older kbr5 uses /usr/lib/mit/sbin path.
+sub kadmin_path {
+    my $path = "/usr/sbin/kadmin.local";
+    my $old_path = "/usr/lib/mit/sbin/kadmin.local";
+
+    return SCR->Execute (".target.stat", $path) ? $path : $old_path;
+}
+
 ##------------------------------------------
 ##--------------------- global API functions
 
@@ -150,7 +162,7 @@ sub PluginPresent {
 	y2debug ("Kerberos plugin not present");
 	return 0;
     }
-    my $out	= SCR->Execute (".target.bash_output", "/usr/lib/mit/sbin/kadmin.local -nq 'list_principals ".String->Quote("".$data->{uid})."*' | /usr/bin/grep '".String->Quote("".$data->{uid})."*'");
+    my $out	= SCR->Execute (".target.bash_output", "${\kadmin_path()} -nq 'list_principals ".String->Quote("".$data->{uid})."*' | /usr/bin/grep '".String->Quote("".$data->{uid})."*'");
     if ($out->{"stdout"} =~ /^$data->{uid}/ ) {
 	y2milestone ("Kerberos plugin present");
 	return 1;
@@ -240,7 +252,7 @@ BEGIN { $TYPEINFO{Write} = ["function", "boolean", "any", "any"];}
 sub Write {
 
     my ($self, $config, $data)  = @_;
-    my $command = '/usr/lib/mit/sbin/kadmin.local';
+    my $command = kadmin_path();
     my $input = "";
 
     #y2milestone(Dumper($data));

--- a/src/modules/UsersPluginKerberos.pm
+++ b/src/modules/UsersPluginKerberos.pm
@@ -88,7 +88,7 @@ sub kadmin_path {
     my $path = "/usr/sbin/kadmin.local";
     my $old_path = "/usr/lib/mit/sbin/kadmin.local";
 
-    return SCR->Execute (".target.stat", $path) ? $path : $old_path;
+    return -x $path ? $path : $old_path;
 }
 
 ##------------------------------------------


### PR DESCRIPTION
## Problem

The package *krb5* was adapted to provide binaries at */usr/sbin* path instead of */usr/lib/mit/sbin*, see https://build.opensuse.org/request/show/814662.

YaST is still using the old */usr/lib/mit/sbin* paths. 

* https://trello.com/c/PxH6LJhf/1951-3-new-krb5-path-in-tw

* https://bugzilla.opensuse.org/show_bug.cgi?id=1174078

## Solution

Adapt YaST code to use the new paths.

Note: the changes in the *kbr5* package were done without a change in the version number, so *yast2-users* cannot indicate a conflict with any *kbr5* old version. And also note that this new *yast2-users* package will be submitted to both: SLE-15-SP3 and Factory, but most likely SLE-15-SP3 will not receive any update for *kbr5*. Because that, *yast2-users* has to deal with both possible paths (/usr/lib/mit/sbin and /usr/sbin).