### PR TITLE
Use yast2-pam/Nsswitch module to read NSS configuration

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -3,6 +3,7 @@ Fri Jul 24 14:00:40 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Load the right nsswitch.conf from either, /usr/etc or /etc
 - Related to bsc#1173119.
+- 4.3.5
 
 -------------------------------------------------------------------
 Tue Jul 14 15:06:32 UTC 2020 - José Iván López González <jlopez@suse.com>

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 24 14:00:40 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Load the right nsswitch.conf from either, /usr/etc or /etc
+- Related to bsc#1173119.
+
+-------------------------------------------------------------------
 Tue Jul 14 15:06:32 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Use available kadmin.local binary (either at /usr/lib/mit/sbin

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -46,8 +46,8 @@ Requires:       perl-X500-DN
 Requires:       perl-gettext
 Requires:       yast2-country
 
-# Autologin.supported?
-Requires:       yast2-pam >= 4.2.0
+# CFA::Nsswitch
+Requires:       yast2-pam >= 4.3.0
 
 Requires:       yast2-security
 

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5753,7 +5753,7 @@ sub ReadNISAvailable {
 
     my $passwd_source = Nsswitch->ReadDb ("passwd");
 
-    if ( grep ( /^nis|compat$/, @$passwd_source ) ) {
+    if ( grep ( /^(nis|compat)$/, @$passwd_source ) ) {
       return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
     }
 

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5752,13 +5752,11 @@ BEGIN { $TYPEINFO{ReadNISAvailable} = ["function", "boolean"];}
 sub ReadNISAvailable {
 
     my $passwd_source = Nsswitch->ReadDb ("passwd");
-    if (@$passwd_source) {
-      foreach my $source (@$passwd_source) {
-        if ($source eq "nis" || $source eq "compat") {
-          return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
-        }
-      }
+
+    if ( grep ( /^nis|compat$/, @$passwd_source ) ) {
+      return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
     }
+
     return 0;
 }
 ##-------------------------------------------------------------------------

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -251,6 +251,7 @@ YaST::YCP::Import ("UsersRoutines");
 YaST::YCP::Import ("UsersSimple");
 YaST::YCP::Import ("UsersUI");
 YaST::YCP::Import ("SSHAuthorizedKeys");
+YaST::YCP::Import ("Nsswitch");
 
 ##-------------------------------------------------------------------------
 ##----------------- various routines --------------------------------------
@@ -5750,14 +5751,13 @@ sub ReadNISMaster {
 BEGIN { $TYPEINFO{ReadNISAvailable} = ["function", "boolean"];}
 sub ReadNISAvailable {
 
-    my $passwd_source = SCR->Read (".etc.nsswitch_conf.passwd");
-    if (defined $passwd_source) {
-	foreach my $source (split (/ /, $passwd_source)) {
-
-	    if ($source eq "nis" || $source eq "compat") {
-		return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
-	    }
-	}
+    my @passwd_source = Nsswitch->ReadDb ("passwd");
+    if (@passwd_source) {
+      foreach my $source (@passwd_source) {
+        if ($source eq "nis" || $source eq "compat") {
+          return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
+        }
+      }
     }
     return 0;
 }

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5751,9 +5751,9 @@ sub ReadNISMaster {
 BEGIN { $TYPEINFO{ReadNISAvailable} = ["function", "boolean"];}
 sub ReadNISAvailable {
 
-    my @passwd_source = Nsswitch->ReadDb ("passwd");
-    if (@passwd_source) {
-      foreach my $source (@passwd_source) {
+    my $passwd_source = Nsswitch->ReadDb ("passwd");
+    if (@$passwd_source) {
+      foreach my $source (@$passwd_source) {
         if ($source eq "nis" || $source eq "compat") {
           return (Package->Installed ("ypbind") && Service->Status ("ypbind") == 0);
         }


### PR DESCRIPTION
## Problem

The old SCR nsswitch agent has been replaced by a CFA class able to deal with the new layout having the configuration split between `/usr/etc` and `/etc.` See https://github.com/yast/yast-pam/pull/20 for more details.

## Solution

Start using the [yast2-pam/Nsswitch module](https://github.com/yast/yast-pam/blob/43201e3ed0d50f8dce3a853aef3057265d8aa471/src/modules/Nsswitch.rb) instead of the no longer available SCR agent.

## Test

* **Not unit testing** for the complex Perl module.
* Tested manually running.