### PR TITLE
Public key selector: filter is based on filesystems

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec  2 10:41:55 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- In the public key selector, allow to choose any device that
+  contains any filesystem except swap and squashfs (bsc#1178509).
+- 4.3.10
+
+-------------------------------------------------------------------
 Wed Nov 11 11:09:04 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Importing public SSH key in administrator screen: Disable

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/leaf_blk_device.rb
+++ b/src/lib/users/leaf_blk_device.rb
@@ -49,7 +49,7 @@ module Y2Users
         parent = find_root_device(hash)
         new(
           name: hash["name"], disk: parent["name"], model: parent["model"],
-          transport: parent["tran"], fstype: hash["fstype"]
+          fstype: hash["fstype"]
         )
       end
 
@@ -61,7 +61,7 @@ module Y2Users
       def lsblk
         output = Yast::Execute.locally(
           "/usr/bin/lsblk", "--inverse", "--json", "--paths",
-          "--output", "NAME,TRAN,FSTYPE,MODEL", stdout: :capture
+          "--output", "NAME,FSTYPE,MODEL", stdout: :capture
         )
         return { "blockdevices" => [] } if output.nil?
         JSON.parse(output)
@@ -84,9 +84,6 @@ module Y2Users
     # @return [String] Disk's kernel name
     attr_reader :disk
 
-    # @return [Symbol] Disk's transport (:usb, :ata, etc.)
-    attr_reader :transport
-
     # @return [Symbol] Filesystem type
     attr_reader :fstype
 
@@ -95,13 +92,11 @@ module Y2Users
     # @param name      [String]  Kernel name
     # @param disk      [String]  Disk's kernel name
     # @param model     [String]  Hardware model
-    # @param transport [symbol]  Transport
     # @param fstype    [Symbol]  Filesystem type
-    def initialize(name:, disk:, model:, transport: nil, fstype: nil)
+    def initialize(name:, disk:, model:, fstype: nil)
       @name = name
       @model = model
       @disk = disk
-      @transport = transport.to_sym if transport
       @fstype = fstype.to_sym if fstype
     end
 
@@ -110,13 +105,6 @@ module Y2Users
     # @return [Boolean]
     def filesystem?
       !!fstype
-    end
-
-    # Determines whether the device has a transport
-    #
-    # @return [Boolean]
-    def transport?
-      !!transport
     end
   end
 end

--- a/src/lib/users/leaf_blk_device.rb
+++ b/src/lib/users/leaf_blk_device.rb
@@ -95,7 +95,7 @@ module Y2Users
     # @param fstype    [Symbol]  Filesystem type
     def initialize(name:, disk:, model:, fstype: nil)
       @name = name
-      @model = model
+      @model = model.strip if model
       @disk = disk
       @fstype = fstype.to_sym if fstype
     end

--- a/src/lib/users/widgets/public_key_selector.rb
+++ b/src/lib/users/widgets/public_key_selector.rb
@@ -207,12 +207,13 @@ module Y2Users
       # @return [Yast::Term]
       def blk_devices_combo_box
         options = available_blk_devices.map do |dev|
-          label = dev.model ? "#{dev.model.strip} (#{dev.name})" : dev.name
+          label = dev.model ? "#{dev.model} (#{dev.name})" : dev.name
           Item(Id(dev.name), label, dev.name == selected_blk_device_name)
         end
         ComboBox(Id(:blk_device), Opt(:hstretch), "", options)
       end
 
+      EXCLUDED_FSTYPES = [:squashfs, :swap].freeze
       # Returns a list of devices that can be selected
       #
       # Only the devices that meet the following conditions are considered:
@@ -227,7 +228,7 @@ module Y2Users
       # @return [Array<LeafBlkDevice>] List of devices
       def available_blk_devices
         @available_blk_devices ||= LeafBlkDevice.all.select do |dev|
-          dev.filesystem? && dev.fstype != :squashfs
+          dev.filesystem? && !EXCLUDED_FSTYPES.include?(dev.fstype)
         end
       end
 

--- a/src/lib/users/widgets/public_key_selector.rb
+++ b/src/lib/users/widgets/public_key_selector.rb
@@ -226,7 +226,7 @@ module Y2Users
       # @return [Array<LeafBlkDevice>] List of devices
       def available_blk_devices
         @available_blk_devices ||= LeafBlkDevice.all.select do |dev|
-          dev.filesystem? && dev.fstype != :squash
+          dev.filesystem? && dev.fstype != :squashfs
         end
       end
 

--- a/src/lib/users/widgets/public_key_selector.rb
+++ b/src/lib/users/widgets/public_key_selector.rb
@@ -226,7 +226,7 @@ module Y2Users
       # @return [Array<LeafBlkDevice>] List of devices
       def available_blk_devices
         @available_blk_devices ||= LeafBlkDevice.all.select do |dev|
-          dev.filesystem? && dev.fstype != :squash && dev.transport?
+          dev.filesystem? && dev.fstype != :squash
         end
       end
 

--- a/src/lib/users/widgets/public_key_selector.rb
+++ b/src/lib/users/widgets/public_key_selector.rb
@@ -207,7 +207,8 @@ module Y2Users
       # @return [Yast::Term]
       def blk_devices_combo_box
         options = available_blk_devices.map do |dev|
-          Item(Id(dev.name), "#{dev.model} (#{dev.name})", dev.name == selected_blk_device_name)
+          label = dev.model ? "#{dev.model.strip} (#{dev.name})" : dev.name
+          Item(Id(dev.name), label, dev.name == selected_blk_device_name)
         end
         ComboBox(Id(:blk_device), Opt(:hstretch), "", options)
       end

--- a/test/fixtures/lsblk.txt
+++ b/test/fixtures/lsblk.txt
@@ -1,16 +1,17 @@
 {
    "blockdevices": [
-      {"name": "/dev/sda1", "tran": null, "fstype": "vfat", "rm": "0", "model": null,
+      {"name": "/dev/sda1", "fstype": "vfat", "model": null,
          "children": [
-            {"name": "/dev/sda", "tran": "sata", "fstype": null, "rm": "0", "model": "WDC WD10EZEX-75M"}
+            {"name": "/dev/sda", "fstype": null, "model": "WDC WD10EZEX-75M"}
          ]
       },
-      {"name": "/dev/sda2", "tran": null, "fstype": "ext4", "rm": "0", "model": null,
+      {"name": "/dev/sda2", "fstype": "ext4", "model": null,
          "children": [
-            {"name": "/dev/sda", "tran": "sata", "fstype": null, "rm": "0", "model": "WDC WD10EZEX-75M"}
+            {"name": "/dev/sda", "fstype": null, "model": "WDC WD10EZEX-75M"}
          ]
       },
-      {"name": "/dev/sr0", "tran": "sata", "fstype": null, "rm": "1", "model": "DVD-ROM DS-8DBSH"},
-      {"name": "/dev/sr1", "tran": "usb", "fstype": "iso9660", "rm": "1", "model": "File-CD Gadget  "}
+      {"name": "/dev/sr0", "fstype": null, "model": "DVD-ROM DS-8DBSH"},
+      {"name": "/dev/sr1", "fstype": "iso9660", "model": "File-CD Gadget  "},
+      {"name": "/dev/loop0", "fstype": "squashfs", "model": null}
    ]
 }

--- a/test/lib/users/leaf_blk_device_test.rb
+++ b/test/lib/users/leaf_blk_device_test.rb
@@ -36,7 +36,8 @@ describe Y2Users::LeafBlkDevice do
         an_object_having_attributes(name: "/dev/sda1", fstype: :vfat),
         an_object_having_attributes(name: "/dev/sda2", fstype: :ext4),
         an_object_having_attributes(name: "/dev/sr0", fstype: nil),
-        an_object_having_attributes(name: "/dev/sr1", fstype: :iso9660)
+        an_object_having_attributes(name: "/dev/sr1", fstype: :iso9660),
+        an_object_having_attributes(name: "/dev/loop0", fstype: :squashfs)
       )
     end
 
@@ -71,31 +72,6 @@ describe Y2Users::LeafBlkDevice do
 
       it "returns false" do
         expect(subject.filesystem?).to eq(false)
-      end
-    end
-  end
-
-  describe "#transport?" do
-    subject do
-      Y2Users::LeafBlkDevice.new(
-        name: "/dev/sdb1", model: "MyBrand 8G", disk: "/dev/sdb", fstype: "ext4",
-        transport: transport
-      )
-    end
-
-    context "when the device has a transport" do
-      let(:transport) { "usb" }
-
-      it "returns true" do
-        expect(subject.transport?).to eq(true)
-      end
-    end
-
-    context "when the device does not have a transport" do
-      let(:transport) { nil }
-
-      it "returns false" do
-        expect(subject.transport?).to eq(false)
       end
     end
   end

--- a/test/lib/users/widgets/public_key_selector_test.rb
+++ b/test/lib/users/widgets/public_key_selector_test.rb
@@ -39,7 +39,7 @@ describe Y2Users::Widgets::PublicKeySelector do
   end
 
   describe "#contents" do
-    let(:blk_devices) { [usb_with_fs, usb_no_fs, squashfs] }
+    let(:blk_devices) { [usb_with_fs, usb_no_fs, squashfs, swap] }
 
     let(:usb_with_fs) do
       Y2Users::LeafBlkDevice.new(
@@ -56,6 +56,12 @@ describe Y2Users::Widgets::PublicKeySelector do
     let(:squashfs) do
       Y2Users::LeafBlkDevice.new(
         name: "/dev/loop0", model: "MyBrand 4G", disk: "/dev/loop0", fstype: :squashfs
+      )
+    end
+
+    let(:swap) do
+      Y2Users::LeafBlkDevice.new(
+        name: "/dev/sda1", model: nil, disk: "/dev/sda", fstype: :swap
       )
     end
 
@@ -76,6 +82,10 @@ describe Y2Users::Widgets::PublicKeySelector do
 
       it "does not include devices which has a squashfs filesystem" do
         expect(widget.contents.to_s).to_not include("/dev/loop0")
+      end
+
+      it "does not include swap devices" do
+        expect(widget.contents.to_s).to_not include("/dev/sda1")
       end
 
       context "when a key is selected" do

--- a/test/lib/users/widgets/public_key_selector_test.rb
+++ b/test/lib/users/widgets/public_key_selector_test.rb
@@ -55,7 +55,7 @@ describe Y2Users::Widgets::PublicKeySelector do
 
     let(:squashfs) do
       Y2Users::LeafBlkDevice.new(
-        name: "/dev/some", model: "MyBrand 4G", disk: "/dev/sdc", fstype: :squashfs
+        name: "/dev/loop0", model: "MyBrand 4G", disk: "/dev/loop0", fstype: :squashfs
       )
     end
 
@@ -75,7 +75,7 @@ describe Y2Users::Widgets::PublicKeySelector do
       end
 
       it "does not include devices which has a squashfs filesystem" do
-        expect(widget.contents.to_s).to_not include("/dev/loop1")
+        expect(widget.contents.to_s).to_not include("/dev/loop0")
       end
 
       context "when a key is selected" do

--- a/test/lib/users/widgets/public_key_selector_test.rb
+++ b/test/lib/users/widgets/public_key_selector_test.rb
@@ -39,33 +39,23 @@ describe Y2Users::Widgets::PublicKeySelector do
   end
 
   describe "#contents" do
-    let(:blk_devices) { [usb_with_fs, usb_no_fs, squashfs, no_transport] }
+    let(:blk_devices) { [usb_with_fs, usb_no_fs, squashfs] }
 
     let(:usb_with_fs) do
       Y2Users::LeafBlkDevice.new(
-        name: "/dev/sdb1", model: "MyBrand 8G", disk: "/dev/sdb", transport: :usb,
-        fstype: :vfat
+        name: "/dev/sdb1", model: "MyBrand 8G", disk: "/dev/sdb", fstype: :vfat
       )
     end
 
     let(:usb_no_fs) do
       Y2Users::LeafBlkDevice.new(
-        name: "/dev/sdc1", model: "MyBrand 4G", disk: "/dev/sdc", transport: :usb,
-        fstype: nil
+        name: "/dev/sdc1", model: "MyBrand 4G", disk: "/dev/sdc", fstype: nil
       )
     end
 
     let(:squashfs) do
       Y2Users::LeafBlkDevice.new(
-        name: "/dev/some", model: "MyBrand 4G", disk: "/dev/sdc", transport: :unknown,
-        fstype: :squashfs
-      )
-    end
-
-    let(:no_transport) do
-      Y2Users::LeafBlkDevice.new(
-        name: "/dev/loop1", model: "MyBrand 8G", disk: "/dev/sdb", transport: nil,
-        fstype: :unknown
+        name: "/dev/some", model: "MyBrand 4G", disk: "/dev/sdc", fstype: :squashfs
       )
     end
 
@@ -85,10 +75,6 @@ describe Y2Users::Widgets::PublicKeySelector do
       end
 
       it "does not include devices which has a squashfs filesystem" do
-        expect(widget.contents.to_s).to_not include("/dev/loop1")
-      end
-
-      it "does not include devices which does not have a transport" do
         expect(widget.contents.to_s).to_not include("/dev/loop1")
       end
 


### PR DESCRIPTION
It is allowed to use any device that contains a filesystem if such a filesystem is not squashfs (which is basically used by the installer). It should fix [bsc#1178509](https://bugzilla.suse.com/show_bug.cgi?id=1178509).