### PR TITLE
Copy skel from usr

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  1 09:10:11 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Copy files from /usr/etc/skel when creating the home directory.
+- bsc#1183136 and related to bsc#1179261.
+- 4.4.0
+
+-------------------------------------------------------------------
 Thu Apr  1 08:22:28 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix missing Reset handling in auto client leading to crash in

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.11
+Version:        4.4.0
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4493,6 +4493,7 @@ sub Write {
 		my $chown_home	        = $user{"chown_home"};
 		$chown_home	        = 1 if (!defined $chown_home);
 		my $skel	        = $useradd_defaults{"skel"};
+		my $copy_usr_skel	= "yes";
 
 		if ($user_mod eq "imported" || $user_mod eq "added") {
 		    y2usernote ("User '$username' created");
@@ -4503,11 +4504,12 @@ sub Write {
 			next;
 		    }
 		    if (bool ($user{"no_skeleton"})) {
-			$skel 	= "";
+			$skel = "";
+			$copy_usr_skel = "";
 		    }
 		    if (bool ($create_home) || $user_mod eq "imported")
 		    {
-			UsersRoutines->CreateHome ($skel, $home, $use_btrfs_subvolume);
+			UsersRoutines->CreateHome ($skel, $home, $use_btrfs_subvolume, $copy_usr_skel);
 		    }
 		    if ($home ne "/var/lib/nobody" && bool ($chown_home)) {
 			if (UsersRoutines->ChownHome ($uid, $gid, $home))
@@ -4555,7 +4557,7 @@ sub Write {
 			}
 			# create new home directory
 			elsif (not %{SCR->Read (".target.stat", $home)}) {
-			    UsersRoutines->CreateHome ($skel, $home);
+			    UsersRoutines->CreateHome ($skel, $home, "", $copy_usr_skel);
 			}
 			# do not change root's ownership of home directories
 			if (bool ($chown_home))

--- a/src/modules/UsersLDAP.pm
+++ b/src/modules/UsersLDAP.pm
@@ -1404,7 +1404,7 @@ sub WriteUsers {
 		if ($server) {
 		    if ($create_home) {
 			UsersRoutines->CreateHome (
-			    $useradd_defaults{"skel"}, $home);
+			    $useradd_defaults{"skel"}, $home, "", "yes");
 		    }
 		    if ($home ne "/var/lib/nobody" && $chown_home) {
 			if (UsersRoutines->ChownHome ($uid, $gid, $home)) {

--- a/src/modules/UsersRoutines.pm
+++ b/src/modules/UsersRoutines.pm
@@ -50,6 +50,9 @@ YaST::YCP::Import ("String");
 # path to btrfs
 my $btrfs = "/usr/sbin/btrfs";
 
+# path to the usr skel
+my $usr_skel = "/usr/etc/skel";
+
 ##-------------------------------------------------------------------------
 ##----------------- helper routines ---------------------------------------
 
@@ -60,23 +63,45 @@ sub btrfs_subvolume {
     return ( SCR->Execute( ".target.bash", $cmd ) eq 0 );
 }
 
+sub copy_skel {
+    my ( $skel, $home ) = @_;
+
+    if ( $skel ne "" && %{ SCR->Read( ".target.stat", $skel ) } ) {
+        my $cmd = sprintf(
+            "/usr/bin/cp -r '%s/.' '%s'",
+            String->Quote($skel),
+            String->Quote($home)
+        );
+        my %cmd_out = %{ SCR->Execute( ".target.bash_output", $cmd ) };
+        my $stderr = $cmd_out{"stderr"} || "";
+
+        if ( $stderr ne "" ) {
+            y2error( "Error calling $cmd: $stderr" );
+            return 0;
+        }
+
+        y2usernote("Home skeleton copied: '$cmd'.");
+    }
+}
+
 ##-------------------------------------------------------------------------
 ##----------------- directory manipulation routines -----------------------
 
 ##------------------------------------
 # Create home directory
-# @param skeleton skeleton directory for new home
+# @param skel skeleton directory for new home (typically from /etc/default/useradd config)
 # @param home name of new home directory
 # @param use_btrfs whether the home directory must be a btrfs subvolume
+# @param copy_usr_skel whether the usr skel (i.e., /usr/etc/skel) should be copied
 # @return success
 BEGIN { $TYPEINFO{CreateHome} = ["function",
     "boolean",
-    "string", "string", "string"];
+    "string", "string", "string", "string"];
 }
 sub CreateHome {
 
     my $self = shift;
-    my ( $skel, $home, $use_btrfs ) = @_;
+    my ( $skel, $home, $use_btrfs, $copy_usr_skel ) = @_;
 
     # Create a path to new home directory, if not exists
     my $home_path = substr( $home, 0, rindex( $home, "/" ) );
@@ -133,23 +158,11 @@ sub CreateHome {
         }
     }
 
-    # Now copy the skeleton
-    if ( $skel ne "" && %{ SCR->Read( ".target.stat", $skel ) } ) {
-        my $cmd = sprintf(
-            "/usr/bin/cp -r '%s/.' '%s'",
-            String->Quote($skel),
-            String->Quote($home)
-        );
-        my %cmd_out = %{ SCR->Execute( ".target.bash_output", $cmd ) };
-        my $stderr = $cmd_out{"stderr"} || "";
-
-        if ( $stderr ne "" ) {
-            y2error( "Error calling $cmd: $stderr" );
-            return 0;
-        }
-
-        y2usernote("Home skeleton copied: '$cmd'.");
+    if ($copy_usr_skel) {
+        copy_skel($usr_skel, $home);
     }
+
+    copy_skel($skel, $home);
 
     y2milestone("The directory $home was successfully created.");
 


### PR DESCRIPTION
### Problem

*yast-users* does not use the *useradd* command for creating a new user. Instead of that, it does all the work by its own (create home directory, adapt permissions, set password, etc). One of the steps performed by *yast-users* is to execute the *useradd.local* script. That script was taking care of copying the content of */usr/etc/skel* into the new created home directory. But *useradd.local* does not do it anymore. Such a logic was moved to *useradd* in the *shadow* suite.  So now, when a new user is created with *yast-users*, the content of */usr/etc/skel* is not copied at all, resulting on incomplete home directories. 

That missing files in the new home directories is blocking the lastest changes for the *shadow* suite in Factory (including the management of */usr/etc/skel* directly by *useradd*): https://build.opensuse.org/request/show/872327.

* https://bugzilla.suse.com/show_bug.cgi?id=1183136


### Solution

Ideally, *yast-users* should be adapted to use *useradd* command. But that would require to almost re-write the whole module. For now, this issue was fixed by simply copying */usr/etc/skel* before copying */etc/skel* in order to unblock the submit request for the *shadow* suite.

Note that the YaST team has already started working in a new *yast-users-ng* module, which will make use of *useradd* command.


### Tests

* Manually tested.
