### PR TITLE
Fix auto users reset

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  1 08:22:28 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix missing Reset handling in auto client leading to crash in
+  autoyast UI (bsc#1184216)
+- 4.3.11
+
+-------------------------------------------------------------------
 Wed Dec  2 10:41:55 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - In the public key selector, allow to choose any device that

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/clients/auto.rb
+++ b/src/lib/users/clients/auto.rb
@@ -90,6 +90,10 @@ module Y2Users
         true
       end
 
+      def reset
+        import({})
+      end
+
     private
 
       # Checking double user entries

--- a/test/lib/users/clients/auto_test.rb
+++ b/test/lib/users/clients/auto_test.rb
@@ -116,5 +116,14 @@ describe Y2Users::Clients::Auto do
         subject.run
       end
     end
+
+    context "Reset" do
+      let(:func) { "Reset" }
+
+      it "import empty profile" do
+        expect(Yast::Users).to receive(:Import).with({})
+        subject.run
+      end
+    end
   end
 end


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1184216

Missing reset method result in calling abstract method that lead to exception.