### PR TITLE
Copy code from yast2

### DIFF
--- a/src/lib/y2user/configuration.rb
+++ b/src/lib/y2user/configuration.rb
@@ -1,0 +1,62 @@
+module Y2User
+  # Holds references to elements of user configuration like users, groups or passwords.
+  # Class itself holds references to different configuration instances.
+  # TODO: write example
+  class Configuration
+    class << self
+      def get(name)
+        @register ||= {}
+        @register[name]
+      end
+
+      def register(configuration)
+        @register ||= {}
+        @register[configuration.name] = configuration
+      end
+
+      def remove(configuration)
+        name = configuration.is_a?(self) ? configuration.name : configuration
+
+        @register.delete(name)
+      end
+
+      def system(reader: nil, force_read: false)
+        res = get(:system)
+        return res if res && !force_read
+
+        if !reader
+          require "y2user/readers/getent"
+          reader = Readers::Getent.new
+        end
+
+        # TODO: make system config immutable, so it cannot be modified directly
+        res = new(:system)
+        reader.read_to(res)
+
+        res
+      end
+    end
+
+    attr_reader :name
+    attr_accessor :users
+    attr_accessor :groups
+    attr_accessor :passwords
+
+    def initialize(name, users: [], groups: [], passwords: [])
+      @name = name
+      @users = users
+      @groups = groups
+      @passwords = passwords
+      self.class.register(self)
+    end
+
+    def clone_as(new_name)
+      result = self.class.new(new_name)
+      result.users = users.map { |u| u.clone_to(result) }
+      result.groups = users.map { |u| u.clone_to(groups) }
+      result.passwords = users.map { |u| u.clone_to(passwords) }
+
+      result
+    end
+  end
+end

--- a/src/lib/y2user/group.rb
+++ b/src/lib/y2user/group.rb
@@ -1,0 +1,54 @@
+require "yast2/execute"
+
+module Y2User
+  # Represents user groups on system.
+  class Group
+    # @return[Y2User::Configuration] reference to configuration in which it lives
+    attr_reader :configuration
+
+    # @return[String] group name
+    attr_reader :name
+
+    # @return[String, nil] group id  or nil if it is not yet assigned.
+    attr_reader :gid
+
+    # @return[Array<String>] list of user names
+    # @note to get list of users in given group use method #groups
+    attr_reader :users_name
+
+    # @return[:local, :ldap, :unknown] where is user defined
+    attr_reader :source
+
+    # @see respective attributes for possible values
+    def initialize(configuration, name, gid: nil, users_name: [], source: :unknown)
+      @configuration = configuration
+      @name = name
+      @gid = gid
+      @users_name = users_name
+      @source = source
+    end
+
+    # @return [Array<Y2User::User>] all users in this group, including ones that
+    # has it as primary group
+    def users
+      configuration.users.select { |u| u.gid == gid || users_name.include?(u.name) }
+    end
+
+    ATTRS = [:name, :gid, :users_name].freeze
+
+    # Clones group to different configuration object.
+    # @return [Y2User::Group] newly cloned group object
+    def clone_to(configuration)
+      new_config = ATTRS.each_with_object({}) { |a, r| r[a] = public_send(a) }
+      new_config.delete(:name) # name is separate argument
+      self.class.new(configuration, name, new_config)
+    end
+
+    # Compares group object if all attributes are same excluding configuration reference.
+    # @return [Boolean] true if it is equal
+    def ==(other)
+      # do not compare configuration to allow comparison between different configs
+      ATTRS.all? { |a| public_send(a) == other.public_send(a) }
+    end
+  end
+end

--- a/src/lib/y2user/password.rb
+++ b/src/lib/y2user/password.rb
@@ -1,0 +1,71 @@
+require "yast2/execute"
+
+module Y2User
+  # Password configuration for user including its hashed value.
+  class Password
+    # @return [String] login name for given password
+    attr_reader :name
+
+    # @return [String, nil] Encrypted password. It can have several specific values:
+    #   - "!" or "*" is disabled login by password
+    #   - "" password-less login allowed
+    #   - "!..." disabled password. After exclamation mark is old value that no longer can be used for login
+    #   - nil means password is not yet set
+    attr_reader :value
+
+    # @return [Date, :force_change, nil] Possible value are date of the last change, :force_change when next login force user to change it and nil for disabled aging feature
+    attr_reader :last_change
+
+    # @return [Integer] Minimum number of days before next password change. 0 means no restriction.
+    attr_reader :minimum_age
+
+    # @return [Integer, nil] Maximum number of days after which user is forced to change password. nil means no restriction.
+    attr_reader :maximum_age
+
+    # @return [Integer] Number of days before expire date happen. 0 means no warning.
+    attr_reader :warning_period
+
+    # @return [Integer, nil] Number of days after expire date when old password can be still used. nil means no limit
+    attr_reader :inactivity_period
+
+    # @return [Date, nil] Date when whole account expire or nil if there are no account expiration.
+    attr_reader :account_expiration
+
+    # @return[:local, :ldap, :unknown] where is user defined
+    attr_reader :source
+
+    # @see respective attributes for possible values
+    def initialize(configuration, name, value: nil, last_change: nil, minimum_age: nil,
+      maximum_age: nil, warning_period: nil, inactivity_period: nil,
+      account_expiration: nil, source: :unknown)
+      @configuration = configuration
+      @name = name
+      @value = value
+      @last_change = last_change
+      @minimum_age = minimum_age
+      @maximum_age = maximum_age
+      @warning_period = warning_period
+      @inactivity_period = inactivity_period
+      @account_expiration = account_expiration
+      @source = source
+    end
+
+    ATTRS = [:name, :value, :last_change, :minimum_age, :maximum_age, :warning_period,
+             :inactivity_period, :account_expiration].freeze
+
+    # Clones password to different configuration object.
+    # @return [Y2User::Password] newly cloned password object
+    def clone_to(configuration)
+      new_config = ATTRS.each_with_object({}) { |a, r| r[a] = public_send(a) }
+      new_config.delete(:name) # name is separate argument
+      self.class.new(configuration, name, new_config)
+    end
+
+    # Compares password object if all attributes are same excluding configuration reference.
+    # @return [Boolean] true if it is equal
+    def ==(other)
+      # do not compare configuration to allow comparison between different configs
+      ATTRS.all? { |a| public_send(a) == other.public_send(a) }
+    end
+  end
+end

--- a/src/lib/y2user/readers/getent.rb
+++ b/src/lib/y2user/readers/getent.rb
@@ -1,0 +1,117 @@
+require "yast2/execute"
+require "date"
+
+require "y2user/group"
+require "y2user/user"
+require "y2user/password"
+
+module Y2User
+  module Readers
+    # Reads users configuration using getent utility.
+    class Getent
+      def read_to(configuration)
+        configuration.users = read_users(configuration)
+        configuration.groups = read_groups(configuration)
+        configuration.passwords = read_passwords(configuration)
+      end
+
+    private
+
+      PASSWD_MAPPING = {
+        "name"   => 0,
+        "passwd" => 1,
+        "uid"    => 2,
+        "gid"    => 3,
+        "gecos"  => 4,
+        "home"   => 5,
+        "shell"  => 6
+      }.freeze
+
+      def read_users(configuration)
+        getent = Yast::Execute.on_target!("/usr/bin/getent", "passwd", stdout: :capture)
+        getent.lines.map do |line|
+          values = line.chomp.split(":")
+          gecos = values[PASSWD_MAPPING["gecos"]] || ""
+          User.new(
+            configuration,
+            values[PASSWD_MAPPING["name"]],
+            uid:   values[PASSWD_MAPPING["uid"]],
+            gid:   values[PASSWD_MAPPING["gid"]],
+            shell: values[PASSWD_MAPPING["shell"]],
+            gecos: gecos.split(","),
+            home:  values[PASSWD_MAPPING["home"]]
+          )
+        end
+      end
+
+      GROUP_MAPPING = {
+        "name"   => 0,
+        "passwd" => 1,
+        "gid"    => 2,
+        "users"  => 3
+      }.freeze
+
+      def read_groups(configuration)
+        getent = Yast::Execute.on_target!("/usr/bin/getent", "group", stdout: :capture)
+        getent.lines.map do |line|
+          values = line.chomp.split(":")
+          Group.new(
+            configuration,
+            values[GROUP_MAPPING["name"]],
+            gid:        values[GROUP_MAPPING["gid"]],
+            users_name: values[GROUP_MAPPING["users"]]&.split(",") || []
+          )
+        end
+      end
+
+      SHADOW_MAPPING = {
+        "username"           => 0,
+        "value"              => 1,
+        "last_change"        => 2,
+        "minimum_age"        => 3,
+        "maximum_age"        => 4,
+        "warning_period"     => 5,
+        "inactivity_period"  => 6,
+        "account_expiration" => 7
+      }.freeze
+
+      def read_passwords(configuration)
+        getent = Yast::Execute.on_target!("/usr/bin/getent", "shadow", stdout: :capture)
+        getent.lines.map do |line|
+          values = line.chomp.split(":")
+          max_age = values[SHADOW_MAPPING["maximum_age"]]
+          inactivity_period = values[SHADOW_MAPPING["inactivity_period"]]
+          Password.new(
+            configuration,
+            values[SHADOW_MAPPING["username"]],
+            value:              values[SHADOW_MAPPING["value"]],
+            last_change:        parse_last_change(values[SHADOW_MAPPING["last_change"]]),
+            minimum_age:        values[SHADOW_MAPPING["minimum_age"]].to_i,
+            maximum_age:        max_age&.to_i,
+            warning_period:     values[SHADOW_MAPPING["warning_period"]].to_i,
+            inactivity_period:  inactivity_period&.to_i,
+            account_expiration: parse_account_expiration(values[SHADOW_MAPPING["account_expiration"]])
+          )
+        end
+      end
+
+      def parse_last_change(value)
+        return nil if !value || value.empty?
+
+        return :force_change if value == "0"
+
+        # last_change is days till unix start 1970, so we expand it to number of seconds
+        unix_time = value.to_i * 24 * 60 * 60
+        Date.strptime(unix_time.to_s, "%s")
+      end
+
+      def parse_account_expiration(value)
+        return nil if !value || value.empty?
+
+        # last_change is days till unix start 1970, so we expand it to number of seconds
+        unix_time = value.to_i * 24 * 60 * 60
+        Date.strptime(unix_time.to_s, "%s")
+      end
+    end
+  end
+end

--- a/src/lib/y2user/readers/users_simple.rb
+++ b/src/lib/y2user/readers/users_simple.rb
@@ -1,0 +1,26 @@
+require "yast2/execute"
+require "date"
+
+require "y2user/group"
+require "y2user/user"
+require "y2user/password"
+
+Yast.import "UsersSimple"
+
+module Y2User
+  module Readers
+    # Reads users configuration using old Yast Module UsersSimple.
+    class UsersSimple
+      def read_to(configuration)
+        users = Yast::UsersSimple.GetUsers
+        # TODO: only created users, not imported ones for now
+        users.each do |user|
+          configuration.users << User.new(configuration, user["uid"], gecos: [user["cn"]])
+          # lets just use the strongest available
+          configuration.passwords << Password.new(configuration, user["uid"],
+            value: Yast::Builtins.cryptsha512(user["userPassword"]))
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2user/user.rb
+++ b/src/lib/y2user/user.rb
@@ -1,0 +1,83 @@
+require "yast2/execute"
+
+module Y2User
+  # Representing user configuration on system in contenxt of given User Configuration.
+  # @note Immutable class.
+  class User
+    # @return[Y2User::Configuration] reference to configuration in which it lives
+    attr_reader :configuration
+
+    # @return[String] user name
+    attr_reader :name
+
+    # @return[String, nil] user ID or nil if it is not yet assigned.
+    attr_reader :uid
+
+    # @return[String, nil] primary group ID or nil if it is not yet assigned.
+    # @note to get primary group use method #primary_group
+    attr_reader :gid
+
+    # @return[String, nil] default shell or nil if it is not yet assigned.
+    attr_reader :shell
+
+    # @return[String, nil] home directory or nil if it is not yet assigned.
+    attr_reader :home
+
+    # @return [Array<String>] Fields in GECOS entry.
+    attr_reader :gecos
+
+    # @return[:local, :ldap, :unknown] where is user defined
+    attr_reader :source
+
+    # @see respective attributes for possible values
+    def initialize(configuration, name, uid: nil, gid: nil, shell: nil, home: nil, gecos: [], source: :unknown)
+      # TODO: GECOS
+      @configuration = configuration
+      @name = name
+      @uid = uid
+      @gid = gid
+      @shell = shell
+      @home = home
+      @source = source
+      @gecos = gecos
+    end
+
+    # @return [Y2User::Group, nil] primary group set to given user or
+    #   nil if group is not set yet
+    def primary_group
+      configuration.groups.find { |g| g.gid == gid }
+    end
+
+    # @return [Array<Y2User::Group>] list of groups where is user included including primary group
+    def groups
+      configuration.groups.select { |g| g.users.include?(self) }
+    end
+
+    # @return [Y2User::Password] Password configuration assigned to user
+    def password
+      configuration.passwords.find { |p| p.name == name }
+    end
+
+    # @return [String] Returns full name from gecos entry or username if not specified in gecos.
+    def full_name
+      gecos.first || name
+    end
+
+    ATTRS = [:name, :uid, :gid, :shell, :home].freeze
+
+    # Clones user to different configuration object.
+    # @return [Y2User::User] newly cloned user object
+    def clone_to(configuration)
+      new_config = ATTRS.each_with_object({}) { |a, r| r[a] = public_send(a) }
+      new_config.delete(:name) # name is separate argument
+      self.class.new(configuration, name, new_config)
+    end
+
+    # Compares user object if all attributes are same excluding configuration reference.
+    # @return [Boolean] true if it is equal
+    def ==(other)
+      # do not compare configuration to allow comparison between different configs
+      ATTRS.all? { |a| public_send(a) == other.public_send(a) }
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Some new classes are being developed in order to read and write users and groups. Initially, it was decided to put that classes in the *yast2* module. The idea was to avoid the *yast2-users* dependency from [other YaST modules](https://github.com/yast/yast-users-ng/blob/master/doc/known_API_usage.md) which need to read the list of users. But that decision was re-evaluated because currently there is no problem with such a dependency of *yast2-users*. Moreover, placing that classes in *yast2* presents other problems:

* Makes organization of classes less clear, because part is in *yast2* and other part in *yast-users*.
* Could add unnecessary dependencies to *yast2* (e.g., homed). 

## Solution

This PR copies the current *y2users* code from *yast2*.
