### PR TITLE
Linux writer implementation

### DIFF
--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -125,7 +125,7 @@ module Y2Users
           "--gid"        => user.gid,
           "--shell"      => user.shell,
           "--home-dir"   => user.home,
-          "--expiredate" => user.expire_date,
+          "--expiredate" => user.expire_date.to_s,
           "--comment"    => user.gecos.join(",")
         }
 

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -79,6 +79,7 @@ module Y2Users
     # TODO: other password attributes like #maximum_age, #inactivity_period, etc.
     # TODO: no authorized keys yet
     class Writer
+      include Yast::Logger
       # Constructor
       #
       # NOTE: right now we consider the system is empty, so we only receive one parameter.
@@ -126,6 +127,12 @@ module Y2Users
       def add_user(user)
         Yast::Execute.on_target!(USERADD, *useradd_options(user))
         Yast::Execute.on_target!(CHPASSWD, *chpasswd_options(user)) if user.password&.value
+      rescue Cheetah::ExecutionFailed => e
+        if e.message.include?(USERADD)
+          log.error("Error creating user '#{user.name}' - #{e.message}")
+        else
+          log.error("Error setting password for '#{user.name}' - #{e.message}")
+        end
       end
 
       # Generates and returns the options expected by `useradd` for given user

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -106,15 +106,34 @@ module Y2Users
       # @return [Y2User::Configuration]
       attr_reader :configuration
 
+      # Command for creating new users
+      USERADD = "/usr/sbin/useradd".freeze
+      private_constant :USERADD
+
       def add_user(user)
-        # useradd pepe --uid X --gid Y --shell S --home-dir H --comment GECOS
-        #   --expiredate password.account_expiration
-        # if home_wanted?
-        #   --create-home
-        #   --btrfs-subvolume-home if so
-        # end
-        #
+        Yast::Execute.on_target!(USERADD, *useradd_options(user))
         # chpasswd
+      end
+
+      # Generates and returns the options expected by `useradd` for given user
+      #
+      # @param user [Y2Users::User]
+      # @return [Array<String>]
+      def useradd_options(user)
+        opts = {
+          "--uid"        => user.uid,
+          "--gid"        => user.gid,
+          "--shell"      => user.shell,
+          "--home-dir"   => user.home,
+          "--expiredate" => user.expire_date,
+          "--comment"    => user.gecos.join(",")
+        }
+
+        opts = opts.reject { |_, v| v.to_s.empty? }.flatten
+        # opts << "--create-home" if user.create_home?
+        # opts << "--btrfs-subvolume-home" if user.btrfs_subvolume_home?
+        opts << user.name
+        opts
       end
     end
   end

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -81,6 +81,11 @@ module Y2Users
       configuration.passwords.find { |p| p.name == name }
     end
 
+    # @return [Date, nil] date when the account expires or nil if never
+    def expire_date
+      password&.account_expiration
+    end
+
     # @return [String] Returns full name from gecos entry or username if not specified in gecos.
     def full_name
       gecos.first || name

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -27,7 +27,7 @@ require "y2users/linux/writer"
 describe Y2Users::Linux::Writer do
   subject(:writer) { described_class.new(configuration) }
 
-  xdescribe "#write" do
+  describe "#write" do
     let(:configuration) { Y2Users::Configuration.new(:test) }
     let(:user) { Y2Users::User.new(configuration, username, **user_attrs) }
     let(:password) { Y2Users::Password.new(configuration, username, value: pwd_value) }


### PR DESCRIPTION
This is a follow-up of #247. It starts adding functionality in Y2Users::Linux::Writer, making use of [`useradd`](https://man7.org/linux/man-pages/man8/useradd.8.htmlhttps://man7.org/linux/man-pages/man8/useradd.8.html) and [`chpasswd`](https://man7.org/linux/man-pages/man8/chpasswd.8.html) commands.

It adds basic unit tests too, but it's expected to improve them (see #249) 