### PR TITLE
Add UsersSimple writer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://EditorConfig.org  -*- ini -*-
+# This is a unified way to tell all your editors
+# about the proper indentation style in this repo.
+#
+# Emacs:   https://github.com/editorconfig/editorconfig-emacs#readme
+# Vim:     https://github.com/editorconfig/editorconfig-vim#readme
+# VS Code: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+# don't continue looking in upper directories, this is the top level
+root = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+
+[*.pm]
+indent_style = tab
+indent_size = 4
+tab_width = 8

--- a/src/lib/y2users.rb
+++ b/src/lib/y2users.rb
@@ -1,0 +1,23 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/configuration"
+require "y2users/user"
+require "y2users/password"
+require "y2users/group"

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -1,0 +1,65 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+Yast.import "UsersSimple"
+
+module Y2Users
+  module UsersSimple
+    # Class for writing users configuration into the old UsersSimple Yast Module
+    class Writer
+      # Constructor
+      #
+      # @param configuration [Configuration]
+      def initialize(configuration)
+        @configuration = configuration
+      end
+
+      # Stores all users from {#configuration} into the UsersSimple module
+      def write
+        users_simple = configuration.users.map { |u| to_user_simple(u) }
+        Yast::UsersSimple.SetUsers(users_simple)
+      end
+
+    private
+
+      # @return [Configuration]
+      attr_reader :configuration
+
+      # Converts an {User} object into an user hash as UsersSimple module expects
+      #
+      # @param user [User]
+      # @return [Hash]
+      def to_user_simple(user)
+        {
+          uid:           user.name,
+          uidNumber:     user.uid,
+          gidNumber:     user.gid,
+          loginShell:    user.shell,
+          homeDirectory: user.home,
+          cn:            user.full_name,
+          # TODO: Y2Users::Password class stores an encrypted password, but UsersSimple expects
+          #   plain password.
+          userPassword:  user.password.value
+        }
+      end
+    end
+  end
+end

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -1,0 +1,206 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users"
+require "y2users/users_simple/writer"
+
+describe Y2Users::UsersSimple::Writer do
+  subject { described_class.new(config) }
+
+  let(:config) { Y2Users::Configuration.new(:test) }
+
+  def user_simple(name)
+    Yast::UsersSimple.GetUsers.find { |u| u["uid"] == name }
+  end
+
+  describe "#write" do
+    context "when the users config does not contain users" do
+      before do
+        config.users = []
+      end
+
+      it "does not store users into UsersSimple module" do
+        subject.write
+
+        expect(Yast::UsersSimple.GetUsers).to be_empty
+      end
+    end
+
+    context "when the users config contains users" do
+      before do
+        config.users = [root, user]
+        config.passwords = [root_password, user_password]
+      end
+
+      let(:root) { Y2Users::User.new(config, "root", **root_attrs) }
+
+      let(:root_attrs) do
+        {
+          uid:   0,
+          gid:   0,
+          shell: "/bin/bash",
+          home:  "/root",
+          gecos: ["Root User"]
+        }
+      end
+
+      let(:root_password) { Y2Users::Password.new(config, "root", value: "S3cr3T") }
+
+      let(:user) { Y2Users::User.new(config, "test", **user_attrs) }
+
+      let(:user_attrs) do
+        {
+          uid:   uid,
+          gid:   gid,
+          shell: shell,
+          home:  home,
+          gecos: gecos
+        }
+      end
+
+      let(:uid) { 1000 }
+      let(:gid) { 100 }
+      let(:shell) { "/bin/zsh" }
+      let(:home) { "/home/test" }
+      let(:gecos) { ["Test User"] }
+
+      let(:user_password) { Y2Users::Password.new(config, "test", value: "123456") }
+
+      it "stores all users into UsersSimple module" do
+        subject.write
+
+        expect(Yast::UsersSimple.GetUsers.size).to eq(2)
+      end
+
+      it "stores the name of the users" do
+        subject.write
+
+        names = Yast::UsersSimple.GetUsers.map { |u| u["uid"] }
+
+        expect(names).to contain_exactly("root", "test")
+      end
+
+      it "stores the uid of the users" do
+        subject.write
+
+        expect(user_simple("root")["uidNumber"]).to eq("0")
+        expect(user_simple("test")["uidNumber"]).to eq("1000")
+      end
+
+      it "stores the gid of the users" do
+        subject.write
+
+        expect(user_simple("root")["gidNumber"]).to eq("0")
+        expect(user_simple("test")["gidNumber"]).to eq("100")
+      end
+
+      it "stores the shell of the users" do
+        subject.write
+
+        expect(user_simple("root")["loginShell"]).to eq("/bin/bash")
+        expect(user_simple("test")["loginShell"]).to eq("/bin/zsh")
+      end
+
+      it "stores the home directory of the users" do
+        subject.write
+
+        expect(user_simple("root")["homeDirectory"]).to eq("/root")
+        expect(user_simple("test")["homeDirectory"]).to eq("/home/test")
+      end
+
+      it "stores the full name of the users" do
+        subject.write
+
+        expect(user_simple("root")["cn"]).to eq("Root User")
+        expect(user_simple("test")["cn"]).to eq("Test User")
+      end
+
+      it "stores the password of the users" do
+        subject.write
+
+        expect(user_simple("root")["userPassword"]).to eq("S3cr3T")
+        expect(user_simple("test")["userPassword"]).to eq("123456")
+      end
+
+      context "when a user has no uid" do
+        let(:uid) { nil }
+
+        it "does not store an user uid" do
+          subject.write
+
+          expect(user_simple("test")["uidNumber"]).to be_nil
+        end
+      end
+
+      context "when a user has no gid" do
+        let(:gid) { nil }
+
+        it "does not store an user gid" do
+          subject.write
+
+          expect(user_simple("test")["gidNumber"]).to be_nil
+        end
+      end
+
+      context "when a user has no shell" do
+        let(:shell) { nil }
+
+        it "does not store an user shell" do
+          subject.write
+
+          expect(user_simple("test")["loginShell"]).to be_nil
+        end
+      end
+
+      context "when a user has no home" do
+        let(:home) { nil }
+
+        it "does not store an user home" do
+          subject.write
+
+          expect(user_simple("test")["homeDirectory"]).to be_nil
+        end
+      end
+
+      context "when a user has no specific full name" do
+        let(:gecos) { [] }
+
+        it "stores the user name as full name" do
+          subject.write
+
+          expect(user_simple("test")["cn"]).to eq("test")
+        end
+      end
+
+      context "when a user has no password" do
+        let(:user_password) { Y2Users::Password.new(config, "test", value: nil) }
+
+        it "does not store an user password" do
+          subject.write
+
+          expect(user_simple("test")["userPassword"]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

During the installation, we plan to create new *Y2Users::User* objects as result of the users forms. But we need to save the users information into the *UsersSimple* module because several reason:

* As a way of saving the users data for recovering it later when the users are going to be created in the system.
* As a way of ensuring that other modules can still access to the users data from *UsersSimple*, as they could be doing now.


## Solution

Added new writer (*Y2Users::UsersSimple::Writer*) that stores information from *Y2Users::User* objects into the *UsersSimple* module.

NOTES:

* *Y2Users::Password* contains an encrypted password, but *UsersSimple* expects a plain password. Maybe,  *Y2Users::Password* should store a plain password too.
* *UsersSimple* has some separate attributes in order to save some specific data, for example the root password. Right now, those attributes are not populated by the writer. The root password is stored as part of the root user.
