### PR TITLE
UsersSimple Writer: manage root user info

### DIFF
--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -113,6 +113,13 @@ module Y2Users
       ATTRS.all? { |a| public_send(a) == other.public_send(a) }
     end
 
+    # Whether it is the root user
+    #
+    # @return [Boolean]
+    def root?
+      name == "root"
+    end
+
     # Whether this is a system user
     #
     # This is important for several reasons:

--- a/src/lib/y2users/users_simple.rb
+++ b/src/lib/y2users/users_simple.rb
@@ -23,3 +23,4 @@ module Y2Users
 end
 
 require "y2users/users_simple/reader"
+require "y2users/users_simple/writer"

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -23,7 +23,7 @@ Yast.import "UsersSimple"
 
 module Y2Users
   module UsersSimple
-    # Class for writing users config into the old UsersSimple Yast Module
+    # Class for writing users configuration into the old UsersSimple Yast Module
     class Writer
       # Constructor
       #
@@ -44,6 +44,7 @@ module Y2Users
         root = config.users.find(&:root?)
         return unless root
 
+        # TODO: save plain password instead of encrypted one.
         Yast::UsersSimple.SetRootPassword(root.password.value) unless root.password.nil?
       end
 


### PR DESCRIPTION
## Problem

*UsersSimple* module is not expected to include the *root* user in its list of users. But *Y2Users::UsersSimple::Writer* is not excluding the root user when writing users into *UsersSimple*.

## Solution

*Y2Users::UsersSimple::Writer* does not store *root* user anymore. But it uses the *UsersSimple* API to store root related info like the password.
