### PR TITLE
[Y2Users::Linux::Writer] Creates only new users

### DIFF
--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -24,9 +24,9 @@ module Y2Users
     # Writes users and groups to the system using Yast2::Execute and standard
     # linux tools.
     #
-    # NOTE: currently it only creates new users or modifies passwords of
-    # existing ones. Removing or fully modifying users is still not covered.
-    # No group management either.
+    # NOTE: currently it only creates new users or modifies the password value
+    # of existing ones.  Removing or fully modifying users is still not covered.
+    # No group management or passowrd configuration either.
     #
     # A brief history of the differences with the Yast::Users (perl) module:
     #
@@ -107,8 +107,8 @@ module Y2Users
       # @return [Y2User::Config]
       attr_reader :config
 
-      # Initial state of the system that will be compared with {#config} to know what changes need
-      # to be performed
+      # Initial state of the system (usually a Y2User::Config.system) that will be compared with
+      # {#config} to know what changes need to be performed.
       #
       # @return [Y2User::Config]
       attr_reader :initial_config

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -96,6 +96,8 @@ module Y2Users
       end
 
       # Performs the changes in the system
+      #
+      # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
       def write
         self.issues = Y2Issues::List.new
 

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -99,7 +99,7 @@ module Y2Users
       #
       # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
       def write
-        self.issues = Y2Issues::List.new
+        @issues = Y2Issues::List.new
 
         config.users.map do |user|
           add_user(user)
@@ -108,7 +108,7 @@ module Y2Users
         # TODO: update the NIS database (make -C /var/yp) if needed
         # TODO: remove the passwd cache for nscd (bug 24748, 41648)
 
-        issues
+        @issues
       end
 
     private
@@ -124,10 +124,10 @@ module Y2Users
       # @return [Y2User::Config]
       attr_reader :initial_config
 
-      # The list of issues generated while writting changes to the system
+      # The list of issues generated while writting changes to the system. See #write
       #
       # @return [Y2Issues::List]
-      attr_accessor :issues
+      attr_reader :issues
 
       # Command for creating new users
       USERADD = "/usr/sbin/useradd".freeze

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -92,7 +92,7 @@ module Y2Users
       # Performs the changes in the system
       def write
         config.users.map do |user|
-          add_user(user) if new_user?(user)
+          add_user(user)
           set_password(user)
         end
         # TODO: update the NIS database (make -C /var/yp) if needed
@@ -146,6 +146,8 @@ module Y2Users
       #
       # @param user [Y2User::User]
       def add_user(user)
+        return unless new_user?(user)
+
         Yast::Execute.on_target!(USERADD, *useradd_options(user))
       rescue Cheetah::ExecutionFailed => e
         log.error("Error creating user '#{user.name}' - #{e.message}")

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -93,7 +93,7 @@ module Y2Users
       def write
         config.users.map do |user|
           add_user(user)
-          set_password(user)
+          change_password(user)
         end
         # TODO: update the NIS database (make -C /var/yp) if needed
         # TODO: remove the passwd cache for nscd (bug 24748, 41648)
@@ -156,7 +156,7 @@ module Y2Users
       # Executes the command for setting the password of given user
       #
       # @param user [Y2User::User]
-      def set_password(user)
+      def change_password(user)
         return unless user.password&.value
 
         Yast::Execute.on_target!(CHPASSWD, *chpasswd_options(user)) if user.password&.value

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -70,7 +70,6 @@ module Y2Users
     # updated always, no matter whether useradd.local has been called.
     #
     #
-    #
     # NOTE: we need to check why nscd_passwd is relevant
     # NOTE: no support for the Yast::Users option no_skeleton
     # NOTE: no support for the Yast::Users chown_home=0 option (what is good for?)
@@ -82,14 +81,11 @@ module Y2Users
       include Yast::Logger
       # Constructor
       #
-      # NOTE: right now we consider the system is empty, so we only receive one parameter.
-      #   But in the future we might need another configuration describing the initial state,
-      #   so we can compare and know what changes are actually needed.
-      #
-      # @param config [Y2User::Config] configuration containing the users
-      #   and groups that should exist in the system after writing
-      def initialize(config)
+      # @param config [Y2User::Config] see #config
+      # @param initial_config [Y2User::Config] see #initial_config
+      def initialize(config, initial_config)
         @config = config
+        @initial_config = initial_config
       end
 
       # Performs the changes in the system
@@ -106,6 +102,12 @@ module Y2Users
       #
       # @return [Y2User::Config]
       attr_reader :config
+
+      # Initial state of the system that will be compared with {#config} to know what changes need
+      # to be performed
+      #
+      # @return [Y2User::Config]
+      attr_reader :initial_config
 
       # Command for creating new users
       USERADD = "/usr/sbin/useradd".freeze

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -50,16 +50,6 @@ describe Y2Users::Linux::Writer do
     let(:expiration_date) { nil }
 
     RSpec.shared_examples "setting expiration date" do
-      context "without an expiration date" do
-        it "does not include the --expiredate option" do
-          expect(Yast::Execute).to receive(:on_target!) do |*args|
-            expect(args).to_not include("--expiredate")
-          end
-
-          writer.write
-        end
-      end
-
       context "with an expiration date" do
         let(:expiration_date) { Date.today }
 
@@ -72,10 +62,20 @@ describe Y2Users::Linux::Writer do
           writer.write
         end
       end
+
+      context "without an expiration date" do
+        it "does not include the --expiredate option" do
+          expect(Yast::Execute).to receive(:on_target!) do |*args|
+            expect(args).to_not include("--expiredate")
+          end
+
+          writer.write
+        end
+      end
     end
 
     RSpec.shared_examples "setting password" do
-      context "when the user has a password" do
+      context "which has a password set" do
         let(:pwd_value) { "$6$3HkB4uLKri75$Qg6Pp" }
 
         # If we would have used the --password argument of useradd, the encrypted password would
@@ -90,7 +90,7 @@ describe Y2Users::Linux::Writer do
         end
       end
 
-      context "when the user has no password" do
+      context "which does not have a password set" do
         let(:pwd_value) { nil }
 
         it "does not execute chpasswd" do

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -26,10 +26,12 @@ require "y2users/password"
 require "y2users/linux/writer"
 
 describe Y2Users::Linux::Writer do
-  subject(:writer) { described_class.new(config) }
+  subject(:writer) { described_class.new(config, initial_config) }
 
   describe "#write" do
-    let(:config) { Y2Users::Config.new(:test) }
+    let(:initial_config) { Y2Users::Config.new(:initial) }
+
+    let(:config) { initial_config.clone_as(:desired) }
     let(:user) do
       user = Y2Users::User.new(config, username, **user_attrs)
       user.password = password

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -45,6 +45,7 @@ describe Y2Users::Linux::Writer do
     end
 
     let(:username) { "testuser" }
+    let(:user_attrs) { {} }
     let(:pwd_value) { nil }
     let(:expiration_date) { nil }
 
@@ -104,6 +105,20 @@ describe Y2Users::Linux::Writer do
       config.users << user
 
       allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    context "for an existing user" do
+      before do
+        initial_config.users << user
+      end
+
+      it "does not execute useradd" do
+        expect(Yast::Execute).to_not receive(:on_target!).with(/useradd/, any_args)
+
+        writer.write
+      end
+
+      include_examples "setting password"
     end
 
     context "for a new regular user with all the attributes" do


### PR DESCRIPTION
Following with  `Y2Users::Linux::Writer` implementation (see #247, #249, and #250), now it 

* receives the _initial configuration_, and
* only creates new users or modifies passwords of existing ones