### PR TITLE
Adapt readers and writers to use the new API

### DIFF
--- a/src/lib/y2users/config_manager.rb
+++ b/src/lib/y2users/config_manager.rb
@@ -36,7 +36,7 @@ module Y2Users
     # @note if given id is already registered, it is overwritten
     # rubocop:disable Naming/UncommunicativeMethodParamName
     def register(config, as:)
-      raise ArgumentError, "#{as.inspect} is not Symbol" unless as.is_a?(:Symbol)
+      raise ArgumentError, "#{as.inspect} is not Symbol" unless as.is_a?(Symbol)
 
       @register[as] = config
     end

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -101,7 +101,7 @@ module Y2Users
       def write
         issues = Y2Issues::List.new
 
-        config.users.map do |user|
+        new_users.map do |user|
           add_user(user, issues)
           change_password(user, issues)
         end
@@ -141,16 +141,13 @@ module Y2Users
       CHPASSWD = "/usr/sbin/chpasswd".freeze
       private_constant :CHPASSWD
 
-      # Whether given user does not exist yet
+      # Returns the list of users that should be created
       #
-      # FIXME: choose a better criteria to identify a new user. An internal Y2User::User id?
+      # TODO: WIP
       #
-      # @param user [Y2User::User]
-      # @return [Boolean] true if there is a user with same name in @initial_config; false otherwise
-      def new_user?(user)
-        @initial_users_names ||= initial_config.users.map(&:name)
-
-        !@initial_users_names.include?(user.name)
+      # @return [Array<Users>]
+      def new_users
+        config.new_users_from(initial_config)
       end
 
       # Executes the command for creating the user
@@ -158,8 +155,6 @@ module Y2Users
       # @param user [Y2User::User] the user to be created on the system
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def add_user(user, issues)
-        return unless new_user?(user)
-
         Yast::Execute.on_target!(USERADD, *useradd_options(user))
       rescue Cheetah::ExecutionFailed => e
         issues << Y2Issues::Issue.new(

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -44,7 +44,7 @@ module Y2Users
       #
       # TODO: only created users, not imported ones for now
       #
-      # @returns [Array<User>] the collection of users
+      # @return [Array<User>] the collection of users
       def users
         Yast::UsersSimple.GetUsers.map do |user_attrs|
           user = User.new(user_attrs["uid"])
@@ -56,7 +56,7 @@ module Y2Users
 
       # Returns the root user
       #
-      # @returns [User] the root user
+      # @return [User] the root user
       def root_user
         user = User.new("root")
         user.gecos = ["root"]

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -17,17 +17,15 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "date"
-require "yast2/execute"
+require "yast"
 require "y2users/user"
-require "y2users/group"
 require "y2users/password"
 
 Yast.import "UsersSimple"
 
 module Y2Users
   module UsersSimple
-    # Class for reading users configuration from old {Yast::UsersSimple} module
+    # Class for reading users configuration from old Yast::UsersSimple module
     class Reader
       # Attaches users to given configuration
       #

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -33,19 +33,26 @@ module Y2Users
       def read_to(config)
         users = Yast::UsersSimple.GetUsers
         # TODO: only created users, not imported ones for now
-        users.each do |user|
-          user = User.new(config, user["uid"], gecos: [user["cn"]])
-          user.password = Password.create_plain(user["userPassword"])
-          config.users << user
+        users.each do |user_attrs|
+          user = User.new(user_attrs["uid"])
+          user.gecos = [user_attrs["cn"]]
+          user.password = Password.create_plain(user_attrs["userPassword"])
+          config.attach(user)
         end
 
         # Read also root user settings
-        root_pwd_plain = Yast::UsersSimple.GetRootPassword
-        root_pwd = Password.create_plain(root_pwd_plain)
-        root_user = User.new(config, "root")
-        root_user.password = root_pwd
+        config.attach(root_user)
+      end
 
-        config.users << root_user
+    private
+
+      def root_user
+        user = User.new("root")
+        user.gecos = ["root"]
+        user.uid = 0
+        passwd_str = Yast::UsersSimple.GetRootPassword
+        user.password = Password.create_plain(passwd_str) unless passwd_str.empty?
+        user
       end
     end
   end

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -17,28 +17,24 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast2/execute"
 require "date"
-
-require "y2users/group"
+require "yast2/execute"
 require "y2users/user"
+require "y2users/group"
 require "y2users/password"
 
 Yast.import "UsersSimple"
 
 module Y2Users
   module UsersSimple
-    # Class for reading users configuration from old Yast Module UsersSimple.
+    # Class for reading users configuration from old {Yast::UsersSimple} module
     class Reader
+      # Attaches users to given configuration
+      #
+      # @param config [Config]
       def read_to(config)
-        users = Yast::UsersSimple.GetUsers
-        # TODO: only created users, not imported ones for now
-        users.each do |user_attrs|
-          user = User.new(user_attrs["uid"])
-          user.gecos = [user_attrs["cn"]]
-          user.password = Password.create_plain(user_attrs["userPassword"])
-          config.attach(user)
-        end
+        # Read new users
+        config.attach(users)
 
         # Read also root user settings
         config.attach(root_user)
@@ -46,6 +42,23 @@ module Y2Users
 
     private
 
+      # Returns the list users
+      #
+      # TODO: only created users, not imported ones for now
+      #
+      # @returns [Array<User>] the collection of users
+      def users
+        Yast::UsersSimple.GetUsers.map do |user_attrs|
+          user = User.new(user_attrs["uid"])
+          user.gecos = [user_attrs["cn"]]
+          user.password = Password.create_plain(user_attrs["userPassword"])
+          user
+        end
+      end
+
+      # Returns the root user
+      #
+      # @returns [User] the root user
       def root_user
         user = User.new("root")
         user.gecos = ["root"]

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -44,10 +44,10 @@ module Y2Users
         root = config.users.find(&:root?)
         return unless root
 
-        value = root.password&.value
-        return unless value
+        root_password = root.password&.value
+        return unless root_password
 
-        Yast::UsersSimple.SetRootPassword(value.content) if value.plain?
+        Yast::UsersSimple.SetRootPassword(root_password&.content)
       end
 
     private
@@ -62,6 +62,7 @@ module Y2Users
       def to_user_simple(user)
         # TODO: users simple allows encrypted, but then it needs to specify _encrypted => true
         password = user.password&.value&.content if user.password&.value&.plain?
+
         {
           uid:           user.name,
           uidNumber:     user.uid,

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -40,13 +40,12 @@ describe Y2Users::UsersSimple::Writer do
 
     # Root user
     let(:root) do
-      user = Y2Users::User.new(config, "root",
-        uid:   0,
-        gid:   0,
-        shell: "/bin/bash",
-        home:  "/root",
-        gecos: ["Root User"])
-
+      user = Y2Users::User.new("root")
+      user.uid = 0
+      user.gid = 0
+      user.shell = "/bin/bash"
+      user.home = "/root"
+      user.gecos = ["Root User"]
       user.password = root_password
       user
     end
@@ -86,10 +85,6 @@ describe Y2Users::UsersSimple::Writer do
     end
 
     context "when the users config does not contain users" do
-      before do
-        config.users = []
-      end
-
       it "does not store users into UsersSimple module" do
         subject.write
 
@@ -105,7 +100,7 @@ describe Y2Users::UsersSimple::Writer do
 
     context "when the users config only contains root" do
       before do
-        config.users = [root]
+        config.attach(root)
       end
 
       it "does not store users into UsersSimple module" do
@@ -119,19 +114,16 @@ describe Y2Users::UsersSimple::Writer do
 
     context "when the users config contains users" do
       before do
-        config.users = [root, user1, user2]
+        config.attach(root, user1, user2)
       end
 
-      # User
-
       let(:user1) do
-        user = Y2Users::User.new(config, "test1",
-          uid:   uid,
-          gid:   gid,
-          shell: shell,
-          home:  home,
-          gecos: gecos)
-
+        user = Y2Users::User.new("test1")
+        user.uid = uid
+        user.gid = gid
+        user.shell = shell
+        user.home = home
+        user.gecos = gecos
         user.password = user1_password
         user
       end
@@ -144,16 +136,13 @@ describe Y2Users::UsersSimple::Writer do
 
       let(:user1_password) { Y2Users::Password.create_plain("123456") }
 
-      # User
-
       let(:user2) do
-        user = Y2Users::User.new(config, "test2",
-          uid:   1001,
-          gid:   101,
-          shell: "/bin/bash",
-          home:  "/home/test2",
-          gecos: ["Test User2"])
-
+        user = Y2Users::User.new("test2")
+        user.uid = 1001
+        user.gid = 101
+        user.shell = "/bin/bash"
+        user.home = "/home/test2"
+        user.gecos = ["Test User2"]
         user.password = user2_password
         user
       end


### PR DESCRIPTION
## Problem

Readers and writers for `Y2Users::Linux` and `Y2Users::UsersSimple` got updated after migrating to the new API.

## Solution

Adapt readers and writers to the new API.
