### PR TITLE
Adaptation of Dialogs::InstUserFirst to use Y2Users

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,8 +64,12 @@ ywidget_DATA = \
 	lib/users/widgets/inst_root_first.rb \
 	lib/users/widgets/public_key_selector.rb
 
-ylibdir = @ylibdir@/users
+ylibdir = @ylibdir@
 ylib_DATA = \
+  lib/y2users.rb
+
+ylib_usersdir = @ylibdir@/users
+ylib_users_DATA = \
   lib/users/ca_password_validator.rb \
   lib/users/local_password.rb \
   lib/users/encryption_method.rb \
@@ -77,6 +81,31 @@ ylib_DATA = \
   lib/users/ssh_authorized_keyring.rb \
   lib/users/users_database.rb \
   lib/users/widgets.rb
+
+ylib_y2usersdir = @ylibdir@/y2users
+ylib_y2users_DATA = \
+  lib/y2users/config_element.rb \
+  lib/y2users/config_manager.rb \
+  lib/y2users/config.rb \
+  lib/y2users/group.rb \
+  lib/y2users/help_texts.rb \
+  lib/y2users/linux.rb \
+  lib/y2users/password.rb \
+  lib/y2users/password_validator.rb \
+  lib/y2users/user.rb \
+  lib/y2users/users_simple.rb \
+  lib/y2users/user_validator.rb \
+  lib/y2users/validation_config.rb
+
+ylib_y2users_linuxdir = @ylibdir@/y2users/linux
+ylib_y2users_linux_DATA = \
+  lib/y2users/linux/reader.rb \
+  lib/y2users/linux/writer.rb
+
+ylib_y2users_userssimpledir = @ylibdir@/y2users/users_simple
+ylib_y2users_userssimple_DATA = \
+  lib/y2users/users_simple/reader.rb \
+  lib/y2users/users_simple/writer.rb
 
 scrconf_DATA = \
   scrconf/etc_default_useradd.scr \
@@ -97,6 +126,6 @@ scalable_DATA = \
   icons/hicolor/scalable/apps/yast-users.svg \
   icons/hicolor/scalable/apps/yast-users-system.svg
 
-EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(ylibdialog_DATA) $(ylib_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA) $(ylibclient_DATA) $(scalable_DATA)
+EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(ylibdialog_DATA) $(ylib_DATA) $(ylib_users_DATA) $(ylib_y2users_DATA) $(ylib_y2users_linux_DATA) $(ylib_y2users_userssimple_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA) $(ylibclient_DATA) $(scalable_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -20,7 +20,7 @@
 require "yast"
 require "cwm/widget"
 
-require "users/ca_password_validator"
+require "y2users/help_texts"
 require "users/local_password"
 
 Yast.import "Popup"
@@ -34,6 +34,8 @@ module Users
     class << self
       attr_accessor :approved_pwd
     end
+
+    include Y2Users::HelpTexts
 
     # If `little_space` is `false` (the default), the widget will
     # use a vertical layout, and include a "don't forget this" label.
@@ -178,7 +180,7 @@ module Users
           "</p>\n"
         )
 
-      helptext << Yast::UsersSimple.ValidPasswordHelptext
+      helptext << valid_password_text
 
       # help text, continued 4
       helptext << _(
@@ -187,7 +189,7 @@ module Users
         "</p>"
       )
 
-      helptext << ::Users::CAPasswordValidator.new.help_text
+      helptext << ca_password_text
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/src/lib/y2users.rb
+++ b/src/lib/y2users.rb
@@ -19,6 +19,7 @@
 
 require "y2users/config"
 require "y2users/config_manager"
+require "y2users/validation_config"
 require "y2users/user"
 require "y2users/password"
 require "y2users/group"

--- a/src/lib/y2users/help_texts.rb
+++ b/src/lib/y2users/help_texts.rb
@@ -1,0 +1,68 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/validation_config"
+
+module Y2Users
+  # Mixin to centralize some help texts
+  #
+  # This may disappear in the future, but it's needed during the process of
+  # moving stuff to the Y2Users namespace
+  module HelpTexts
+    include Yast::I18n
+    Yast.import "UsersSimple"
+
+    # Needed to be able to call textdomain below
+    extend Yast::I18n
+
+    def self.included(_mod)
+      # Needed to prevent the automatic checks (rake check:pot) from complaining
+      textdomain "users"
+    end
+
+    # Configuration of the validation process
+    #
+    # @return [Y2Users::ValidationConfig]
+    def validation_config
+      @validation_config ||= Y2Users::ValidationConfig.new
+    end
+
+    # Text describing the characters accepted as part of a password
+    #
+    # @return [String] formatted and localized text
+    def valid_password_text
+      Yast::UsersSimple.ValidPasswordHelptext
+    end
+
+    # Text about the CA constraints, if applicable
+    #
+    # @return [String] formatted and localized text if feature is enabled, empty string otherwise
+    def ca_password_text
+      return "" unless validation_config.check_ca?
+
+      format(
+        _(
+          "<p>If you intend to use this password for creating certificates,\n" \
+          "it has to be at least %s characters long.</p>"
+        ),
+        validation_config.ca_min_password_length
+      )
+    end
+  end
+end

--- a/src/lib/y2users/password_validator.rb
+++ b/src/lib/y2users/password_validator.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2issues"
+require "users/local_password"
+require "y2users/validation_config"
+
+module Y2Users
+  # Internal class to validate the attributes of a {Password} object.
+  # This is not part of the stable API.
+  class PasswordValidator
+    Yast.import "UsersSimple"
+
+    LOCATION = "field:password.content".freeze
+    private_constant :LOCATION
+
+    # Constructor
+    #
+    # @param user [Y2Users::User] see {#user}
+    def initialize(user)
+      @user = user
+    end
+
+    # @return [Y2Issues::List]
+    def issues
+      list = Y2Issues::List.new
+
+      return list unless password&.value&.plain?
+
+      err = Yast::UsersSimple.CheckPassword(content, "local")
+      list << Y2Issues::Issue.new(err, location: LOCATION, severity: :fatal) unless err.empty?
+
+      # TODO: This actually shows the UI with the confirmation already, so we need to
+      # change this part
+      local_passwd = ::Users::LocalPassword.new(username: user.name, plain: content)
+      if !local_passwd.valid?
+        local_passwd.errors.each do |error|
+          list << Y2Issues::Issue.new(error, location: LOCATION)
+        end
+      end
+
+      list
+    end
+
+  private
+
+    # @return [Y2Users::User] user containing the password to validate
+    attr_reader :user
+
+    # @return [Y2Users::Password] password to validate
+    def password
+      user.password
+    end
+
+    # @return [String, nil] password content
+    def content
+      password&.value&.content
+    end
+
+    # @return [ValidationConfig]
+    def config
+      @config ||= ValidationConfig.new
+    end
+  end
+end

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -18,6 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "y2users/config_element"
+require "y2users/user_validator"
+require "y2users/password_validator"
 
 module Y2Users
   # Class to represent an user
@@ -188,6 +190,20 @@ module Y2Users
       cloned.password = password.clone
 
       cloned
+    end
+
+    # Validation errors
+    #
+    # @return [Y2Issues::List]
+    def issues
+      UserValidator.new(self).issues
+    end
+
+    # Validation errors of the current password
+    #
+    # @return [Y2Issues::List]
+    def password_issues
+      PasswordValidator.new(self).issues
     end
 
   private

--- a/src/lib/y2users/user_validator.rb
+++ b/src/lib/y2users/user_validator.rb
@@ -1,0 +1,87 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2issues"
+require "y2users/validation_config"
+
+module Y2Users
+  # Internal class to validate the attributes of a {User} object.
+  # This is not part of the stable API.
+  class UserValidator
+    Yast.import "UsersSimple"
+
+    # Issue location describing the User#name attribute
+    NAME_LOC = "field:name".freeze
+    # Issue location describing the User#full_name attribute
+    FULL_NAME_LOC = "field:full_name".freeze
+    private_constant :NAME_LOC, :FULL_NAME_LOC
+
+    # Constructor
+    #
+    # @param user [Y2Users::User] see {#user}
+    def initialize(user)
+      @user = user
+    end
+
+    # @return [Y2Issues::List]
+    def issues
+      list = Y2Issues::List.new
+
+      err = Yast::UsersSimple.CheckUsernameLength(user.name)
+      add_fatal_issue(list, err, NAME_LOC)
+
+      err = Yast::UsersSimple.CheckUsernameContents(user.name, "")
+      add_fatal_issue(list, err, NAME_LOC)
+
+      # Yast::UsersSimple.CheckUsernameConflicts is currently used only when manually creating
+      # the initial user during installation, it simply checks against a hard-coded list of
+      # system user names that are expected to exist in a system right after installation.
+      err = Yast::UsersSimple.CheckUsernameConflicts(user.name)
+      add_fatal_issue(list, err, NAME_LOC)
+
+      err = Yast::UsersSimple.CheckFullname(user.full_name)
+      add_fatal_issue(list, err, FULL_NAME_LOC)
+
+      return list unless user.password
+
+      user.password.issues.map do |issue|
+        list << issue
+      end
+
+      list
+    end
+
+  private
+
+    # @return [Y2Users::User] user to validate
+    attr_reader :user
+
+    # @return [ValidationConfig]
+    def config
+      @config ||= ValidationConfig.new
+    end
+
+    # Adds a fatal issue to the given list to represent the given error, if any
+    def add_fatal_issue(list, error, location)
+      return if error.empty?
+
+      list << Y2Issues::Issue.new(error, location: location, severity: :fatal)
+    end
+  end
+end

--- a/src/lib/y2users/validation_config.rb
+++ b/src/lib/y2users/validation_config.rb
@@ -1,0 +1,57 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Users
+  # Class to configure the validation process of the classes in the Y2Users namespace.
+  class ValidationConfig
+    Yast.import "UsersSimple"
+    Yast.import "ProductFeatures"
+
+    # See {#ca_min_password_length}
+    CA_MIN_LENGTH = 4
+    private_constant :CA_MIN_LENGTH
+
+    # Minimum length of a valid password
+    def min_password_length
+      Yast::UsersSimple.GetMinPasswordLength("local")
+    end
+
+    # Minimum length of the password for the root user if the CA constraints are
+    # active
+    #
+    # @see #check_ca?
+    def ca_min_password_length
+      CA_MIN_LENGTH
+    end
+
+    # Maximum length of a valid password
+    def max_password_length
+      Yast::UsersSimple.GetMaxPasswordLength("local")
+    end
+
+    # Returns whether YaST should check CA constraints
+    #
+    # See installation control file: globals->root_password_ca_check
+    #
+    # @return [Boolean] whether to check the constraints
+    def check_ca?
+      !!Yast::ProductFeatures.GetBooleanFeature("globals", "root_password_ca_check")
+    end
+  end
+end

--- a/test/lib/users/ca_password_validator_test.rb
+++ b/test/lib/users/ca_password_validator_test.rb
@@ -19,73 +19,20 @@
 
 require_relative "../../test_helper"
 require "users/ca_password_validator"
+require "y2users/validation_config"
 
 describe Users::CAPasswordValidator do
-  describe "#enabled?" do
-    before do
-      allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
-        .with("globals", "root_password_ca_check")
-        .and_return(ca_check)
-    end
-
-    context "if CA password check is enabled" do
-      let(:ca_check) { true }
-
-      it "returns true" do
-        expect(subject.enabled?).to eq true
-      end
-    end
-
-    context "if ca password check is disabled" do
-      let(:ca_check) { false }
-
-      it "returns false" do
-        expect(subject.enabled?).to eq false
-      end
-    end
-
-    context "if ca password check is not set" do
-      let(:ca_check) { nil }
-
-      it "returns false" do
-        expect(subject.enabled?).to eq false
-      end
-    end
-  end
-
-  describe "#help_text" do
-    before do
-      allow(subject).to(receive(:enabled?))
-        .and_return enabled
-    end
-
-    context "if the CA check is disabled" do
-      let(:enabled) { false }
-
-      it "returns an empty string" do
-        expect(subject.help_text).to eq ""
-      end
-    end
-
-    context "if the CA check is enabled" do
-      let(:enabled) { true }
-
-      it "returns a set of html paragraphs" do
-        expect(subject.help_text).to be_a String
-        expect(subject.help_text).to start_with "<p>"
-        expect(subject.help_text).to end_with "</p>"
-      end
-    end
+  let(:config) do
+    double(Y2Users::ValidationConfig, check_ca?: check_ca, ca_min_password_length: 4)
   end
 
   describe "#errors_for" do
     before do
-      allow(subject).to(receive(:enabled?))
-        .and_return enabled
+      allow(subject).to receive(:config).and_return(config)
     end
 
     context "if the CA check is disabled" do
-      let(:enabled) { false }
+      let(:check_ca) { false }
 
       it "returns empty list for a long password" do
         expect(subject.errors_for("aL0ngPassw0rd")).to eq []
@@ -97,7 +44,7 @@ describe Users::CAPasswordValidator do
     end
 
     context "if the CA check is enabled" do
-      let(:enabled) { true }
+      let(:check_ca) { true }
 
       it "returns empty list for a long password" do
         expect(subject.errors_for("aL0ngPassw0rd")).to eq []

--- a/test/lib/users/local_password_test.rb
+++ b/test/lib/users/local_password_test.rb
@@ -26,8 +26,9 @@ describe Users::LocalPassword do
     allow(Yast::UsersSimple).to receive(:CheckPasswordUI) do |args|
       args["userPassword"].start_with?("Bad") ? ["Error"] : []
     end
-    allow(subject.ca_validator).to receive(:enabled?).and_return ca_enabled
+    allow(Y2Users::ValidationConfig).to receive(:new).and_return validation_config
   end
+  let(:validation_config) { double(check_ca?: ca_enabled, ca_min_password_length: 4) }
   let(:ca_enabled) { true }
 
   describe "#valid?" do

--- a/test/lib/y2users/help_texts_test.rb
+++ b/test/lib/y2users/help_texts_test.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users/help_texts"
+
+describe Y2Users::HelpTexts do
+
+  # Just a dumb class to test the mixin
+  class DummyHelp
+    include Y2Users::HelpTexts
+  end
+
+  describe "#ca_password_text" do
+    subject(:help) { DummyHelp.new }
+
+    before do
+      allow(help.validation_config).to(receive(:check_ca?)).and_return enabled
+    end
+
+    context "if the CA check is disabled" do
+      let(:enabled) { false }
+
+      it "returns an empty string" do
+        expect(help.ca_password_text).to eq ""
+      end
+    end
+
+    context "if the CA check is enabled" do
+      let(:enabled) { true }
+
+      it "returns a set of html paragraphs" do
+        text = help.ca_password_text
+        expect(text).to be_a String
+        expect(text).to start_with "<p>"
+        expect(text).to end_with "</p>"
+      end
+    end
+  end
+end

--- a/test/lib/y2users/validation_config_test.rb
+++ b/test/lib/y2users/validation_config_test.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users"
+
+describe Y2Users::ValidationConfig do
+  describe "#check_ca?" do
+    before do
+      allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+        .with("globals", "root_password_ca_check")
+        .and_return(ca_check)
+    end
+
+    context "if CA password check is enabled" do
+      let(:ca_check) { true }
+
+      it "returns true" do
+        expect(subject.check_ca?).to eq true
+      end
+    end
+
+    context "if ca password check is disabled" do
+      let(:ca_check) { false }
+
+      it "returns false" do
+        expect(subject.check_ca?).to eq false
+      end
+    end
+
+    context "if ca password check is not set" do
+      let(:ca_check) { nil }
+
+      it "returns false" do
+        expect(subject.check_ca?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of https://trello.com/c/nFDiHYCU/2415-validation-of-the-new-user-with-a-better-api

Included:

- Fixed `Y2Users::UsersSimple::Reader`
- Adapted the InstUserFirst dialog to:
  - When the dialog opens:
    - Load the information from `UserSimple` into `Y2User` objects (using the fixed reader)
    - Preload the form with the information from those objects
  - When the user click "next"
    - Update the `Y2User` objects with the information entered by the user
    - Check objects with the new `Y2User` validators, reporting `Y2Issues::Issues` to the user
    - Write the information in the `Y2Users` objects back to `UserSimple` if the objects are valid
- Small reorganization of the code that generates the help texts
  - Better sharing between several dialogs with no direct dependency on `UsersSimple`
  - Allowed to re-enable Rucobop rules for "Metrics/MethodLength" and "Metrics/AbcSize"

Excluded:

- [Rewriting the validations in Ruby](https://trello.com/c/yDXqaGHa/4690-ruby-based-validators), since the current validators still rely on `Yast::UsersSimple` under the hood
- Cleanup of the form to completely stop using `UsersSimple` data structures. For that, we would need to also [migrate to `Y2Users` the functionality of importing users](https://trello.com/c/K0OVGo6g/4674-importing-users-during-installation-also-based-on-new-classes) from previous installations.

Testing:

- Tested manually executing the dialog stand-alone
- Tested in a real installation system (going back, etc.)