### PR TITLE
Adapt Users::PasswordWidget to use Y2Users

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -89,6 +89,7 @@ ylib_y2users_DATA = \
   lib/y2users/config.rb \
   lib/y2users/group.rb \
   lib/y2users/help_texts.rb \
+  lib/y2users/inst_users_dialog_helper.rb \
   lib/y2users/linux.rb \
   lib/y2users/password.rb \
   lib/y2users/password_validator.rb \

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -94,9 +94,7 @@ module Users
       Yast::UI.ChangeWidget(Id(:pw2), :Value, current_password)
     end
 
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def validate
       password1 = Yast::UI.QueryWidget(Id(:pw1), :Value)
       password2 = Yast::UI.QueryWidget(Id(:pw2), :Value)
@@ -126,9 +124,7 @@ module Users
 
       true
     end
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     def store
       return if allow_empty? && empty?
@@ -137,8 +133,7 @@ module Users
       root_user.password = Y2Users::Password.create_plain(password1)
     end
 
-    # rubocop:disable Metrics/MethodLength
-    def help
+    def help # rubocop:disable Metrics/MethodLength
       # help text ( explain what the user "root" is and does ) 1
       helptext = _(
         "<p>\n" \
@@ -180,7 +175,6 @@ module Users
 
       helptext << ca_password_text
     end
-    # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -21,13 +21,13 @@ require "yast"
 require "y2users"
 require "y2users/users_simple"
 
+Yast.import "UI"
+Yast.import "Popup"
+Yast.import "Report"
+
 module Y2Users
   # Mixin for user and password validations based on Y2Users for isntallation dialogs
   module InstUsersDialogHelper
-    Yast.import "UI"
-    Yast.import "Popup"
-    Yast.import "Report"
-
     # Needed to be able to call textdomain below
     extend Yast::I18n
 

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -1,0 +1,121 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2users"
+require "y2users/users_simple"
+
+module Y2Users
+  # Mixin for user and password validations based on Y2Users for isntallation dialogs
+  module InstUsersDialogHelper
+    Yast.import "UI"
+    Yast.import "Popup"
+    Yast.import "Report"
+
+  private
+
+    # Config object holding the users and passwords to create
+    #
+    # @return [Y2Users::Config]
+    def users_config
+      return @users_config if @users_config
+
+      @users_config = Y2Users::Config.new
+      Y2Users::UsersSimple::Reader.new.read_to(@users_config)
+      @users_config
+    end
+
+    # All users to be created
+    #
+    # @return [Array<Y2Users::User>]
+    def users
+      users_config.users.reject(&:root?)
+    end
+
+    # User to be created, useful during the :new_user action in which {#users}
+    # is known to contain only one element
+    #
+    # @return [Y2Users::User]
+    def user
+      users.first
+    end
+
+    # Root users for which is possible to define the password during the :new_user action
+    #
+    # @return [Y2Users::User]
+    def root_user
+      @root_user ||= users_config.users.find(&:root?)
+    end
+
+    # The user on which to perform password validations
+    #
+    # It might be re-defined in the dialog
+    #
+    # @see #valid_user?
+    # @see #valid_password?
+    #
+    # @return [Y2Users::User]
+    def user_to_validate
+      user
+    end
+
+    # Checks whether the information entered for the user is valid, reporting the problem to
+    # the user otherwise
+    #
+    # @return [Boolean]
+    def valid_user?
+      issue = user.issues.first
+      if issue
+        Yast::Report.Error(issue.message)
+        focus_on(issue.location)
+        return false
+      end
+
+      true
+    end
+
+    # Sets the UI focus in the widget corresponding to the given issue location
+    #
+    # @param location [Y2Issues::Location]
+    def focus_on(location)
+      id = (location.path == "name") ? :username : :full_name
+      Yast::UI.SetFocus(Id(id))
+    end
+
+    # Checks whether the entered password is acceptable, reporting fatal problems to the user and
+    # asking for confirmation for the non-fatal ones
+    #
+    # @return [Boolean]
+    def valid_password?
+      issues = user_to_validate.password_issues
+      return true if issues.empty?
+
+      Yast::UI.SetFocus(Id(:pw1))
+
+      fatal = issues.find(&:fatal?)
+      if fatal
+        Yast::Report.Error(fatal.message)
+        return false
+      end
+
+      message = issues.map(&:message).join("\n\n") + "\n\n" + _("Really use this password?")
+      Yast::Popup.YesNo(message)
+    end
+  end
+end

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -32,7 +32,6 @@ module Y2Users
     extend Yast::I18n
 
     def self.included(_mod)
-      # Needed to prevent the automatic checks (rake check:pot) from complaining
       textdomain "users"
     end
 

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -28,6 +28,14 @@ module Y2Users
     Yast.import "Popup"
     Yast.import "Report"
 
+    # Needed to be able to call textdomain below
+    extend Yast::I18n
+
+    def self.included(_mod)
+      # Needed to prevent the automatic checks (rake check:pot) from complaining
+      textdomain "users"
+    end
+
   private
 
     # Config object holding the users and passwords to create

--- a/test/lib/y2users/password_validator_test.rb
+++ b/test/lib/y2users/password_validator_test.rb
@@ -41,7 +41,7 @@ describe Y2Users::PasswordValidator do
     context "when validating an encrypted password" do
       let(:password) { Y2Users::Password.create_encrypted("") }
 
-      it "return an empty issues list" do
+      it "returns an empty issues list" do
         expect(validator.issues).to be_empty
       end
     end

--- a/test/lib/y2users/password_validator_test.rb
+++ b/test/lib/y2users/password_validator_test.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env rspec
+#
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+require "y2users/user"
+require "y2users/password"
+require "y2users/password_validator"
+require "users/local_password"
+
+Yast.import "UsersSimple"
+
+describe Y2Users::PasswordValidator do
+  subject(:validator) { described_class.new(user) }
+
+  let(:user) { Y2Users::User.new("test") }
+
+  before do
+    allow(user).to receive(:password).and_return(password)
+  end
+
+  describe "#issues" do
+    context "when validating an encrypted password" do
+      let(:password) { Y2Users::Password.create_encrypted("") }
+
+      it "return an empty issues list" do
+        expect(validator.issues).to be_empty
+      end
+    end
+
+    context "when validating a plain password" do
+      before do
+        allow(Yast::UsersSimple).to receive(:CheckPassword).and_return(fatal_issues)
+        allow(::Users::LocalPassword).to receive(:new).and_return(local_password_validator)
+      end
+
+      let(:password) { Y2Users::Password.create_plain(password_content) }
+      let(:password_content) { "s3cr3T" }
+      let(:password_errors) { "" }
+      let(:local_password_validator) do
+        double(::Users::LocalPassword, valid?: false, errors: warning_issues)
+      end
+      let(:fatal_issues) { "" }
+      let(:warning_issues) { [] }
+
+      it "returns a list of Y2Issues" do
+        expect(validator.issues).to be_a(Y2Issues::List)
+      end
+
+      context "when there are fatal issues" do
+        let(:fatal_issues) { "Yast::UsersSimple password validations failed" }
+        let(:warning_issues) { ["too short!"] }
+
+        it "contains a fatal issue" do
+          issues = validator.issues
+
+          expect(issues).to_not be_empty
+          expect(issues.fatal?).to eq(true)
+        end
+
+        it "does not proceed with further validations" do
+          issues = validator.issues
+
+          expect(issues.map(&:message)).to_not include(*warning_issues)
+        end
+      end
+
+      context "when there are no fatal issues" do
+        it "does not contains a fatal issue" do
+          issues = validator.issues
+
+          expect(issues.fatal?).to eq(false)
+        end
+
+        context "and no warnings" do
+          it "returns an empty issues list" do
+            expect(validator.issues).to be_empty
+          end
+        end
+
+        context "but any warning" do
+          let(:warning_issues) { ["too short!", "includes the username"] }
+
+          it "contains warning issues" do
+            issues = validator.issues
+
+            expect(issues).to_not be_empty
+            expect(issues.map(&:severity).uniq).to eq([:warn])
+            expect(issues.map(&:message)).to include(*warning_issues)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -8,6 +8,16 @@ def stub_widget_value(id, value)
 end
 
 describe Users::PasswordWidget do
+  let(:root_user) { Y2Users::User.new("root") }
+  let(:password) { Y2Users::Password.create_plain(pwd) }
+  let(:pwd) { "s3cr3T" }
+
+  before do
+    allow(root_user).to receive(:root?).and_return(true)
+    allow(subject).to receive(:root_user).and_return(root_user)
+    allow(Y2Users::Password).to receive(:create_plain).and_return(password)
+  end
+
   it "has help text" do
     expect(subject.help).to_not be_empty
   end
@@ -17,9 +27,13 @@ describe Users::PasswordWidget do
   end
 
   context "initialization" do
+    let(:pwd) { "paranoic" }
+
+    before do
+      allow(root_user).to receive(:password).and_return(password)
+    end
+
     it "initializes password to current value" do
-      pwd = "paranoic"
-      allow(Yast::UsersSimple).to receive(:GetRootPassword).and_return(pwd)
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw1), :Value, pwd)
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:pw2), :Value, pwd)
 
@@ -59,24 +73,28 @@ describe Users::PasswordWidget do
       expect(subject.validate).to eq false
     end
 
-    it "reports error if password contain forbidden characters" do
+    it "reports error if password does not validate" do
       stub_widget_value(:pw1, "mimic_forbidden")
       stub_widget_value(:pw2, "mimic_forbidden")
 
-      expect(Yast::UsersSimple).to receive(:CheckPassword).with("mimic_forbidden", "local")
-        .and_return("Invalid password")
+      fatal_issue = Y2Issues::Issue.new("Invalid password", severity: :fatal)
+      issues = Y2Issues::List.new([fatal_issue])
+
+      allow(root_user).to receive(:password_issues).and_return(issues)
+
       expect(Yast::Report).to receive(:Error)
       expect(Yast::UI).to receive(:SetFocus).with(Id(:pw1))
 
       expect(subject.validate).to eq false
     end
 
-    it "asks for confirmation if password is not strong enough" do
+    it "asks for confirmation if password validates with warnings" do
       stub_widget_value(:pw1, "a")
       stub_widget_value(:pw2, "a")
 
-      allow(Yast::UsersSimple).to receive(:CheckPassword).and_return("")
-      allow(Users::LocalPassword).to receive(:new).and_return(double(valid?: false, errors: ["E"]))
+      warning_issue = Y2Issues::Issue.new("Not strong password")
+      issues = Y2Issues::List.new([warning_issue])
+      allow(root_user).to receive(:password_issues).and_return(issues)
 
       expect(Yast::UI).to receive(:SetFocus).with(Id(:pw1))
       expect(Yast::Popup).to receive(:YesNo).and_return(false)
@@ -88,8 +106,9 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "a")
       stub_widget_value(:pw2, "a")
 
-      allow(Yast::UsersSimple).to receive(:CheckPassword).and_return("")
-      allow(Users::LocalPassword).to receive(:new).and_return(double(valid?: false, errors: ["E"]))
+      warning_issue = Y2Issues::Issue.new("Not strong password")
+      issues = Y2Issues::List.new([warning_issue])
+      allow(root_user).to receive(:password_issues).and_return(issues)
 
       expect(Yast::UI).to receive(:SetFocus).with(Id(:pw1))
       expect(Yast::Popup).to receive(:YesNo).and_return(true).once
@@ -102,8 +121,8 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "a")
       stub_widget_value(:pw2, "a")
 
-      allow(Yast::UsersSimple).to receive(:CheckPassword).and_return("")
-      allow(Users::LocalPassword).to receive(:new).and_return(double(valid?: true))
+      issues = Y2Issues::List.new
+      allow(root_user).to receive(:password_issues).and_return(issues)
 
       expect(subject.validate).to eq true
     end
@@ -112,13 +131,22 @@ describe Users::PasswordWidget do
   it "stores its value" do
     stub_widget_value(:pw1, "new cool password")
 
-    expect(Yast::UsersSimple).to receive(:SetRootPassword).with("new cool password")
+    expect(Y2Users::Password).to receive(:create_plain).with("new cool password")
+    expect(root_user).to receive(:password=).with(password)
 
     subject.store
   end
 
   context "when the widget is allowed to be empty" do
     subject { described_class.new(allow_empty: true) }
+
+    let(:root_user) { double(Y2Users::User) }
+    let(:password) { double(Y2Users::Password) }
+
+    before do
+      allow(subject).to receive(:root_user).and_return(root_user)
+      allow(Y2Users::Password).to receive(:create_plain).and_return(password)
+    end
 
     it "does not validate the password" do
       stub_widget_value(:pw1, "")
@@ -131,7 +159,7 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "")
       stub_widget_value(:pw2, "")
 
-      expect(Yast::UsersSimple).to_not receive(:SetRootPassword)
+      expect(Y2Users::Password).to_not receive(:create_plain)
       subject.store
     end
 
@@ -139,7 +167,8 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "new cool password")
       stub_widget_value(:pw2, "new cool password")
 
-      expect(Yast::UsersSimple).to receive(:SetRootPassword).with("new cool password")
+      expect(Y2Users::Password).to receive(:create_plain).with("new cool password")
+      expect(root_user).to receive(:password=).with(password)
       subject.store
     end
   end

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -9,13 +9,10 @@ end
 
 describe Users::PasswordWidget do
   let(:root_user) { Y2Users::User.new("root") }
-  let(:password) { Y2Users::Password.create_plain(pwd) }
-  let(:pwd) { "s3cr3T" }
 
   before do
     allow(root_user).to receive(:root?).and_return(true)
     allow(subject).to receive(:root_user).and_return(root_user)
-    allow(Y2Users::Password).to receive(:create_plain).and_return(password)
   end
 
   it "has help text" do
@@ -27,6 +24,7 @@ describe Users::PasswordWidget do
   end
 
   context "initialization" do
+    let(:password) { Y2Users::Password.create_plain(pwd) }
     let(:pwd) { "paranoic" }
 
     before do
@@ -131,8 +129,11 @@ describe Users::PasswordWidget do
   it "stores its value" do
     stub_widget_value(:pw1, "new cool password")
 
-    expect(Y2Users::Password).to receive(:create_plain).with("new cool password")
-    expect(root_user).to receive(:password=).with(password)
+    expect(root_user).to receive(:password=) do |password|
+      expect(password).to be_a(Y2Users::Password)
+      expect(password.value.plain?).to eq true
+      expect(password.value.content).to eq "new cool password"
+    end
 
     subject.store
   end
@@ -141,17 +142,16 @@ describe Users::PasswordWidget do
     subject { described_class.new(allow_empty: true) }
 
     let(:root_user) { double(Y2Users::User) }
-    let(:password) { double(Y2Users::Password) }
 
     before do
       allow(subject).to receive(:root_user).and_return(root_user)
-      allow(Y2Users::Password).to receive(:create_plain).and_return(password)
     end
 
     it "does not validate the password" do
       stub_widget_value(:pw1, "")
       stub_widget_value(:pw2, "")
 
+      expect(root_user).to_not receive(:password_issues)
       expect(subject.validate).to eq(true)
     end
 
@@ -159,7 +159,7 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "")
       stub_widget_value(:pw2, "")
 
-      expect(Y2Users::Password).to_not receive(:create_plain)
+      expect(root_user).to_not receive(:password=)
       subject.store
     end
 
@@ -167,8 +167,12 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw1, "new cool password")
       stub_widget_value(:pw2, "new cool password")
 
-      expect(Y2Users::Password).to receive(:create_plain).with("new cool password")
-      expect(root_user).to receive(:password=).with(password)
+      expect(root_user).to receive(:password=) do |password|
+        expect(password).to be_a(Y2Users::Password)
+        expect(password.value.plain?).to eq true
+        expect(password.value.content).to eq "new cool password"
+      end
+
       subject.store
     end
   end


### PR DESCRIPTION
Related to 

* Trello card (internal link): https://trello.com/c/dsDBpo7B/
* Previous PR: https://github.com/yast/yast-users/pull/261

It adapts the `Users::PasswordWidget`, used by _inst\_root\_first_ dialog and widget, to rely on Y2Users objects instead of keep using Yast::UsersSimple directly. 

It has been tested manually, apart to adapt the existent unit tests too.