### PR TITLE
Add ConfigMerger

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,6 +86,7 @@ ylib_y2usersdir = @ylibdir@/y2users
 ylib_y2users_DATA = \
   lib/y2users/config_element.rb \
   lib/y2users/config_manager.rb \
+  lib/y2users/config_merger.rb \
   lib/y2users/config.rb \
   lib/y2users/group.rb \
   lib/y2users/help_texts.rb \

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2users/config_merger"
 
 module Y2Users
   # Class to represent a configuration of users and groups
@@ -90,6 +91,26 @@ module Y2Users
       elements.each { |e| config.clone_element(e) }
 
       config
+    end
+
+    # Generates a new config as result of merging the users and groups of the given config into the
+    # users and groups of the current config.
+    #
+    # @param other [Config]
+    # @return [Config]
+    def merge(other)
+      clone.merge!(other)
+    end
+
+    # Modifies the current config by merging the users and groups of the given config into the users
+    # and groups of the current config
+    #
+    # @return [Config]
+    def merge!(other)
+      merger = ConfigMerger.new(self, other)
+      merger.merge
+
+      self
     end
 
   protected

--- a/src/lib/y2users/config_merger.rb
+++ b/src/lib/y2users/config_merger.rb
@@ -1,0 +1,105 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Users
+  # Helper class to merge users and groups from one config into another config
+  class ConfigMerger
+    # Constructor
+    #
+    # @param lhs [Config] Left Hand Size config. This config is modified.
+    # @param rhs [Config] Right Hand Size config
+    def initialize(lhs, rhs)
+      @lhs = lhs
+      @rhs = rhs
+    end
+
+    # Merges users and groups from {lhs} config into {rhs} config
+    #
+    # Users and groups that already exist on {lhs} are updated with their {rhs} counterparts. Note
+    # that for users, their uid and gid are not updated according to the {rhs} values.
+    def merge
+      elements = rhs.users + rhs.groups
+
+      elements.each { |e| merge_element(lhs, e) }
+    end
+
+  private
+
+    # Left Hand Size config
+    #
+    # @return [Config]
+    attr_reader :lhs
+
+    # Right Hand Size config
+    #
+    # @return [Config]
+    attr_reader :rhs
+
+    # Merges an element into a config
+    #
+    # @param config [Config] This config is modified
+    # @param element [User, Group]
+    def merge_element(config, element)
+      current_element = find_element(config, element)
+
+      new_element = element.clone
+
+      if current_element
+        new_element.assign_internal_id(current_element.id)
+        copy_values(current_element, new_element)
+        config.detach(current_element)
+      end
+
+      config.attach(new_element)
+    end
+
+    # Finds an element into a config by its name
+    #
+    # @param config [Config]
+    # @param element [User, Group]
+    #
+    # @raise [RuntimeError] if the the given element is not an {User} or {Group}.
+    #
+    # @return [User, Group, nil] nil if the config does not contain an element with the same name as
+    #   the given element.
+    def find_element(config, element)
+      elements = case element
+      when User
+        config.users
+      when Group
+        config.groups
+      else
+        raise "Element #{element} not valid. It must be an User or Group"
+      end
+
+      elements.find { |e| e.name == element.name }
+    end
+
+    # Copies values from one element into another
+    #
+    # @param from [Config] source element
+    # @param to [Config] target element
+    def copy_values(from, to)
+      return unless from.is_a?(User)
+
+      to.uid = from.uid
+      to.gid = from.gid
+    end
+  end
+end

--- a/src/lib/y2users/config_merger.rb
+++ b/src/lib/y2users/config_merger.rb
@@ -22,17 +22,18 @@ module Y2Users
   class ConfigMerger
     # Constructor
     #
-    # @param lhs [Config] Left Hand Size config. This config is modified.
-    # @param rhs [Config] Right Hand Size config
+    # @param lhs [Config] Left Hand Side config. This config is modified.
+    # @param rhs [Config] Right Hand Side config
     def initialize(lhs, rhs)
       @lhs = lhs
       @rhs = rhs
     end
 
-    # Merges users and groups from {lhs} config into {rhs} config
+    # Merges users and groups from {rhs} config into {lhs} config
     #
-    # Users and groups that already exist on {lhs} are updated with their {rhs} counterparts. Note
-    # that for users, their uid and gid are not updated according to the {rhs} values.
+    # Users and groups that already exist on {lhs} are updated with their {rhs} counterparts.
+    #
+    # @see merge_element
     def merge
       elements = rhs.users + rhs.groups
 
@@ -41,12 +42,12 @@ module Y2Users
 
   private
 
-    # Left Hand Size config
+    # Left Hand Side config
     #
     # @return [Config]
     attr_reader :lhs
 
-    # Right Hand Size config
+    # Right Hand Side config
     #
     # @return [Config]
     attr_reader :rhs
@@ -93,11 +94,16 @@ module Y2Users
 
     # Copies values from one element into another
     #
-    # @param from [Config] source element
-    # @param to [Config] target element
+    # @param from [User, Group] Source element
+    # @param to [User, Group] Target element. This element is modified.
     def copy_values(from, to)
       return unless from.is_a?(User)
 
+      # For an user, its uid and gid should not be updated in order to keep the current AutoYaST
+      # behavior. In general, this only affects to the AutoYaST case. In other scenarios like a
+      # regular installation, all users from {rhs} (except root) are new users, so this code is
+      # not executed for them. And, during installation, only the password can be modified for root,
+      # so this actually changes nothing for the root user.
       to.uid = from.uid
       to.gid = from.gid
     end

--- a/src/lib/y2users/group.rb
+++ b/src/lib/y2users/group.rb
@@ -86,6 +86,8 @@ module Y2Users
     #
     # @return [Boolean]
     def ==(other)
+      return false unless other.is_a?(self.class)
+
       [:name, :gid, :users_name, :source].all? do |a|
         public_send(a) == other.public_send(a)
       end

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -97,6 +97,8 @@ module Y2Users
     # @param other [Password]
     # @return [Boolean]
     def ==(other)
+      return false unless other.is_a?(self.class)
+
       [:value, :last_change, :minimum_age, :maximum_age, :warning_period, :inactivity_period,
        :account_expiration].all? do |a|
         public_send(a) == other.public_send(a)
@@ -140,6 +142,8 @@ module Y2Users
     # @param other [PasswordValue]
     # @return [Boolean]
     def ==(other)
+      return false unless other.is_a?(self.class)
+
       content == other.content
     end
 

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -141,6 +141,8 @@ module Y2Users
     #
     # @return [Boolean]
     def ==(other)
+      return false unless other.is_a?(self.class)
+
       [:name, :uid, :gid, :shell, :home, :gecos, :source, :password].all? do |a|
         public_send(a) == other.public_send(a)
       end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,18 @@
 # Tests for users
 TESTS = \
+  lib/y2users/config_manager_test.rb \
+  lib/y2users/config_merger_test.rb \
+  lib/y2users/config_test.rb \
+  lib/y2users/user_test.rb \
+  lib/y2users/group_test.rb \
+  lib/y2users/password_test.rb \
+  lib/y2users/password_validator_test.rb \
+  lib/y2users/validation_config_test.rb \
+  lib/y2users/help_texts_test.rb \
+  lib/y2users/linux/local_reader_test.rb \
+  lib/y2users/linux/reader_test.rb \
+  lib/y2users/linux/writer_test.rb \
+  lib/y2users/users_simple/writer_test.rb \
   lib/users/ca_password_validator_test.rb \
   lib/users/encryption_method_test.rb \
   lib/users/ssh_authorized_keys_file_test.rb \

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -1,0 +1,222 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users"
+
+describe Y2Users::ConfigMerger do
+  subject { described_class.new(lhs, rhs) }
+
+  let(:lhs) { Y2Users::Config.new }
+
+  let(:rhs) { Y2Users::Config.new }
+
+  describe "#merge" do
+    before do
+      lhs.attach(lhs_users)
+      lhs.attach(lhs_groups)
+    end
+
+    let(:lhs_users) { [] }
+
+    let(:lhs_groups) { [] }
+
+    def lhs_user(name)
+      lhs.users.find { |u| u.name == name }
+    end
+
+    def lhs_group(name)
+      lhs.groups.find { |g| g.name == name }
+    end
+
+    context "when the rhs config contains users" do
+      before do
+        rhs.attach(rhs_users)
+      end
+
+      let(:user1) do
+        user = Y2Users::User.new("test1")
+        user.uid = 1000
+        user.gid = 100
+        user.home = "/home/test1"
+        user
+      end
+
+      let(:user2) do
+        user = Y2Users::User.new("test2")
+        user.uid = 1001
+        user.gid = 101
+        user.home = "/home/test1"
+        user
+      end
+
+      let(:user3) do
+        user = Y2Users::User.new("test3")
+        user.uid = 1003
+        user.gid = 103
+        user.home = "/home/test3"
+        user
+      end
+
+      let(:rhs_users) { [user1, user2] }
+
+      context "and the lhs config does not contain users with the same name" do
+        let(:lhs_users) { [user3] }
+
+        it "adds the new users to the lhs config" do
+          expect(lhs.users.size).to eq(1)
+
+          subject.merge
+
+          expect(lhs.users.map(&:name)).to contain_exactly("test1", "test2", "test3")
+        end
+
+        it "keeps attributes from rhs users" do
+          subject.merge
+
+          expect(lhs_user("test1")).to eq(user1)
+          expect(lhs_user("test2")).to eq(user2)
+        end
+      end
+
+      context "and the lhs config contains users with the same name" do
+        let(:lhs_users) { [lhs_user1, user3] }
+
+        let(:lhs_user1) do
+          user = user1.clone
+          user.uid = 1100
+          user.gid = 110
+          user.home = "/home/lhs_user1"
+          user
+        end
+
+        it "does not add a new user with the same name to the lhs config" do
+          subject.merge
+
+          expect(lhs.users.map(&:name)).to contain_exactly("test1", "test2", "test3")
+        end
+
+        it "updates the lhs user with the data from the corresponding rhs user" do
+          subject.merge
+
+          expect(lhs_user("test1").home).to eq("/home/test1")
+        end
+
+        it "keeps the lhs user id" do
+          id = lhs_user("test1").id
+          subject.merge
+
+          expect(lhs_user("test1").id).to eq(id)
+        end
+
+        it "keeps the lhs user uid" do
+          subject.merge
+
+          expect(lhs_user("test1").uid).to eq(1100)
+        end
+
+        it "keeps the lhs user gid" do
+          subject.merge
+
+          expect(lhs_user("test1").gid).to eq(110)
+        end
+      end
+    end
+
+    context "when the rhs config contains groups" do
+      before do
+        rhs.attach(rhs_groups)
+      end
+
+      let(:group1) do
+        group = Y2Users::Group.new("test1")
+        group.gid = 100
+        group.users_name = ["test1", "test2"]
+        group
+      end
+
+      let(:group2) do
+        group = Y2Users::Group.new("test2")
+        group.gid = 101
+        group.users_name = ["test2", "test3"]
+        group
+      end
+
+      let(:group3) do
+        group = Y2Users::Group.new("test3")
+        group.gid = 103
+        group.users_name = ["test3"]
+        group
+      end
+
+      let(:rhs_groups) { [group1, group2] }
+
+      context "and the lhs config does not contain groups with the same name" do
+        let(:lhs_groups) { [group3] }
+
+        it "adds the new groups to the lhs config" do
+          expect(lhs.groups.size).to eq(1)
+
+          subject.merge
+
+          expect(lhs.groups.map(&:name)).to contain_exactly("test1", "test2", "test3")
+        end
+
+        it "keeps attributes from rhs groups" do
+          subject.merge
+
+          expect(lhs_group("test1")).to eq(group1)
+          expect(lhs_group("test2")).to eq(group2)
+        end
+      end
+
+      context "and the lhs config contains groups with the same name" do
+        let(:lhs_groups) { [lhs_group1, group3] }
+
+        let(:lhs_group1) do
+          group = group1.clone
+          group.gid = 110
+          group.users_name = ["test1"]
+          group
+        end
+
+        it "does not add a new group with the same name to the lhs config" do
+          subject.merge
+
+          expect(lhs.groups.map(&:name)).to contain_exactly("test1", "test2", "test3")
+        end
+
+        it "updates the lhs group with the data from the corresponding rhs group" do
+          subject.merge
+
+          expect(lhs_group("test1")).to eq(group1)
+        end
+
+        it "keeps the lhs group id" do
+          id = lhs_group("test1").id
+          subject.merge
+
+          expect(lhs_group("test1").id).to eq(id)
+        end
+      end
+    end
+  end
+end

--- a/test/lib/y2users/config_test.rb
+++ b/test/lib/y2users/config_test.rb
@@ -187,6 +187,64 @@ describe Y2Users::Config do
     end
   end
 
+  describe "#clone" do
+    before do
+      subject.attach([user1, user2, group1, group2])
+    end
+
+    let(:user1) { Y2Users::User.new("test1") }
+
+    let(:user2) { Y2Users::User.new("test2") }
+
+    let(:group1) { Y2Users::Group.new("test1") }
+
+    let(:group2) { Y2Users::Group.new("test2") }
+
+    def find(config, element)
+      elements = config.users + config.groups
+
+      elements.find { |e| e == element }
+    end
+
+    it "generates a new config object" do
+      config = subject.clone
+
+      expect(config).to_not eq(subject)
+    end
+
+    it "copies all users from the current config" do
+      config = subject.clone
+
+      expect(config.users).to eq(subject.users)
+    end
+
+    it "copies all groups from the current config" do
+      config = subject.clone
+
+      expect(config.groups).to eq(subject.groups)
+    end
+
+    it "keeps the same users id" do
+      config = subject.clone
+
+      config.users.each do |user|
+        original_user = find(subject, user)
+
+        expect(user.id).to eq(original_user.id)
+      end
+    end
+
+    it "keeps the same groups id" do
+      config = subject.clone
+
+      config.groups.each do |group|
+        original_group = find(subject, group)
+
+        expect(group.id).to eq(original_group.id)
+      end
+    end
+  end
+
   describe "#merge" do
     before do
       subject.attach([user1, group1])

--- a/test/lib/y2users/config_test.rb
+++ b/test/lib/y2users/config_test.rb
@@ -186,4 +186,102 @@ describe Y2Users::Config do
       end
     end
   end
+
+  describe "#merge" do
+    before do
+      subject.attach([user1, group1])
+      other.attach([user1.clone, user2, group2])
+    end
+
+    let(:other) { Y2Users::Config.new }
+
+    let(:user1) { Y2Users::User.new("test1") }
+
+    let(:user2) { Y2Users::User.new("test2") }
+
+    let(:group1) { Y2Users::Group.new("test1") }
+
+    let(:group2) { Y2Users::Group.new("test2") }
+
+    it "generates a new config object" do
+      config = subject.merge(other)
+
+      expect(config).to_not eq(subject)
+    end
+
+    it "does not mofidify the current config" do
+      users = subject.users
+      groups = subject.groups
+
+      subject.merge(other)
+
+      expect(subject.users).to eq(users)
+      expect(subject.groups).to eq(groups)
+    end
+
+    it "merges users from the given config into the users of the current config" do
+      config = subject.merge(other)
+
+      names = config.users.map(&:name)
+
+      expect(names).to contain_exactly("test1", "test2")
+    end
+
+    it "merges groups from the given config into the groups of the current config" do
+      config = subject.merge(other)
+
+      names = config.groups.map(&:name)
+
+      expect(names).to contain_exactly("test1", "test2")
+    end
+  end
+
+  describe "#merge!" do
+    before do
+      subject.attach([user1, group1])
+      other.attach([user1.clone, user2, group2])
+    end
+
+    let(:other) { Y2Users::Config.new }
+
+    let(:user1) { Y2Users::User.new("test1") }
+
+    let(:user2) { Y2Users::User.new("test2") }
+
+    let(:group1) { Y2Users::Group.new("test1") }
+
+    let(:group2) { Y2Users::Group.new("test2") }
+
+    it "does not generate a new config object" do
+      config = subject.merge!(other)
+
+      expect(config).to eq(subject)
+    end
+
+    it "modifies the current config object" do
+      users = subject.users
+      groups = subject.groups
+
+      subject.merge!(other)
+
+      expect(subject.users).to_not eq(users)
+      expect(subject.groups).to_not eq(groups)
+    end
+
+    it "merges users from the given config into the users of the current config" do
+      subject.merge!(other)
+
+      names = subject.users.map(&:name)
+
+      expect(names).to contain_exactly("test1", "test2")
+    end
+
+    it "merges groups from the given config into the groups of the current config" do
+      subject.merge!(other)
+
+      names = subject.groups.map(&:name)
+
+      expect(names).to contain_exactly("test1", "test2")
+    end
+  end
 end

--- a/test/lib/y2users/group_test.rb
+++ b/test/lib/y2users/group_test.rb
@@ -157,5 +157,13 @@ describe Y2Users::Group do
         expect(subject == other).to eq(false)
       end
     end
+
+    context "when the given object is not a group" do
+      let(:other) { "This is not a group" }
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
   end
 end

--- a/test/lib/y2users/password_test.rb
+++ b/test/lib/y2users/password_test.rb
@@ -148,6 +148,44 @@ describe Y2Users::Password do
         expect(subject == other).to eq(false)
       end
     end
+
+    context "when the given object is not a password" do
+      let(:other) { "This is not a password" }
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+  end
+end
+
+shared_examples "password value comparison" do
+  describe "#==" do
+    let(:other) { described_class.new(other_content) }
+
+    context "when the #content matches" do
+      let(:other_content) { subject.content }
+
+      it "returns true" do
+        expect(subject == other).to eq(true)
+      end
+    end
+
+    context "when the #content does not match" do
+      let(:other_content) { "other" }
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+
+    context "when the given object is not a password value" do
+      let(:other) { "This is not a password value" }
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
   end
 end
 
@@ -166,25 +204,7 @@ describe Y2Users::PasswordPlainValue do
     end
   end
 
-  describe "#==" do
-    let(:other) { described_class.new(content) }
-
-    context "when the #content matches" do
-      let(:content) { "S3cr3T" }
-
-      it "returns true" do
-        expect(subject == other).to eq(true)
-      end
-    end
-
-    context "when the #content does not match" do
-      let(:content) { "other" }
-
-      it "returns false" do
-        expect(subject == other).to eq(false)
-      end
-    end
-  end
+  include_examples "password value comparison"
 end
 
 describe Y2Users::PasswordEncryptedValue do
@@ -247,4 +267,6 @@ describe Y2Users::PasswordEncryptedValue do
       end
     end
   end
+
+  include_examples "password value comparison"
 end

--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -332,6 +332,14 @@ describe Y2Users::User do
         expect(subject == other).to eq(false)
       end
     end
+
+    context "when the given object is not an user" do
+      let(:other) { "This is not an user" }
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
   end
 
   describe "#root?" do


### PR DESCRIPTION
## Problem

In the *users_finish* client, we need to pass two configs to the config writer in order to create the new users. The idea is to read the users from the system, and then to generate a new config from the system one but adding all the user that were stored in *UsersSimple*. Then, the writer would take care of creating the new users by comparing these two configs. Note that the password of root user should be updated if needed.

In order to keep the writer as simple as possible, we need to prepare the target config in a way that the new users can be created and the root password can be updated by the writer. At the same time, the rest of users from system should not be touched at all.


## Solution

Create a `ConfigMerger` class to merge the users and groups from one config into another config. This will be useful in other scenarios too, for example AutoYaST.
