### PR TITLE
Improved reader and writer for UserSimple

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,8 +101,15 @@ ylib_y2users_DATA = \
 
 ylib_y2users_linuxdir = @ylibdir@/y2users/linux
 ylib_y2users_linux_DATA = \
+  lib/y2users/linux/local_reader.rb \
   lib/y2users/linux/reader.rb \
   lib/y2users/linux/writer.rb
+
+ylib_y2users_parsersdir = @ylibdir@/y2users/parsers
+ylib_y2users_parsers_DATA = \
+  lib/y2users/parsers/group.rb \
+  lib/y2users/parsers/passwd.rb \
+  lib/y2users/parsers/shadow.rb
 
 ylib_y2users_userssimpledir = @ylibdir@/y2users/users_simple
 ylib_y2users_userssimple_DATA = \
@@ -128,6 +135,6 @@ scalable_DATA = \
   icons/hicolor/scalable/apps/yast-users.svg \
   icons/hicolor/scalable/apps/yast-users-system.svg
 
-EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(ylibdialog_DATA) $(ylib_DATA) $(ylib_users_DATA) $(ylib_y2users_DATA) $(ylib_y2users_linux_DATA) $(ylib_y2users_userssimple_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA) $(ylibclient_DATA) $(scalable_DATA)
+EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(ylibdialog_DATA) $(ylib_DATA) $(ylib_users_DATA) $(ylib_y2users_DATA) $(ylib_y2users_linux_DATA) $(ylib_y2users_parsers) $(ylib_y2users_userssimple_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA) $(ylibclient_DATA) $(scalable_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "y2users/user"
 require "y2users/password"
+require "y2users/parsers/shadow"
 
 Yast.import "UsersSimple"
 
@@ -27,6 +28,13 @@ module Y2Users
   module UsersSimple
     # Class for reading users configuration from old Yast::UsersSimple module
     class Reader
+      # @see #{shadow_string}
+      SORTED_SHADOW_ATTRS = [
+        "uid", "userPassword", "shadowLastChange", "shadowMin", "shadowMax",
+        "shadowWarning", "shadowInactive", "shadowExpire", "shadowFlag"
+      ].freeze
+      private_constant :SORTED_SHADOW_ATTRS
+
       # Attaches users to given configuration
       #
       # @param config [Config]
@@ -42,16 +50,27 @@ module Y2Users
 
       # Returns the list users
       #
-      # TODO: only created users, not imported ones for now
-      #
       # @return [Array<User>] the collection of users
       def users
-        Yast::UsersSimple.GetUsers.map do |user_attrs|
-          user = User.new(user_attrs["uid"])
-          user.gecos = [user_attrs["cn"]]
-          user.password = Password.create_plain(user_attrs["userPassword"])
-          user
-        end
+        Yast::UsersSimple.GetUsers.map { |u| user(u) }
+      end
+
+      # Creates a {User} object based on the data structure of an UsersSimple user
+      #
+      # @param user_attrs [Hash] a user representation in the format used by UsersSimple
+      # @return [User]
+      def user(user_attrs)
+        user = User.new(user_attrs["uid"])
+
+        user.uid   = attr_value(:uidNumber, user_attrs)
+        user.gid   = attr_value(:gidNumber, user_attrs)
+        user.shell = attr_value(:loginShell, user_attrs)
+        user.home  = attr_value(:homeDirectory, user_attrs)
+        user.gecos = [attr_value(:cn, user_attrs)].compact
+
+        user.password = create_password(user_attrs)
+
+        user
       end
 
       # Returns the root user
@@ -60,10 +79,45 @@ module Y2Users
       def root_user
         user = User.new("root")
         user.gecos = ["root"]
-        user.uid = 0
+        user.uid = "0"
         passwd_str = Yast::UsersSimple.GetRootPassword
         user.password = Password.create_plain(passwd_str) unless passwd_str.empty?
         user
+      end
+
+      # Value of the given field for the given UsersSimple user
+      #
+      # @param attr [#to_s] name of the attribute
+      # @param user [Hash] a user representation in the format used by UsersSimple
+      # @return [String, nil] nil if the value is missing or empty
+      def attr_value(attr, user)
+        value = user[attr.to_s]
+        return nil if value == ""
+
+        value
+      end
+
+      # Creates a {Password} object based on the data structure of an UsersSimple user
+      #
+      # @param user [Hash] a user representation in the format used by UsersSimple
+      # @return [Password]
+      def create_password(user)
+        parser = Parsers::Shadow.new
+        content = shadow_string(user)
+
+        password = parser.parse(content).values.first
+        password.value = PasswordPlainValue.new(user["userPassword"]) unless user["encrypted"]
+        password
+      end
+
+      # Entry in /etc/shadow describing the password of the given user
+      #
+      # @param user [Hash] a user representation in the format used by UsersSimple
+      # @return [String]
+      def shadow_string(user)
+        SORTED_SHADOW_ATTRS.map do |attr|
+          user[attr] || ""
+        end.join(":")
       end
     end
   end

--- a/test/fixtures/root2/etc/shadow
+++ b/test/fixtures/root2/etc/shadow
@@ -1,4 +1,4 @@
-a_user:$6$pLaWhcXR$iiiiiilTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:16785::::::
+a_user:$6$pLaWhcXR$iiiiiilTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:17555:3:30:5:30:17889:
 root:$6$pLaWhcXR$gn1LrOlTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:16899::::::
 bin:*:16765::::::
 daemon:*:16765::::::

--- a/test/fixtures/root3/etc/passwd
+++ b/test/fixtures/root3/etc/passwd
@@ -1,5 +1,5 @@
 b_user:x:1000:100:A test local user:/home/b_user:/bin/bash
-c_user:x:1001:100:A test local user:/home/c_user:/bin/bash
+c_user:x:1001:100::/home/c_user:/bin/bash
 root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/bin/bash
 daemon:x:2:2:Daemon:/sbin:/bin/bash

--- a/test/fixtures/root3/etc/shadow
+++ b/test/fixtures/root3/etc/shadow
@@ -1,5 +1,5 @@
-b_user:$6$pLaWhcXR$iiiiiilTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:16785::::::
-c_user:$6$pLaWhcXR$iiiiiilTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:16785::::::
+b_user:$1$.QKDPc5E$SWlkjRWexrXYgc98F.:16785::::::
+c_user:$6$pLaWhcXR$iiiiiilTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:18754:0:90:14:::
 root:$6$pLaWhcXR$gn1LrOlTEV9B.SBn.iITpknL6eg/n63am7rzp2fMsB8ap5cUWl3ZcnT7o5mTcrG85bz/NhaC1D/izwkJeL5gI.:16899::::::
 bin:*:16765::::::
 daemon:*:16765::::::

--- a/test/lib/y2users/users_simple/reader_test.rb
+++ b/test/lib/y2users/users_simple/reader_test.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/config"
+require "y2users/users_simple/reader"
+
+describe Y2Users::UsersSimple::Reader do
+  describe "#read_to" do
+    before { Yast::UsersSimple.SetUsers(users_simple_users) }
+
+    let(:config) { Y2Users::Config.new }
+
+    context "for a set of users directly imported from a previous system by UsersSimple" do
+      let(:import_dir) { File.join(FIXTURES_PATH, "root3", "etc") }
+
+      let(:users_simple_users) do
+        # This imports regular users ignoring root, the old pre-Y2Users way
+        Yast::UsersSimple.ReadUserData(import_dir)
+        users = Yast::UsersSimple.GetImportedUsers("local").values
+        users.each { |u| u["encrypted"] = true }
+        users
+      end
+
+      it "fills the given config with the proper data" do
+        subject.read_to(config)
+
+        expect(config.users.size).to eq 3
+        expect(config.users.map(&:name)).to contain_exactly("root", "b_user", "c_user")
+
+        b_user = config.users.find { |u| u.name == "b_user" }
+        expect(b_user.shell).to eq "/bin/bash"
+        expect(b_user.uid).to eq "1000"
+        expect(b_user.home).to eq "/home/b_user"
+        expect(b_user.full_name).to eq "A test local user"
+        expect(b_user.password.value.encrypted?).to eq true
+        expect(b_user.password.value.content).to match(/^\$1\$.QKD/)
+        expect(b_user.password.last_change).to be_a(Date)
+        expect(b_user.password.last_change.to_s).to eq "2015-12-16"
+        expect(b_user.password.minimum_age).to eq 0
+        expect(b_user.password.maximum_age).to be_nil
+        expect(b_user.password.warning_period).to eq 0
+
+        c_user = config.users.find { |u| u.name == "c_user" }
+        expect(c_user.uid).to eq "1001"
+        expect(c_user.gecos).to eq []
+        expect(c_user.password.value.encrypted?).to eq true
+        expect(c_user.password.last_change).to be_a(Date)
+        expect(c_user.password.last_change.to_s).to eq "2021-05-07"
+        expect(c_user.password.minimum_age).to eq 0
+        expect(c_user.password.maximum_age).to eq 90
+        expect(c_user.password.warning_period).to eq 14
+        expect(c_user.password.inactivity_period).to be_nil
+      end
+    end
+
+    context "for a set of users created with minimal information" do
+      before do
+        Yast::UsersSimple.SetRootPassword(root_pwd)
+      end
+
+      let(:root_pwd) { "secretRoot" }
+
+      let(:users_simple_users) do
+        [
+          { "uid" => "test", "cn" => "Test User", "userPassword" => "secret" }
+        ]
+      end
+
+      it "fills the given config with the proper data" do
+        subject.read_to(config)
+
+        expect(config.users.size).to eq 2
+        expect(config.users.map(&:name)).to contain_exactly("root", "test")
+
+        root = config.users.find { |u| u.uid == "0" }
+        expect(root.name).to eq "root"
+        expect(root.shell).to be_nil
+        expect(root.password.value.encrypted?).to eq false
+        expect(root.password.value.content).to eq root_pwd
+
+        user = config.users.find { |u| u.name == "test" }
+        expect(user.shell).to be_nil
+        expect(user.uid).to be_nil
+        expect(user.home).to be_nil
+        expect(user.full_name).to eq "Test User"
+        expect(user.password.value.encrypted?).to eq false
+        expect(user.password.value.content).to eq "secret"
+        expect(user.password.last_change).to be_nil
+        expect(user.password.minimum_age).to eq 0
+        expect(user.password.maximum_age).to be_nil
+        expect(user.password.warning_period).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from #265 

This PR includes:

 - Improvements in `UsersSimple::Writer` to properly write both encrypted and plain passwords and also to write all the shadow attributes (expiration date, last password change, etc.)
 - Decent implementation of `UsersSimple::Reader` supporting all attributes (the previous version was very limited).
 - Bonus track: updated Makefile (it didn't include several of the files added in previously merged pull requests).