### PR TITLE
Adapt users_finish client

### DIFF
--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -333,8 +333,8 @@ describe Y2Users::User do
       end
     end
 
-    context "when the given object is not an user" do
-      let(:other) { "This is not an user" }
+    context "when the given object is not a user" do
+      let(:other) { "This is not a user" }
 
       it "returns false" do
         expect(subject == other).to eq(false)

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -233,7 +233,7 @@ describe Y2Users::UsersSimple::Writer do
       context "when a user has no uid" do
         let(:uid) { nil }
 
-        it "does not store an user uid" do
+        it "does not store a user uid" do
           subject.write
 
           expect(user_simple("test1")["uidNumber"]).to be_nil
@@ -243,7 +243,7 @@ describe Y2Users::UsersSimple::Writer do
       context "when a user has no gid" do
         let(:gid) { nil }
 
-        it "does not store an user gid" do
+        it "does not store a user gid" do
           subject.write
 
           expect(user_simple("test1")["gidNumber"]).to be_nil
@@ -253,7 +253,7 @@ describe Y2Users::UsersSimple::Writer do
       context "when a user has no shell" do
         let(:shell) { nil }
 
-        it "does not store an user shell" do
+        it "does not store a user shell" do
           subject.write
 
           expect(user_simple("test1")["loginShell"]).to be_nil
@@ -263,7 +263,7 @@ describe Y2Users::UsersSimple::Writer do
       context "when a user has no home" do
         let(:home) { nil }
 
-        it "does not store an user home" do
+        it "does not store a user home" do
           subject.write
 
           expect(user_simple("test1")["homeDirectory"]).to be_nil
@@ -283,7 +283,7 @@ describe Y2Users::UsersSimple::Writer do
       context "when a user has no password" do
         let(:user1_password) { nil }
 
-        it "does not store an user password" do
+        it "does not store a user password" do
           subject.write
 
           expect(user_simple("test1")["userPassword"]).to be_nil

--- a/test/users_finish_test.rb
+++ b/test/users_finish_test.rb
@@ -8,6 +8,9 @@ require "users/clients/users_finish"
 describe Yast::UsersFinishClient do
   Yast.import "WFM"
   Yast.import "UsersPasswd"
+  Yast.import "UsersSimple"
+  Yast.import "Autologin"
+  Yast.import "Report"
 
   describe "#run" do
     before do
@@ -71,29 +74,87 @@ describe Yast::UsersFinishClient do
         let(:autoinst) { false }
 
         before do
-          allow(subject).to receive(:setup_all_users).and_return(user_added)
+          # Mocking to avoid to write to the system
+          allow_any_instance_of(Y2Users::Linux::Writer).to receive(:write).and_return(issues)
+
+          # Mocking to avoid to read from the system
+          allow(Y2Users::ConfigManager.instance).to receive(:system).and_return(system_config)
+
+          allow(Y2Users::ConfigManager.instance).to receive(:config).with(:system)
+            .and_return(system_config)
+
+          allow(Y2Users::ConfigManager.instance).to receive(:config).with(:target)
+            .and_return(target_config)
+
+          allow(Yast::UsersSimple).to receive(:AutologinUsed).and_return(autologin)
+          allow(Yast::UsersSimple).to receive(:GetAutologinUser).and_return(autologin_user)
         end
 
-        context "when a new user is added" do
-          let(:user_added) { true }
+        let(:system_config) { Y2Users::Config.new }
 
-          it "write root password and users" do
-            # write root password
-            expect(Yast::UsersSimple).to receive(:Write)
-            # write users
-            expect(Yast::Users).to receive(:Write)
+        let(:target_config) { Y2Users::Config.new }
+
+        let(:autologin) { nil }
+
+        let(:autologin_user) { nil }
+
+        let(:writer) { instance_double(Y2Users::Linux::Writer, write: issues) }
+
+        let(:issues) { [] }
+
+        it "calls the linux writer with the expected configs" do
+          expect(Y2Users::Linux::Writer).to receive(:new).with(target_config, system_config)
+            .and_return(writer)
+
+          expect(writer).to receive(:write)
+
+          subject.run
+        end
+
+        context "when the writer does not report issues" do
+          let(:issues) { [] }
+
+          it "does not report errors to the user" do
+            expect(Yast::Report).to_not receive(:Error)
+
             subject.run
           end
         end
 
-        context "when no new user is added" do
-          let(:user_added) { false }
+        context "when the writer reports issues" do
+          let(:issues) { [issue1, issue2] }
 
-          it "write root password" do
-            # write root password
-            expect(Yast::UsersSimple).to receive(:Write)
-            # do not write users
-            expect(Yast::Users).to_not receive(:Write)
+          let(:issue1) { Y2Issues::Issue.new("error 1") }
+
+          let(:issue2) { Y2Issues::Issue.new("error 2") }
+
+          it "reports all errors to the user" do
+            expect(Yast::Report).to receive(:Error).with("error 1\n\nerror 2")
+
+            subject.run
+          end
+        end
+
+        context "when an user is configured for auto-login" do
+          let(:autologin) { true }
+
+          let(:autologin_user) { true }
+
+          it "configures auto-login for that user" do
+            expect(Yast::Autologin).to receive(:user=).with(autologin_user)
+            expect(Yast::Autologin).to receive(:Use).with(true)
+
+            subject.run
+          end
+        end
+
+        context "when no user is configured for auto-login" do
+          let(:autologin) { false }
+
+          it "does not configure auto-login" do
+            expect(Yast::Autologin).to_not receive(:user=)
+            expect(Yast::Autologin).to_not receive(:Use)
+
             subject.run
           end
         end

--- a/test/users_finish_test.rb
+++ b/test/users_finish_test.rb
@@ -80,11 +80,7 @@ describe Yast::UsersFinishClient do
           # Mocking to avoid to read from the system
           allow(Y2Users::ConfigManager.instance).to receive(:system).and_return(system_config)
 
-          allow(Y2Users::ConfigManager.instance).to receive(:config).with(:system)
-            .and_return(system_config)
-
-          allow(Y2Users::ConfigManager.instance).to receive(:config).with(:target)
-            .and_return(target_config)
+          allow(system_config).to receive(:merge).and_return(target_config)
 
           allow(Yast::UsersSimple).to receive(:AutologinUsed).and_return(autologin)
           allow(Yast::UsersSimple).to receive(:GetAutologinUser).and_return(autologin_user)

--- a/test/users_finish_test.rb
+++ b/test/users_finish_test.rb
@@ -135,7 +135,7 @@ describe Yast::UsersFinishClient do
           end
         end
 
-        context "when an user is configured for auto-login" do
+        context "when a user is configured for auto-login" do
           let(:autologin) { true }
 
           let(:autologin_user) { true }


### PR DESCRIPTION
### Problem

Clients *inst_user_first* and *inst_root_first* were already adapted to use the new `Y2Users` classes, but *users_finish* client is still using the old code to create the users into the system.


### Solution

The *users_finish* client was adapted to use `Y2Users` classes.

NOTE: *users_finish* is also used by AutoYaST, but the AutoYaST part will be adapted in a separate PR.


## Testing

* Added unit tests
* Manually tested:
  * Autologin is not working (will be fixed in a separate PR)
  * Root password form has an issue: https://github.com/yast/yast-users/pull/273  
