### PR TITLE
Write root password to Yast::UsersSimple

### DIFF
--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -22,6 +22,7 @@ require "cwm/widget"
 
 require "y2users/help_texts"
 require "y2users/inst_users_dialog_helper"
+require "y2users/users_simple"
 require "users/local_password"
 
 Yast.import "Popup"
@@ -133,6 +134,7 @@ module Users
 
       password1 = Yast::UI.QueryWidget(Id(:pw1), :Value)
       root_user.password = Y2Users::Password.create_plain(password1)
+      Y2Users::UsersSimple::Writer.new(users_config).write
     end
 
     def help # rubocop:disable Metrics/MethodLength

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -125,23 +125,17 @@ describe Users::PasswordWidget do
 
       expect(subject.validate).to eq true
     end
-  end
 
-  context "when the widget is allowed to be empty" do
-    subject { described_class.new(allow_empty: true) }
+    context "when the widget is allowed to be empty" do
+      subject { described_class.new(allow_empty: true) }
 
-    let(:root_user) { double(Y2Users::User) }
+      it "does not validate the password" do
+        stub_widget_value(:pw1, "")
+        stub_widget_value(:pw2, "")
 
-    before do
-      allow(subject).to receive(:root_user).and_return(root_user)
-    end
-
-    it "does not validate the password" do
-      stub_widget_value(:pw1, "")
-      stub_widget_value(:pw2, "")
-
-      expect(root_user).to_not receive(:password_issues)
-      expect(subject.validate).to eq(true)
+        expect(root_user).to_not receive(:password_issues)
+        expect(subject.validate).to eq(true)
+      end
     end
   end
 

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -140,7 +140,10 @@ describe Users::PasswordWidget do
   end
 
   describe "#store" do
+    # NOTE: testing only examples that make sense. I.e., those that happens when the widget
+    # validates successfully, required condition to dispatch the #store method.
     let(:user_simple_writer) { double(Y2Users::UsersSimple::Writer, write: true) }
+    let(:password) { "new cool password" }
 
     before do
       allow(Y2Users::UsersSimple::Writer).to receive(:new).and_return(user_simple_writer)
@@ -149,21 +152,19 @@ describe Users::PasswordWidget do
       stub_widget_value(:pw2, password)
     end
 
-    RSpec.shared_examples "update UserSimple root password" do
-      it "writes root user password to Users::UserSimple" do
-        expect(Y2Users::UsersSimple::Writer).to receive(:new) do |users_config|
-          root_user = users_config.users.find(&:root?)
-          root_password = root_user.password
+    it "writes root user password to Users::UserSimple" do
+      expect(Y2Users::UsersSimple::Writer).to receive(:new) do |users_config|
+        root_user = users_config.users.find(&:root?)
+        root_password = root_user.password
 
-          expect(root_password).to be_a(Y2Users::Password)
-          expect(root_password.value.plain?).to eq true
-          expect(root_password.value.content).to eq(password)
-          user_simple_writer
-        end
-        expect(user_simple_writer).to receive(:write)
-
-        subject.store
+        expect(root_password).to be_a(Y2Users::Password)
+        expect(root_password.value.plain?).to eq true
+        expect(root_password.value.content).to eq(password)
+        user_simple_writer
       end
+      expect(user_simple_writer).to receive(:write)
+
+      subject.store
     end
 
     context "when the widget is allowed to be empty" do
@@ -178,28 +179,6 @@ describe Users::PasswordWidget do
 
           subject.store
         end
-      end
-
-      context "but password is not empty" do
-        let(:password) { "new cool password" }
-
-        include_examples "update UserSimple root password"
-      end
-    end
-
-    context "when the widget is not allowed to be empty" do
-      subject { described_class.new(allow_empty: false) }
-
-      context "and password is empty" do
-        let(:password) { "" }
-
-        include_examples "update UserSimple root password"
-      end
-
-      context "but password is not empty" do
-        let(:password) { "new cool password" }
-
-        include_examples "update UserSimple root password"
       end
     end
   end


### PR DESCRIPTION
### Problem

While manually testing https://github.com/yast/yast-users/pull/270, I realize that the root password was not being set as expected because an step missing in https://github.com/yast/yast-users/pull/266: to _write back_ the chosen root password to `Yast::UsersSimple` database.

### Solution

This PR fix it by updating the UserSimple password in the PasswordWidget#store method, as it was before #266, but ideally it should be relocated in a more appropriate place in future iterations.

### Tests

* Updated unit tests
* Tested manually too via DUD and proceeding with installation until reach the installed system