### PR TITLE
Do not use an attached user for validations

### DIFF
--- a/src/lib/users/dialogs/inst_user_first.rb
+++ b/src/lib/users/dialogs/inst_user_first.rb
@@ -321,11 +321,12 @@ module Yast
         return false
       end
 
-      user.password = Y2Users::Password.create_plain(pw1)
-      root_user.password = Y2Users::Password.create_plain(pw1) if @use_pw_for_root
+      @password = pw1
       return false unless valid_password?
 
-      @password = pw1
+      user.password = Y2Users::Password.create_plain(pw1)
+      root_user.password = Y2Users::Password.create_plain(pw1) if @use_pw_for_root
+
       true
     end
 
@@ -538,9 +539,12 @@ module Yast
     #
     # @see Y2Users::InstUsersDialogHelper#user_to_validate
     #
-    # @return [Y2Users::User] root user if using entered password for it too; the new user otherwise
+    # @return [Y2Users::User] a root user when using same password for root; a normal user otherwise
     def user_to_validate
-      @use_pw_for_root ? root_user : user
+      username = @user_pw_for_root ? "root" : "user"
+      user = User.new(username)
+      user.password = Y2Users::Password.create_plain(@password)
+      user
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -114,13 +114,14 @@ module Users
         return false
       end
 
-      root_user.password = Y2Users::Password.create_plain(password1)
-
       # do not ask again if already approved (bsc#1025835)
       return true if self.class.approved_pwd == password1
 
+      @password = password1
+
       return false unless valid_password?
 
+      root_user.password = Y2Users::Password.create_plain(password1)
       self.class.approved_pwd = password1
 
       true
@@ -209,9 +210,11 @@ module Users
     #
     # @see Y2Users::InstUsersDialogHelper#user_to_validate
     #
-    # @return [Y2Users::User] the root user
+    # @return [Y2Users::User] a root user
     def user_to_validate
-      root_user
+      user = Y2Users::User.new("root")
+      user.password = Y2Users::Password.create_plain(@password)
+      user
     end
   end
 end

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -74,7 +74,6 @@ module Y2Users
     #
     # It might be re-defined in the dialog
     #
-    # @see #valid_user?
     # @see #valid_password?
     #
     # @return [Y2Users::User]

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -36,7 +36,7 @@ describe Y2Users::UsersSimple::Writer do
 
   describe "#write" do
     before(:each) do
-      Yast::UsersSimple.SetRootPassword("")
+      reset_users_simple
     end
 
     # Root user

--- a/test/support/users_helpers.rb
+++ b/test/support/users_helpers.rb
@@ -1,0 +1,35 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+Yast.import "UsersSimple"
+
+module Yast
+  module RSpec
+    module UsersHelpers
+      # Resets Yast::UsersSimple to an initial state
+      def reset_users_simple
+        UsersSimple.SetUsers([])
+        UsersSimple.SetRootPassword("")
+        UsersSimple.SetAutologinUser("")
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 require "yast"
 require "pathname"
 require "yast/rspec"
+require_relative "support/users_helpers"
 
 if ENV["COVERAGE"]
   require "simplecov"
@@ -63,6 +64,7 @@ RSpec.configure do |config|
 
     config.extend Yast::I18n  # available in context/describe
     config.include Yast::I18n # available in it/let/before/...
+    config.include Yast::RSpec::UsersHelpers
   end
 end
 

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -13,6 +13,7 @@ describe Users::PasswordWidget do
   before do
     allow(root_user).to receive(:root?).and_return(true)
     allow(subject).to receive(:root_user).and_return(root_user)
+    allow(subject).to receive(:user_to_validate).and_return(root_user)
   end
 
   it "has help text" do

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -11,6 +11,7 @@ describe Users::PasswordWidget do
   let(:root_user) { Y2Users::User.new("root") }
 
   before do
+    reset_users_simple
     allow(Y2Users::User).to receive(:new).and_call_original
     allow(Y2Users::User).to receive(:new).with("root").and_return(root_user)
   end

--- a/test/widgets_test.rb
+++ b/test/widgets_test.rb
@@ -11,9 +11,8 @@ describe Users::PasswordWidget do
   let(:root_user) { Y2Users::User.new("root") }
 
   before do
-    allow(root_user).to receive(:root?).and_return(true)
-    allow(subject).to receive(:root_user).and_return(root_user)
-    allow(subject).to receive(:user_to_validate).and_return(root_user)
+    allow(Y2Users::User).to receive(:new).and_call_original
+    allow(Y2Users::User).to receive(:new).with("root").and_return(root_user)
   end
 
   it "has help text" do
@@ -125,18 +124,6 @@ describe Users::PasswordWidget do
 
       expect(subject.validate).to eq true
     end
-  end
-
-  it "stores its value" do
-    stub_widget_value(:pw1, "new cool password")
-
-    expect(root_user).to receive(:password=) do |password|
-      expect(password).to be_a(Y2Users::Password)
-      expect(password.value.plain?).to eq true
-      expect(password.value.content).to eq "new cool password"
-    end
-
-    subject.store
   end
 
   context "when the widget is allowed to be empty" do


### PR DESCRIPTION
Stop using a user attached to the config for performing validations because, as written in the commit message 

> [...] could end up with changes that the user
eventually discarded (e.g., the user changes their mind about using the
same password for the root user)

Instead, it creates a detached _placeholder_ user for it.
