### PR TITLE
Fix autologin

### DIFF
--- a/src/lib/users/clients/users_finish.rb
+++ b/src/lib/users/clients/users_finish.rb
@@ -117,10 +117,13 @@ module Yast
       # resetting Autologin settings
       Autologin.Disable
 
-      return unless UsersSimple.AutologinUsed
+      if UsersSimple.AutologinUsed
+        Autologin.user = UsersSimple.GetAutologinUser
+        Autologin.Use(true)
+      end
 
-      Autologin.user = UsersSimple.GetAutologinUser
-      Autologin.Use(true)
+      # The parameter received by Autologin#Write is obsolete and it has no effect.
+      Autologin.Write(nil)
     end
 
     # System config, which contains all the current users on the system

--- a/test/users_finish_test.rb
+++ b/test/users_finish_test.rb
@@ -82,6 +82,9 @@ describe Yast::UsersFinishClient do
 
           allow(system_config).to receive(:merge).and_return(target_config)
 
+          # Mocking to avoid to write to the system
+          allow(Yast::Autologin).to receive(:Write)
+
           allow(Yast::UsersSimple).to receive(:AutologinUsed).and_return(autologin)
           allow(Yast::UsersSimple).to receive(:GetAutologinUser).and_return(autologin_user)
         end
@@ -137,8 +140,15 @@ describe Yast::UsersFinishClient do
           let(:autologin_user) { true }
 
           it "configures auto-login for that user" do
+            expect(Yast::Autologin).to receive(:Disable)
             expect(Yast::Autologin).to receive(:user=).with(autologin_user)
             expect(Yast::Autologin).to receive(:Use).with(true)
+
+            subject.run
+          end
+
+          it "writes the auto-login config" do
+            expect(Yast::Autologin).to receive(:Write)
 
             subject.run
           end
@@ -147,9 +157,16 @@ describe Yast::UsersFinishClient do
         context "when no user is configured for auto-login" do
           let(:autologin) { false }
 
-          it "does not configure auto-login" do
+          it "configures auto-login for no user" do
+            expect(Yast::Autologin).to receive(:Disable)
             expect(Yast::Autologin).to_not receive(:user=)
             expect(Yast::Autologin).to_not receive(:Use)
+
+            subject.run
+          end
+
+          it "writes the auto-login config" do
+            expect(Yast::Autologin).to receive(:Write)
 
             subject.run
           end


### PR DESCRIPTION
## Problem

After adapting the [*users_finish* client](https://github.com/yast/yast-users/pull/270) to use the new `Y2Users` classes, the autologin feature is not working anymore.


## Solution

Autologin config was not written when creating the users. Fixed.


## Testing

* Added unit tests
* Manually tested

Note: there still is a bug with the root password form, see #273.
