### PR TITLE
Linux::Writer takes care of shadow attributes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ ylib_y2users_DATA = \
   lib/y2users/linux.rb \
   lib/y2users/password.rb \
   lib/y2users/password_validator.rb \
+  lib/y2users/shadow_date_helper.rb \
   lib/y2users/user.rb \
   lib/y2users/users_simple.rb \
   lib/y2users/user_validator.rb \

--- a/src/lib/y2users/parsers/shadow.rb
+++ b/src/lib/y2users/parsers/shadow.rb
@@ -59,7 +59,7 @@ module Y2Users
         expiration = parse_account_expiration(values[SHADOW_MAPPING["account_expiration"]])
         password_value = PasswordEncryptedValue.new(values[SHADOW_MAPPING["value"]])
         password = Password.new(password_value)
-        password.last_change = parse_last_change(values[SHADOW_MAPPING["last_change"]])
+        password.aging = parse_aging(values[SHADOW_MAPPING["last_change"]])
         password.minimum_age = values[SHADOW_MAPPING["minimum_age"]].to_i
         password.maximum_age = max_age&.to_i
         password.warning_period = values[SHADOW_MAPPING["warning_period"]].to_i
@@ -68,12 +68,10 @@ module Y2Users
         password
       end
 
-      def parse_last_change(value)
-        return nil if !value || value.empty?
+      def parse_aging(value)
+        return nil unless value
 
-        return :force_change if value == "0"
-
-        shadow_string_to_date(value)
+        PasswordAging.new(value)
       end
 
       def parse_account_expiration(value)

--- a/src/lib/y2users/parsers/shadow.rb
+++ b/src/lib/y2users/parsers/shadow.rb
@@ -20,11 +20,14 @@
 require "date"
 
 require "y2users/password"
+require "y2users/shadow_date_helper"
 
 module Y2Users
   module Parsers
     # Parses shadow style string and return passwords defined in it
     class Shadow
+      include ShadowDateHelper
+
       # Mapping of attributes to index in shadow file
       SHADOW_MAPPING = {
         "username"           => 0,
@@ -70,17 +73,13 @@ module Y2Users
 
         return :force_change if value == "0"
 
-        # last_change is days till unix start 1970, so we expand it to number of seconds
-        unix_time = value.to_i * 24 * 60 * 60
-        Date.strptime(unix_time.to_s, "%s")
+        shadow_string_to_date(value)
       end
 
       def parse_account_expiration(value)
         return nil if !value || value.empty?
 
-        # last_change is days till unix start 1970, so we expand it to number of seconds
-        unix_time = value.to_i * 24 * 60 * 60
-        Date.strptime(unix_time.to_s, "%s")
+        shadow_string_to_date(value)
       end
     end
   end

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast2/secret_attributes"
+require "y2users/shadow_date_helper"
 
 module Y2Users
   # Password configuration for an user
@@ -27,11 +28,10 @@ module Y2Users
     # @return [PasswordValue, nil] nil if password is not set
     attr_accessor :value
 
-    # Last password change
+    # Aging information for the password, based on the content of the third field of a shadow file
     #
-    # @return [Date, :force_change, nil] date of the last change or :force_change when the next
-    #   login forces the user to change the password or nil for disabled aging feature.
-    attr_accessor :last_change
+    # [PasswordAging, nil] nil means information is unknown (eg. new user without a shadow entry)
+    attr_accessor :aging
 
     # The minimum number of days required between password changes
     #
@@ -99,7 +99,7 @@ module Y2Users
     def ==(other)
       return false unless other.is_a?(self.class)
 
-      [:value, :last_change, :minimum_age, :maximum_age, :warning_period, :inactivity_period,
+      [:value, :aging, :minimum_age, :maximum_age, :warning_period, :inactivity_period,
        :account_expiration].all? do |a|
         public_send(a) == other.public_send(a)
       end
@@ -177,6 +177,87 @@ module Y2Users
     # @return [Boolean]
     def disabled?
       ["*", "!"].include?(content)
+    end
+  end
+
+  # Represents one entry in the third field of the shadow file
+  class PasswordAging
+    include ShadowDateHelper
+
+    # Constructor
+    #
+    # @param value [String, Date] content of the field, automatically converted to the right format
+    #   if provided as a Date object
+    def initialize(value = "")
+      value = date_to_shadow_string(value) if value.is_a?(Date)
+      @content = value
+    end
+
+    # Content of the field
+    #
+    # @return [String]
+    attr_accessor :content
+
+    def to_s
+      content
+    end
+
+    # Whether password aging features are enabled
+    #
+    # @return [Boolean]
+    def enabled?
+      content != ""
+    end
+
+    # Sets the content to the value that disables password aging features
+    def disable
+      self.content = ""
+    end
+
+    # Whether the user must change the password in the next login
+    #
+    # @return [Boolean]
+    def force_change?
+      content == "0"
+    end
+
+    # Sets the content to the value that enforces a password change in the next login
+    def force_change
+      self.content = "0"
+    end
+
+    # Date of the latest password change, or nil if that date is irrelevant
+    #
+    # The date is irrelevant in these two scenarios:
+    #
+    #   - password aging features are disabled (see {#enabled?})
+    #   - the user is forced to change the password in the next login (see {#force_change?})
+    #
+    # @return [Date, nil]
+    def last_change
+      return nil unless enabled?
+      return nil if force_change?
+
+      shadow_string_to_date(content)
+    end
+
+    # Sets the content to the given date
+    #
+    # Note this enables the password aging features and sets {#force_change?} to false
+    #
+    # @param date [Date]
+    def last_change=(date)
+      self.content = date_to_shadow_string(date)
+    end
+
+    # Aging equality
+    #
+    # @param other [Object]
+    # @return [Boolean]
+    def ==(other)
+      return false unless other.is_a?(self.class)
+
+      content == other.content
     end
   end
 end

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -210,6 +210,9 @@ module Y2Users
     end
 
     # Sets the content to the value that disables password aging features
+    #
+    # @note There is not a counterpart method called 'enable'. To activate password aging,
+    #   use {#force_change} or {#last_change=}.
     def disable
       self.content = ""
     end
@@ -243,7 +246,7 @@ module Y2Users
 
     # Sets the content to the given date
     #
-    # Note this enables the password aging features and sets {#force_change?} to false
+    # @note This enables the password aging features and sets {#force_change?} to false.
     #
     # @param date [Date]
     def last_change=(date)

--- a/src/lib/y2users/shadow_date_helper.rb
+++ b/src/lib/y2users/shadow_date_helper.rb
@@ -1,0 +1,44 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "date"
+
+module Y2Users
+  # Mixin for converting the strings used to represent dates in the shadow file
+  module ShadowDateHelper
+    # Converts a string representing the number of days since 1970-01-01 into a date
+    #
+    # @param string [String]
+    # @return [Date]
+    def shadow_string_to_date(string)
+      # We need to expand the days to seconds
+      unix_time = string.to_i * 24 * 60 * 60
+      Date.strptime(unix_time.to_s, "%s")
+    end
+
+    # Converts a date to a string representing the number of days since 1970-01-01
+    #
+    # @param date [Date]
+    # @return [String
+    def date_to_shadow_string(date)
+      # We need to convert the seconds provided by "%s" to days
+      date.strftime("%s").to_i / (24 * 60 * 60)
+    end
+  end
+end

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -85,7 +85,7 @@ module Y2Users
           shadowMax:        password.maximum_age,
           shadowWarning:    password.warning_period,
           shadowInactive:   password.inactivity_period,
-          shadowLastChange: date_string(password.last_change),
+          shadowLastChange: password.aging&.content,
           shadowExpire:     date_string(password.account_expiration)
         }.merge(password_value_attrs(password))
       end

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2users/shadow_date_helper"
 
 Yast.import "UsersSimple"
 
@@ -25,6 +26,8 @@ module Y2Users
   module UsersSimple
     # Class for writing users configuration into the old UsersSimple Yast Module
     class Writer
+      include ShadowDateHelper
+
       # Constructor
       #
       # @param config [Config]
@@ -111,9 +114,8 @@ module Y2Users
       def date_string(date)
         return nil unless date
 
-        # UsersSimple uses the same format than the shadow file - days since 1970-01-01
-        # So we need to convert the seconds provided by "%s" to days
-        date.strftime("%s").to_i / (24 * 60 * 60)
+        # UsersSimple uses the same format than the shadow file
+        date_to_shadow_string(date)
       end
     end
   end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -368,5 +368,25 @@ describe Y2Users::Linux::Writer do
         expect(result.map(&:message)).to include(/password.*could not be set/)
       end
     end
+
+    context "when there is any error setting the password attributes" do
+      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+
+      before do
+        config.attach(user)
+
+        allow(Yast::Execute).to receive(:on_target!)
+          .with(/chage/, any_args)
+          .and_raise(error)
+      end
+
+      it "returns an issues list containing the issue" do
+        result = writer.write
+
+        expect(result).to be_a(Y2Issues::List)
+        expect(result).to_not be_empty
+        expect(result.map(&:message)).to include(/Error setting the properties of the password/)
+      end
+    end
   end
 end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -47,34 +47,104 @@ describe Y2Users::Linux::Writer do
       user
     end
 
-    let(:password) do
-      password = Y2Users::Password.new(pwd_value)
-      password.account_expiration = expiration_date
-      password
-    end
+    let(:password) { Y2Users::Password.new(pwd_value) }
 
     let(:username) { "testuser" }
     let(:pwd_value) { Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75$Qg6Pp") }
-    let(:expiration_date) { nil }
 
-    RSpec.shared_examples "setting expiration date" do
-      context "with an expiration date" do
-        let(:expiration_date) { Date.today }
+    RSpec.shared_examples "setting password attributes" do
+      context "setting some password attributes" do
+        before do
+          password.aging = aging
+          password.account_expiration = towel_day
+          password.minimum_age = minimum_age
+        end
 
-        it "includes the --expiredate option" do
-          expect(Yast::Execute).to receive(:on_target!) do |*args|
-            expect(args).to include("--expiredate")
-            expect(args).to include(expiration_date.to_s)
+        let(:towel_day) { Date.new(2001, 5, 25) }
+        let(:minimum_age) { 20 }
+
+        context "but not the one about password aging" do
+          let(:aging) { nil }
+
+          it "executes 'chage' to set the attributes but excluding 'lastday'" do
+            expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+              options = Hash[*(args[1..-2])]
+
+              expect(options["--mindays"]).to eq minimum_age.to_s
+              expect(options["--expiredate"]).to eq "2001-05-25"
+              expect(options.keys).to_not include("--lastday")
+            end
+
+            writer.write
+          end
+        end
+
+        context "including the password last change" do
+          let(:aging) { Y2Users::PasswordAging.new(towel_day) }
+
+          it "executes 'chage' to set the attributes including 'lastday'" do
+            expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+              options = Hash[*(args[1..-2])]
+
+              expect(options["--mindays"]).to eq minimum_age.to_s
+              expect(options["--expiredate"]).to eq "2001-05-25"
+              expect(options["--lastday"]).to eq "11467"
+            end
+
+            writer.write
+          end
+        end
+
+        context "including the need to change the password" do
+          let(:aging) do
+            age = Y2Users::PasswordAging.new
+            age.force_change
+            age
           end
 
-          writer.write
+          it "executes 'chage' to set the attributes including 'lastday' (to zero)" do
+            expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+              options = Hash[*(args[1..-2])]
+
+              expect(options["--mindays"]).to eq minimum_age.to_s
+              expect(options["--expiredate"]).to eq "2001-05-25"
+              expect(options["--lastday"]).to eq "0"
+            end
+
+            writer.write
+          end
+        end
+
+        context "but disabling password aging" do
+          let(:aging) do
+            age = Y2Users::PasswordAging.new
+            age.disable
+            age
+          end
+
+          it "executes 'chage' to set the attributes and to reset 'lastday'" do
+            expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+              options = Hash[*(args[1..-2])]
+
+              expect(options["--mindays"]).to eq minimum_age.to_s
+              expect(options["--expiredate"]).to eq "2001-05-25"
+              expect(options["--lastday"]).to eq "-1"
+            end
+
+            writer.write
+          end
         end
       end
 
-      context "without an expiration date" do
-        it "does not include the --expiredate option" do
-          expect(Yast::Execute).to receive(:on_target!) do |*args|
-            expect(args).to_not include("--expiredate")
+      context "with default password attributes" do
+        it "executes 'chage' to clean-up all fields except 'lastday'" do
+          expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+            options = Hash[*(args[1..-2])]
+
+            expect(options.keys).to contain_exactly(
+              "--mindays", "--maxdays", "--warndays", "--inactive", "--expiredate"
+            )
+            expect(options.values).to all(eq("-1"))
           end
 
           writer.write
@@ -197,8 +267,8 @@ describe Y2Users::Linux::Writer do
         config.attach(user)
       end
 
-      include_examples "setting expiration date"
       include_examples "setting password"
+      include_examples "setting password attributes"
 
       it "executes useradd with all the parameters, including creation of home directory" do
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
@@ -215,8 +285,8 @@ describe Y2Users::Linux::Writer do
         config.attach(user)
       end
 
-      include_examples "setting expiration date"
       include_examples "setting password"
+      include_examples "setting password attributes"
 
       it "executes useradd only with the argument to create the home directory" do
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "--create-home", username)

--- a/test/lib/y2users/password_test.rb
+++ b/test/lib/y2users/password_test.rb
@@ -73,7 +73,7 @@ describe Y2Users::Password do
     subject { described_class.create_plain("S3cr3T") }
 
     before do
-      subject.last_change = Date.today
+      subject.aging = Y2Users::PasswordAging.new(Date.today)
       subject.minimum_age = 10
       subject.maximum_age = 20
       subject.warning_period = 30
@@ -91,7 +91,7 @@ describe Y2Users::Password do
 
     context "when the #last_change does not match" do
       before do
-        other.last_change = Date.today + 10
+        other.aging = Y2Users::PasswordAging.new(Date.today + 10)
       end
 
       it "returns false" do

--- a/test/lib/y2users/users_simple/reader_test.rb
+++ b/test/lib/y2users/users_simple/reader_test.rb
@@ -54,8 +54,8 @@ describe Y2Users::UsersSimple::Reader do
         expect(b_user.full_name).to eq "A test local user"
         expect(b_user.password.value.encrypted?).to eq true
         expect(b_user.password.value.content).to match(/^\$1\$.QKD/)
-        expect(b_user.password.last_change).to be_a(Date)
-        expect(b_user.password.last_change.to_s).to eq "2015-12-16"
+        expect(b_user.password.aging.last_change).to be_a(Date)
+        expect(b_user.password.aging.last_change.to_s).to eq "2015-12-16"
         expect(b_user.password.minimum_age).to eq 0
         expect(b_user.password.maximum_age).to be_nil
         expect(b_user.password.warning_period).to eq 0
@@ -64,8 +64,8 @@ describe Y2Users::UsersSimple::Reader do
         expect(c_user.uid).to eq "1001"
         expect(c_user.gecos).to eq []
         expect(c_user.password.value.encrypted?).to eq true
-        expect(c_user.password.last_change).to be_a(Date)
-        expect(c_user.password.last_change.to_s).to eq "2021-05-07"
+        expect(c_user.password.aging.last_change).to be_a(Date)
+        expect(c_user.password.aging.last_change.to_s).to eq "2021-05-07"
         expect(c_user.password.minimum_age).to eq 0
         expect(c_user.password.maximum_age).to eq 90
         expect(c_user.password.warning_period).to eq 14
@@ -105,7 +105,7 @@ describe Y2Users::UsersSimple::Reader do
         expect(user.full_name).to eq "Test User"
         expect(user.password.value.encrypted?).to eq false
         expect(user.password.value.content).to eq "secret"
-        expect(user.password.last_change).to be_nil
+        expect(user.password.aging).to be_nil
         expect(user.password.minimum_age).to eq 0
         expect(user.password.maximum_age).to be_nil
         expect(user.password.warning_period).to eq 0

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -151,10 +151,10 @@ describe Y2Users::UsersSimple::Writer do
       let(:user2_password) do
         passwd = Y2Users::Password.create_encrypted("$1$.QKDPc5E$SWlkjRWexrXYgc98F.")
         passwd.aging = Y2Users::PasswordAging.new
-        passwd.aging.last_change = Date.new(2021, 5, 7)
+        passwd.aging.last_change = Date.new(1977, 5, 7)
         passwd.minimum_age = 0
         passwd.maximum_age = 90
-        passwd.warning_period = 14
+        passwd.account_expiration = Date.new(2021, 5, 7)
         passwd
       end
 
@@ -221,12 +221,13 @@ describe Y2Users::UsersSimple::Writer do
 
         expect(user_simple("test1")["shadowLastChange"]).to be_nil
         expect(user_simple("test1")["shadowMin"]).to be_nil
+        expect(user_simple("test1")["shadowExpire"]).to be_nil
 
-        expect(user_simple("test2")["shadowLastChange"]).to eq("18754")
+        expect(user_simple("test2")["shadowLastChange"]).to eq("2683")
         expect(user_simple("test2")["shadowMin"]).to eq("0")
         expect(user_simple("test2")["shadowMax"]).to eq("90")
-        expect(user_simple("test2")["shadowWarning"]).to eq("14")
-        expect(user_simple("test2")["shadowExpire"]).to be_nil
+        expect(user_simple("test2")["shadowWarning"]).to be_nil
+        expect(user_simple("test2")["shadowExpire"]).to eq("18754")
       end
 
       include_examples "root"

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -150,7 +150,8 @@ describe Y2Users::UsersSimple::Writer do
 
       let(:user2_password) do
         passwd = Y2Users::Password.create_encrypted("$1$.QKDPc5E$SWlkjRWexrXYgc98F.")
-        passwd.last_change = Date.new(2021, 5, 7)
+        passwd.aging = Y2Users::PasswordAging.new
+        passwd.aging.last_change = Date.new(2021, 5, 7)
         passwd.minimum_age = 0
         passwd.maximum_age = 90
         passwd.warning_period = 14


### PR DESCRIPTION
Main PR for https://trello.com/c/k4Hckc0k/2458-write-other-shadow-attributes

This PR teaches the linux writer to modify all the fields in the shadow file.

It's easier to review commit by commit
