### PR TITLE
Add collections

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,7 +84,6 @@ ylib_users_DATA = \
 
 ylib_y2usersdir = @ylibdir@/y2users
 ylib_y2users_DATA = \
-  lib/y2users/config_element.rb \
   lib/y2users/config_manager.rb \
   lib/y2users/config_merger.rb \
   lib/y2users/config.rb \
@@ -98,7 +97,11 @@ ylib_y2users_DATA = \
   lib/y2users/user.rb \
   lib/y2users/users_simple.rb \
   lib/y2users/user_validator.rb \
-  lib/y2users/validation_config.rb
+  lib/y2users/validation_config.rb \
+  lib/y2users/config_element.rb \
+  lib/y2users/config_element_collection.rb \
+  lib/y2users/users_collection.rb \
+  lib/y2users/groups_collection.rb
 
 ylib_y2users_linuxdir = @ylibdir@/y2users/linux
 ylib_y2users_linux_DATA = \

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -17,8 +17,9 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
 require "y2users/config_merger"
+require "y2users/users_collection"
+require "y2users/groups_collection"
 
 module Y2Users
   # Class to represent a configuration of users and groups
@@ -29,67 +30,72 @@ module Y2Users
   #   group = Group.new("users")
   #
   #   config1 = Config.new
-  #   config1.users #=> []
+  #   config1.users #=> UsersCollection<[]>
   #   config1.attach(user1, user2, group)
-  #   config1.users #=> [user1, user2]
-  #   config1.groups #=> [group]
+  #   config1.users #=> UsersCollection<[user1, user2]>
+  #   config1.groups #=> GroupCollection<[group]>
   #
-  #   config2 = config1.clone
+  #   config2 = config1.copy
   #   user = config2.users.first
   #   config2.detach(user)
-  #   config2.users #=> [user2]
+  #   config2.users #=> UsersCollection<[user2]>
   class Config
     # Constructor
+    #
+    # @see UsersCollection
+    # @see GroupsCollection
     def initialize
-      @users_manager = ElementManager.new(self)
-      @groups_manager = ElementManager.new(self)
+      @users_collection = UsersCollection.new
+      @groups_collection = GroupsCollection.new
     end
 
-    # Users that belong to this config
+    # Collection of users that belong to this config
     #
-    # @note The list of users cannot be modified directly. Use {#attach} and {#detach} instead.
+    # The collection cannot be modified directly. Use {#attach} and {#detach} instead.
     #
-    # @return [Array<User>]
+    # @return [UsersCollection]
     def users
-      users_manager.elements.dup.freeze
+      users_collection.dup.freeze
     end
 
-    # Groups that belong to this config
+    # Collection of groups that belong to this config
     #
-    # @note The list of groups cannot be modified directly. Use {#attach} and {#detach} instead.
+    # The colletion cannot be modified directly. Use {#attach} and {#detach} instead.
     #
-    # @return [Array<Group>]
+    # @return [GroupsCollection]
     def groups
-      groups_manager.elements.dup.freeze
+      groups_collection.dup.freeze
     end
 
     # Attaches users and groups to this config
     #
-    # The given users and groups cannot be already attached to a config.
+    # The given users and groups cannot be attached to a config and their ids should not be included
+    # in the config, see {#attach_element}.
     #
-    # @param elements [Array<User, Group>]
+    # @param elements [Array<ConfigElement>]
     def attach(*elements)
       elements.flatten.each { |e| attach_element(e) }
     end
 
     # Detaches users and groups from this config
     #
-    # @param elements [Array<User, Group>]
+    # The given  users and groups must be attached to this config, see {#detach_element}.
+    #
+    # @param elements [Array<ConfigElement>]
     def detach(*elements)
       elements.flatten.each { |e| detach_element(e) }
     end
 
-    # Generates a new config with the very same list of users and groups
+    # Generates a deep copy of the config
     #
-    # Note that the cloned users and groups keep the same id as the original users and groups.
+    # The copied users and groups keep the same id as the original users and groups.
     #
     # @return [Config]
-    def clone
+    def copy
+      elements = (users + groups).map(&:copy)
+
       config = self.class.new
-
-      elements = users + groups
-      elements.each { |e| config.clone_element(e) }
-
+      config.attach(elements)
       config
     end
 
@@ -99,7 +105,7 @@ module Y2Users
     # @param other [Config]
     # @return [Config]
     def merge(other)
-      clone.merge!(other)
+      copy.merge!(other)
     end
 
     # Modifies the current config by merging the users and groups of the given config into the users
@@ -113,112 +119,65 @@ module Y2Users
       self
     end
 
-  protected
-
-    # Clones a given user or group and attaches it into this config
-    #
-    # Note that the cloned element keep the same id as the source element.
-    #
-    # @param element [User, Group]
-    def clone_element(element)
-      cloned = element.clone
-      cloned.assign_internal_id(element.id)
-
-      attach(cloned)
-    end
-
   private
 
-    # Manager for users
+    # Collection of users
     #
-    # @return [ElementManager]
-    attr_reader :users_manager
+    # @return [UsersCollection]
+    attr_reader :users_collection
 
-    # Manager for groups
+    # Collection of groups
     #
-    # @return [ElementManager]
-    attr_reader :groups_manager
+    # @return [GroupsCollection]
+    attr_reader :groups_collection
 
-    # Attaches an user or group
+    # Attaches a user or group
     #
-    # An id is assigned to the given user/group, if needed.
+    # @raise [RuntimeError] if the element is already attached to a config
+    # @raise [RuntimeError] if an element with the same id already exists
     #
-    # @param element [User, Group]
+    # @param element [ConfigElement]
     def attach_element(element)
-      element.assign_internal_id(ElementId.next) if element.id.nil?
+      raise "Element #{element} is already attached to a config" if element.attached?
+      raise "Element #{element} already exists in this config" if exist_element?(element)
 
-      element.is_a?(User) ? users_manager.attach(element) : groups_manager.attach(element)
+      element.assign_config(self)
+
+      collection_for(element).add(element)
     end
 
-    # Detaches an user or group
+    # Detaches a user or group
     #
-    # @param element [User, Group]
+    # @raise [RuntimeError] if the given element is not attached to the config
+    #
+    # @param element [ConfigElement]
     def detach_element(element)
-      element.is_a?(User) ? users_manager.detach(element) : groups_manager.detach(element)
+      raise "Element #{element} is not attached to this config" if element.config != self
+
+      exist = exist_element?(element)
+
+      if !exist
+        log.warn("Detach element: element #{element} is attached to the config #{self}, but " \
+          "it cannot be found.")
+      end
+
+      collection_for(element).delete(element.id) if exist
+
+      element.assign_config(nil)
     end
 
-    # Helper class to manage a list of users or groups
-    class ElementManager
-      include Yast::Logger
-
-      # @return [Array<User, Group>]
-      attr_reader :elements
-
-      # @return [Config]
-      attr_reader :config
-
-      # Constructor
-      #
-      # @param config [Config]
-      def initialize(config)
-        @config = config
-        @elements = []
-      end
-
-      # Attaches the element to the config
-      #
-      # @raise [RuntimeError] if the element is already attached
-      #
-      # @param element [User, Group]
-      def attach(element)
-        raise "Element #{element} already attached to config #{config}" if element.attached?
-
-        @elements << element
-
-        element.assign_config(config)
-      end
-
-      # Detaches the element from the config
-      #
-      # @raise [RuntimeError] if the given element is not attached to the config
-      #
-      # @param element [User, Group]
-      def detach(element)
-        raise "Element #{element} is not attached to config #{config}" if element.config != config
-
-        index = @elements.find_index { |e| e.is?(element) }
-
-        if index.nil?
-          log.warn("Detach element: element #{element} is assigned to the config #{config}, but " \
-            "it cannot be found.")
-        end
-
-        @elements.delete_at(index) if index
-
-        element.assign_config(nil)
-        element.assign_internal_id(nil)
-      end
+    # Collection for the given element
+    #
+    # @return [ConfigElementCollection]
+    def collection_for(element)
+      element.is_a?(User) ? @users_collection : @groups_collection
     end
 
-    # Helper class for generating elements ids
-    class ElementId
-      # Generates the next id to be used for an element
-      #
-      # @return [Integer]
-      def self.next
-        @last_element_id ||= 0
-        @last_element_id += 1
-      end
+    # Whether the given element exists in its collection
+    #
+    # @return [Boolean]
+    def exist_element?(element)
+      collection_for(element).include?(element.id)
     end
   end
 end

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -168,6 +168,7 @@ module Y2Users
 
     # Collection for the given element
     #
+    # @param element [ConfigElement]
     # @return [ConfigElementCollection]
     def collection_for(element)
       element.is_a?(User) ? @users_collection : @groups_collection
@@ -175,6 +176,7 @@ module Y2Users
 
     # Whether the given element exists in its collection
     #
+    # @param element [ConfigElement]
     # @return [Boolean]
     def exist_element?(element)
       collection_for(element).include?(element.id)

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -79,7 +79,7 @@ module Y2Users
 
     # Detaches users and groups from this config
     #
-    # The given  users and groups must be attached to this config, see {#detach_element}.
+    # The given users and groups must be attached to this config, see {#detach_element}.
     #
     # @param elements [Array<ConfigElement>]
     def detach(*elements)

--- a/src/lib/y2users/config_element.rb
+++ b/src/lib/y2users/config_element.rb
@@ -18,8 +18,8 @@
 # find current contact information at www.suse.com.
 
 module Y2Users
-  # Methods for an element that can be attached to a {Config} (e.g., {User}, {Group}).
-  module ConfigElement
+  # Base class for an element that can be attached to a config
+  class ConfigElement
     # {Config} in which the element is attached to
     #
     # @return [Config, nil] nil if the element is not attached yet
@@ -33,11 +33,15 @@ module Y2Users
     # @return [Integer, nil] the id is assigned by the config when attaching the element
     attr_reader :id
 
+    def initialize
+      assign_internal_id(IdGenerator.next)
+    end
+
     # Assigns the internal id for this element
     #
     # @note The id of an element should not be modified. This method is exposed in the public API
-    #   only to make possible to set the id when attaching/detaching an element to/from a config,
-    #   see {Config#attach} and {Config#detach}.
+    #   only to make possible to set the id when merging an element from another config, see
+    #   {ConfigMerger}.
     #
     # @param id [Integer]
     def assign_internal_id(id)
@@ -64,10 +68,10 @@ module Y2Users
 
     # Whether this element is considered the same as other
     #
-    # Two elements are considered the same when they have the same id, independently on the rest of
-    # attributes.
+    # Two elements are considered the same when they have the same id, independently on the rest
+    # of attributes.
     #
-    # @param other [User, Group]
+    # @param other [ConfigElement]
     # @return [Boolean]
     def is?(other)
       return false unless self.class == other.class
@@ -76,17 +80,25 @@ module Y2Users
       id == other.id
     end
 
-    # Generates a new cloned element without an specific config or id.
+    # Generates a new cloned element without an specific config.
     #
-    # Note that the new cloned element is not attached to any config.
-    #
-    # @return [User, Group]
-    def clone
-      cloned = super
-      cloned.assign_config(nil)
-      cloned.assign_internal_id(nil)
+    # @return [ConfigElement]
+    def copy
+      element = clone
+      element.assign_config(nil)
 
-      cloned
+      element
+    end
+
+    # Helper class for generating elements ids
+    class IdGenerator
+      # Generates the next id to be used for an element
+      #
+      # @return [Integer]
+      def self.next
+        @last_element_id ||= 0
+        @last_element_id += 1
+      end
     end
   end
 end

--- a/src/lib/y2users/config_element_collection.rb
+++ b/src/lib/y2users/config_element_collection.rb
@@ -1,0 +1,143 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "forwardable"
+
+module Y2Users
+  # Base class for collection of config elements (e.g., {User}, {Group}).
+  class ConfigElementCollection
+    extend Forwardable
+
+    def_delegators :@elements, :each, :select, :find, :reject, :map, :any?, :size, :empty?
+
+    # Constructor
+    #
+    # @param elements [Array<ConfigElement>]
+    def initialize(elements = [])
+      @elements = elements
+    end
+
+    # Adds an element to the collection
+    #
+    # @raise [FrozenError] see {#check_editable}
+    #
+    # @param element [ConfigElement]
+    # @return [self]
+    def add(element)
+      check_editable
+
+      @elements << element
+
+      self
+    end
+
+    # Deletes the element with the given id from the collection
+    #
+    # @raise [FrozenError] see {#check_editable}
+    #
+    # @param id [Integer]
+    # @return [self]
+    def delete(id)
+      check_editable
+
+      @elements.reject! { |e| e.id == id }
+
+      self
+    end
+
+    # List with all the elements
+    #
+    # @return [Array<ConfigElement>]
+    def all
+      @elements.dup
+    end
+
+    alias_method :to_a, :all
+
+    # Generates a new collection with the sum of elements
+    #
+    # @param other [Collection]
+    # @return [Collection]
+    def +(other)
+      self.class.new(all + other.all)
+    end
+
+    # Generates a new collection without the elements whose id is included in the list of ids
+    #
+    # @param ids [Array<Integer>]
+    # @return [Collection]
+    def without(ids)
+      elements = (self.ids - ids).map { |i| by_id(i) }
+
+      self.class.new(elements)
+    end
+
+    # Generates a new collection only with the elements that have changed from another collection
+    #
+    # Note that the new collection only includes elements that exist in the other collection, that
+    # is, the new elements are not considered.
+    #
+    # @param other [Collection]
+    # @return [Collection]
+    def changed_from(other)
+      ids = self.ids & other.ids
+
+      elements = ids.map { |i| by_id(i) }.reject { |e| e == other.by_id(e.id) }
+
+      self.class.new(elements)
+    end
+
+    # Whether the collection already contains an element with the given id
+    #
+    # @param id [Integer]
+    # @return [Boolean]
+    def include?(id)
+      ids.include?(id)
+    end
+
+    # Element with the given id
+    #
+    # @return [ConfigElement, nil] nil if the collection does not include an element with
+    #   such an id.
+    def by_id(value)
+      @elements.find { |e| e.id == value }
+    end
+
+    # All element ids
+    #
+    # @return [Array<Integer>]
+    def ids
+      map(&:id)
+    end
+
+  private
+
+    # Checks whether the collection can be modified
+    #
+    # Modifications in the list of elements should be prevented when the collection is frozen.
+    #
+    # @raise [FrozenError] if the collection is frozen
+    # @return [Boolean]
+    def check_editable
+      return true unless frozen?
+
+      raise FrozenError, "can't modify frozen #{self.class}: #{inspect}"
+    end
+  end
+end

--- a/src/lib/y2users/config_merger.rb
+++ b/src/lib/y2users/config_merger.rb
@@ -35,9 +35,9 @@ module Y2Users
     #
     # @see merge_element
     def merge
-      elements = rhs.users + rhs.groups
+      collection = rhs.users + rhs.groups
 
-      elements.each { |e| merge_element(lhs, e) }
+      collection.each { |e| merge_element(lhs, e) }
     end
 
   private
@@ -55,11 +55,11 @@ module Y2Users
     # Merges an element into a config
     #
     # @param config [Config] This config is modified
-    # @param element [User, Group]
+    # @param element [ConfigElement]
     def merge_element(config, element)
       current_element = find_element(config, element)
 
-      new_element = element.clone
+      new_element = element.copy
 
       if current_element
         new_element.assign_internal_id(current_element.id)
@@ -73,14 +73,14 @@ module Y2Users
     # Finds an element into a config by its name
     #
     # @param config [Config]
-    # @param element [User, Group]
+    # @param element [ConfigElement]
     #
     # @raise [RuntimeError] if the the given element is not an {User} or {Group}.
     #
-    # @return [User, Group, nil] nil if the config does not contain an element with the same name as
-    #   the given element.
+    # @return [ConfigElement, nil] nil if the config does not contain an element with the same
+    #   name as the given element.
     def find_element(config, element)
-      elements = case element
+      collection = case element
       when User
         config.users
       when Group
@@ -89,13 +89,13 @@ module Y2Users
         raise "Element #{element} not valid. It must be an User or Group"
       end
 
-      elements.find { |e| e.name == element.name }
+      collection.find { |e| e.name == element.name }
     end
 
     # Copies values from one element into another
     #
-    # @param from [User, Group] Source element
-    # @param to [User, Group] Target element. This element is modified.
+    # @param from [ConfigElement] Source element
+    # @param to [ConfigElement] Target element. This element is modified.
     def copy_values(from, to)
       return unless from.is_a?(User)
 

--- a/src/lib/y2users/group.rb
+++ b/src/lib/y2users/group.rb
@@ -26,17 +26,14 @@ module Y2Users
   #   group = Group.new("admins")
   #   group.gid = 110
   #   group.attached? #=> false
-  #   group.id #=> nil
+  #   group.id #=> 1
   #
   #   config = Config.new("my_config")
   #   config.attach(group)
   #
   #   group.config #=> config
-  #   group.id #=> 56
   #   group.attached? #=> true
-  class Group
-    include ConfigElement
-
+  class Group < ConfigElement
     # Group name
     #
     # @return [String]
@@ -63,6 +60,8 @@ module Y2Users
     #
     # @param name [String]
     def initialize(name)
+      super()
+
       @name = name
       @users_name = []
       @source = :unknown

--- a/src/lib/y2users/groups_collection.rb
+++ b/src/lib/y2users/groups_collection.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/config_element_collection"
+
+module Y2Users
+  # Collection of groups
+  class GroupsCollection < ConfigElementCollection
+    # Constructor
+    #
+    # @param groups [Array<Group>]
+    def initialize(groups = [])
+      super
+    end
+
+    # Generates a new collection with the groups whose gid is the given gid
+    #
+    # @param value [Integer]
+    # @return [GroupsCollection]
+    def by_gid(value)
+      groups = select { |g| g.gid == value }
+
+      self.class.new(groups)
+    end
+
+    # Group with the given name
+    #
+    # @param value [String]
+    # @return [Group, nil] nil if the collection does not include a group with the given name
+    def by_name(value)
+      find { |g| g.name == value }
+    end
+  end
+end

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -83,11 +83,14 @@ module Y2Users
       @value = value
     end
 
-    def clone
-      cloned = super
-      cloned.value = value.clone
+    # Generates a deep copy of the password
+    #
+    # @return [Password]
+    def copy
+      password = clone
+      password.value = value.clone
 
-      cloned
+      password
     end
 
     # Password equality

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -22,24 +22,21 @@ require "y2users/user_validator"
 require "y2users/password_validator"
 
 module Y2Users
-  # Class to represent an user
+  # Class to represent a user
   #
   # @example
   #   user = User.new("john")
   #   user.uid = 1001
   #   user.system? #=> false
   #   user.attached? #=> false
-  #   user.id #=> nil
+  #   user.id #=> 1
   #
   #   config = Config.new("my_config")
   #   config.attach(user)
   #
   #   user.config #=> config
-  #   user.id #=> 23
   #   user.attached? #=> true
-  class User
-    include ConfigElement
-
+  class User < ConfigElement
     # User names that are considered system users
     # @see #system?
     SYSTEM_NAMES = ["nobody"].freeze
@@ -93,6 +90,8 @@ module Y2Users
     #
     # @param name [String]
     def initialize(name)
+      super()
+
       @name = name
       # TODO: GECOS
       @gecos = []
@@ -206,12 +205,16 @@ module Y2Users
       @system = value
     end
 
-    # @see ConfigElement#clone
-    def clone
-      cloned = super
-      cloned.password = password.clone
+    # Generates a deep copy of the user
+    #
+    # @see ConfigElement#copy
+    #
+    # @return [User]
+    def copy
+      user = super
+      user.password = password.copy if password
 
-      cloned
+      user
     end
 
     # Validation errors

--- a/src/lib/y2users/users_collection.rb
+++ b/src/lib/y2users/users_collection.rb
@@ -1,0 +1,66 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/config_element_collection"
+
+module Y2Users
+  # Collection of users
+  class UsersCollection < ConfigElementCollection
+    # Constructor
+    #
+    # @param users [Array<User>]
+    def initialize(users = [])
+      super
+    end
+
+    # Root user from the collection
+    #
+    # @return [User, nil] nil if the collection does not include a root user
+    def root
+      find(&:root?)
+    end
+
+    # Generates a new collection only with the system users
+    #
+    # @return [UsersCollection]
+    def system
+      users = select(&:system?)
+
+      self.class.new(users)
+    end
+
+    # Generates a new collection with the users whose uid is the given uid
+    #
+    # @param value [Integer]
+    # @return [UsersCollection]
+    def by_uid(value)
+      users = select { |u| u.uid == value }
+
+      self.class.new(users)
+    end
+
+    # User with the given name
+    #
+    # @param value [String]
+    # @return [User, nil] nil if the collection does not include a user with the given name
+    def by_name(value)
+      find { |u| u.name == value }
+    end
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,11 @@ TESTS = \
   lib/y2users/password_validator_test.rb \
   lib/y2users/validation_config_test.rb \
   lib/y2users/help_texts_test.rb \
+  lib/y2users/config_element_examples.rb \
+  lib/y2users/config_element_collection_examples.rb \
+  lib/y2users/users_collection_test.rb \
+  lib/y2users/groups_collection_test.rb \
+  lib/y2users/config_element_examples.rb \
   lib/y2users/linux/local_reader_test.rb \
   lib/y2users/linux/reader_test.rb \
   lib/y2users/linux/writer_test.rb \

--- a/test/lib/y2users/config_element_collection_examples.rb
+++ b/test/lib/y2users/config_element_collection_examples.rb
@@ -1,0 +1,266 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users"
+
+shared_examples "config element collection" do
+  let(:elements) { [element1, element2, element3] }
+
+  let(:element1) { element_class.new("test1") }
+
+  let(:element2) { element_class.new("test2") }
+
+  let(:element3) { element_class.new("test3") }
+
+  let(:element_class) do
+    (described_class == Y2Users::UsersCollection) ? Y2Users::User : Y2Users::Group
+  end
+
+  describe "#add" do
+    let(:element) { element_class.new("test") }
+
+    it "adds the given element to the collection" do
+      expect(subject.any? { |e| e.id == element.id }).to eq(false)
+
+      size = subject.size
+      subject.add(element)
+
+      expect(subject.size).to eq(size + 1)
+      expect(subject.any? { |e| e.id == element.id }).to eq(true)
+    end
+
+    it "returns the collection" do
+      expect(subject.add(element)).to eq(subject)
+    end
+
+    context "if the collection is frozen" do
+      before do
+        subject.freeze
+      end
+
+      it "raises an error" do
+        expect { subject.add(element) }.to raise_error(FrozenError)
+      end
+    end
+  end
+
+  describe "#delete" do
+    context "if the collection includes an element with the given id" do
+      let(:id) { elements.first.id }
+
+      it "deletes the element from the collection" do
+        expect(subject.any? { |e| e.id == id }).to eq(true)
+
+        size = subject.size
+        subject.delete(id)
+
+        expect(subject.size).to eq(size - 1)
+        expect(subject.any? { |e| e.id == id }).to eq(false)
+      end
+
+      it "returns the collection" do
+        expect(subject.delete(id)).to eq(subject)
+      end
+    end
+
+    context "if the collection does not include an element with the given id" do
+      let(:id) { element_class.new("test").id }
+
+      it "does not modify the collection" do
+        size = subject.size
+        subject.delete(id)
+
+        expect(subject.size).to eq(size)
+      end
+
+      it "returns the collection" do
+        expect(subject.delete(id)).to eq(subject)
+      end
+    end
+
+    context "if the collection is frozen" do
+      before do
+        subject.freeze
+      end
+
+      it "raises an error" do
+        expect { subject.delete(elements.first.id) }.to raise_error(FrozenError)
+      end
+    end
+  end
+
+  describe "#all" do
+    it "return the list of elements" do
+      all = subject.all
+
+      expect(all).to eq(elements)
+    end
+  end
+
+  describe "#+" do
+    let(:other) { described_class.new(other_elements) }
+
+    let(:other_elements) { [other_element1, other_element2] }
+
+    let(:other_element1) { elements.first.copy }
+
+    let(:other_element2) { element_class.new("test") }
+
+    it "returns a new collection with all elements from both collections" do
+      all_ids = (subject.all + other.all).map(&:id)
+
+      collection = subject + other
+
+      expect(collection).to be_a(described_class)
+      expect(collection).to_not eq(subject)
+      expect(collection.map(&:id)).to contain_exactly(*all_ids)
+    end
+
+    it "does not modify the left operand collection" do
+      elements = subject.all
+
+      (subject + other)
+
+      expect(subject.all).to eq(elements)
+    end
+
+    it "does not modify the right operand collection" do
+      elements = other.all
+
+      (subject + other)
+
+      expect(other.all).to eq(elements)
+    end
+  end
+
+  describe "#without" do
+    it "returns a new collection excluding the elements with the given ids" do
+      ids = subject.map(&:id)
+
+      element = element_class.new("test")
+      subject.add(element)
+
+      collection = subject.without(ids)
+
+      expect(collection).to be_a(described_class)
+      expect(collection).to_not eq(subject)
+      expect(collection.map(&:id)).to contain_exactly(element.id)
+    end
+
+    context "when the collection does not contain an element with the given ids" do
+      let(:ids) { [element_class.new("test").id] }
+
+      it "returns a new collection with the same elements" do
+        collection = subject.without(ids)
+
+        expect(collection).to be_a(described_class)
+        expect(collection).to_not eq(subject)
+        expect(collection.all).to eq(subject.all)
+      end
+    end
+  end
+
+  describe "#changed_from" do
+    let(:other) { described_class.new(other_elements) }
+
+    let(:other_elements) { [other_element1, other_element2, other_element3] }
+
+    let(:other_element1) do
+      element = element1.copy
+      element.name = "other"
+      element
+    end
+
+    let(:other_element2) do
+      element = element2.copy
+      element.name = "other"
+      element
+    end
+
+    let(:other_element3) { element_class.new("test") }
+
+    it "returns a new collection with the modified elements from the other config" do
+      collection = subject.changed_from(other)
+
+      expect(collection).to be_a(described_class)
+      expect(collection).to_not eq(subject)
+      expect(collection.map(&:id)).to contain_exactly(element1.id, element2.id)
+    end
+
+    it "does not include elements that do not exist in the other config" do
+      collection = subject.changed_from(other)
+
+      expect(collection.map(&:id)).to_not include(element3.id)
+    end
+
+    it "does not include elements that only exist in the other config" do
+      collection = subject.changed_from(other)
+
+      expect(collection.map(&:id)).to_not include(other_element3.id)
+    end
+  end
+
+  describe "#include?" do
+    context "if the collection contains an element with the given id" do
+      let(:id) { element2.id }
+
+      it "returns true" do
+        expect(subject.include?(id)).to eq(true)
+      end
+    end
+
+    context "if the collection does not contain an element with the given id" do
+      let(:id) { element_class.new("test").id }
+
+      it "returns false" do
+        expect(subject.include?(id)).to eq(false)
+      end
+    end
+  end
+
+  describe "#by_id" do
+    context "if the collection contains an element with the given id" do
+      let(:id) { element2.id }
+
+      it "returns the element" do
+        result = subject.by_id(id)
+
+        expect(result).to be_a(element_class)
+        expect(result.id).to eq(element2.id)
+      end
+    end
+
+    context "if the collection does not contain an element with the given id" do
+      let(:id) { element_class.new("test").id }
+
+      it "returns nil" do
+        expect(subject.by_id(id)).to be_nil
+      end
+    end
+  end
+
+  describe "#ids" do
+    it "returns the ids of all the elements" do
+      ids = elements.map(&:id)
+
+      expect(subject.ids).to contain_exactly(*ids)
+    end
+  end
+end

--- a/test/lib/y2users/config_element_collection_examples.rb
+++ b/test/lib/y2users/config_element_collection_examples.rb
@@ -107,7 +107,7 @@ shared_examples "config element collection" do
   end
 
   describe "#all" do
-    it "return the list of elements" do
+    it "returns the list of elements" do
       all = subject.all
 
       expect(all).to eq(elements)
@@ -204,7 +204,7 @@ shared_examples "config element collection" do
       expect(collection.map(&:id)).to contain_exactly(element1.id, element2.id)
     end
 
-    it "does not include elements that do not exist in the other config" do
+    it "does not include elements that do not exist in the config" do
       collection = subject.changed_from(other)
 
       expect(collection.map(&:id)).to_not include(element3.id)

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -101,7 +101,7 @@ describe Y2Users::ConfigMerger do
         let(:lhs_users) { [lhs_user1, user3] }
 
         let(:lhs_user1) do
-          user = user1.clone
+          user = Y2Users::User.new("test1")
           user.uid = 1100
           user.gid = 110
           user.home = "/home/lhs_user1"
@@ -192,7 +192,7 @@ describe Y2Users::ConfigMerger do
         let(:lhs_groups) { [lhs_group1, group3] }
 
         let(:lhs_group1) do
-          group = group1.clone
+          group = Y2Users::Group.new("test1")
           group.gid = 110
           group.users_name = ["test1"]
           group

--- a/test/lib/y2users/config_test.rb
+++ b/test/lib/y2users/config_test.rb
@@ -32,7 +32,7 @@ describe Y2Users::Config do
 
     let(:users) { [] }
 
-    it "returns a immutable collection of users" do
+    it "returns an immutable collection of users" do
       users = subject.users
 
       expect(users).to be_a(Y2Users::UsersCollection)
@@ -71,7 +71,7 @@ describe Y2Users::Config do
 
     let(:groups) { [] }
 
-    it "returns a immutable collection of groups" do
+    it "returns an immutable collection of groups" do
       groups = subject.groups
 
       expect(groups).to be_a(Y2Users::GroupsCollection)

--- a/test/lib/y2users/config_test.rb
+++ b/test/lib/y2users/config_test.rb
@@ -30,11 +30,22 @@ describe Y2Users::Config do
       subject.attach(users)
     end
 
+    let(:users) { [] }
+
+    it "returns a immutable collection of users" do
+      users = subject.users
+
+      expect(users).to be_a(Y2Users::UsersCollection)
+      expect { users.add(Y2Users::User.new("test")) }.to raise_error(RuntimeError)
+    end
+
     context "when there are no attached users" do
       let(:users) { [] }
 
-      it "returns an empty list" do
-        expect(subject.users).to be_empty
+      it "returns an empty collection" do
+        users = subject.users
+
+        expect(users).to be_empty
       end
     end
 
@@ -47,10 +58,8 @@ describe Y2Users::Config do
 
       let(:users) { [user1, user2, user3] }
 
-      it "returns an immutable list with all the attached users" do
-        expect(subject.users).to contain_exactly(user1, user2, user3)
-
-        expect { subject.users << Y2Users::User.new("test") }.to raise_error(RuntimeError)
+      it "returns a collection with all the attached users" do
+        expect(subject.users.all).to contain_exactly(user1, user2, user3)
       end
     end
   end
@@ -60,10 +69,19 @@ describe Y2Users::Config do
       subject.attach(groups)
     end
 
+    let(:groups) { [] }
+
+    it "returns a immutable collection of groups" do
+      groups = subject.groups
+
+      expect(groups).to be_a(Y2Users::GroupsCollection)
+      expect { groups.add(Y2Users::User.new("test")) }.to raise_error(RuntimeError)
+    end
+
     context "when there are no attached groups" do
       let(:groups) { [] }
 
-      it "returns an empty list" do
+      it "returns an empty collection" do
         expect(subject.groups).to be_empty
       end
     end
@@ -77,10 +95,8 @@ describe Y2Users::Config do
 
       let(:groups) { [group1, group2, group3] }
 
-      it "returns an immutable list with all the attached groups" do
-        expect(subject.groups).to contain_exactly(group1, group2, group3)
-
-        expect { subject.groups << Y2Users::Group.new("test2") }.to raise_error(RuntimeError)
+      it "returns a collection with all the attached groups" do
+        expect(subject.groups.all).to contain_exactly(group1, group2, group3)
       end
     end
   end
@@ -92,34 +108,48 @@ describe Y2Users::Config do
 
     let(:group1) { Y2Users::Group.new("test1") }
 
-    it "attaches the given users and groups" do
+    it "adds the given elements to the collections of users and groups" do
       subject.attach(user1, user2, group1)
 
-      expect(subject.users).to contain_exactly(user1, user2)
+      expect(subject.users.all).to contain_exactly(user1, user2)
 
-      expect(subject.groups).to contain_exactly(group1)
+      expect(subject.groups.all).to contain_exactly(group1)
     end
 
-    it "assigns an unique id to the attached elements" do
-      subject.attach(user1, user2, group1)
+    it "assigns the config to the given elements" do
+      subject.attach(user1, group1)
 
-      expect(user1.id).to_not be_nil
-      expect(user2.id).to_not be_nil
-      expect(group1.id).to_not be_nil
-
-      ids = [user1, user2, group1].map(&:id)
-
-      expect(ids).to all(be_a(Integer))
-      expect(ids.uniq.size).to eq(3)
+      expect(user1.config).to eq(subject)
+      expect(group1.config).to eq(subject)
     end
 
-    context "if a given element is already attached" do
+    context "if a given element is already attached to the config" do
       before do
         subject.attach(user2)
       end
 
       it "raises an error" do
-        expect { subject.attach(user2) }.to raise_error(RuntimeError)
+        expect { subject.attach(user2) }.to raise_error(RuntimeError, /already attached/)
+      end
+    end
+
+    context "if a given element is already attached to another config" do
+      before do
+        described_class.new.attach(user2)
+      end
+
+      it "raises an error" do
+        expect { subject.attach(user2) }.to raise_error(RuntimeError, /already attached/)
+      end
+    end
+
+    context "if the given element has an id that already exists in the config" do
+      before do
+        subject.attach(user1)
+      end
+
+      it "raises an error" do
+        expect { subject.attach(user1.copy) }.to raise_error(RuntimeError, /already exists/)
       end
     end
   end
@@ -135,42 +165,33 @@ describe Y2Users::Config do
       subject.attach(user1, user2, group1)
     end
 
-    it "detaches the given users and groups" do
+    it "removes the given elements from the colletions of users and groups" do
       subject.detach(user2, group1)
 
-      expect(subject.users).to contain_exactly(user1)
+      expect(subject.users.all).to contain_exactly(user1)
 
       expect(subject.groups).to be_empty
     end
 
-    it "sets the given elements as detached" do
+    it "removes the config from the given elements" do
       subject.detach(user2, group1)
 
-      expect(user2.attached?).to eq(false)
+      expect(user2.config).to be_nil
 
-      expect(group1.attached?).to eq(false)
-    end
-
-    it "removes the id from the given elements" do
-      subject.detach(user2, group1)
-
-      expect(user2.id).to be_nil
-
-      expect(group1.id).to be_nil
+      expect(group1.config).to be_nil
     end
 
     it "does not modify the rest of elements" do
       subject.detach(user2, group1)
 
-      expect(user1.attached?).to eq(true)
-      expect(user1.id).to_not be_nil
+      expect(user1.config).to eq(subject)
     end
 
     context "if a given element is not attached yet" do
       let(:user3) { Y2Users::User.new("test3")  }
 
       it "raises an error" do
-        expect { subject.detach(user3) }.to raise_error(RuntimeError)
+        expect { subject.detach(user3) }.to raise_error(RuntimeError, /not attached/)
       end
     end
 
@@ -187,7 +208,7 @@ describe Y2Users::Config do
     end
   end
 
-  describe "#clone" do
+  describe "#copy" do
     before do
       subject.attach([user1, user2, group1, group2])
     end
@@ -201,31 +222,31 @@ describe Y2Users::Config do
     let(:group2) { Y2Users::Group.new("test2") }
 
     def find(config, element)
-      elements = config.users + config.groups
+      elements = config.users.all + config.groups.all
 
       elements.find { |e| e == element }
     end
 
     it "generates a new config object" do
-      config = subject.clone
+      config = subject.copy
 
       expect(config).to_not eq(subject)
     end
 
     it "copies all users from the current config" do
-      config = subject.clone
+      config = subject.copy
 
-      expect(config.users).to eq(subject.users)
+      expect(config.users.all).to eq(subject.users.all)
     end
 
     it "copies all groups from the current config" do
-      config = subject.clone
+      config = subject.copy
 
-      expect(config.groups).to eq(subject.groups)
+      expect(config.groups.all).to eq(subject.groups.all)
     end
 
     it "keeps the same users id" do
-      config = subject.clone
+      config = subject.copy
 
       config.users.each do |user|
         original_user = find(subject, user)
@@ -235,7 +256,7 @@ describe Y2Users::Config do
     end
 
     it "keeps the same groups id" do
-      config = subject.clone
+      config = subject.copy
 
       config.groups.each do |group|
         original_group = find(subject, group)
@@ -248,7 +269,7 @@ describe Y2Users::Config do
   describe "#merge" do
     before do
       subject.attach([user1, group1])
-      other.attach([user1.clone, user2, group2])
+      other.attach([user1.copy, user2, group2])
     end
 
     let(:other) { Y2Users::Config.new }
@@ -268,13 +289,13 @@ describe Y2Users::Config do
     end
 
     it "does not mofidify the current config" do
-      users = subject.users
-      groups = subject.groups
+      users = subject.users.all
+      groups = subject.groups.all
 
       subject.merge(other)
 
-      expect(subject.users).to eq(users)
-      expect(subject.groups).to eq(groups)
+      expect(subject.users.all).to eq(users)
+      expect(subject.groups.all).to eq(groups)
     end
 
     it "merges users from the given config into the users of the current config" do
@@ -297,7 +318,7 @@ describe Y2Users::Config do
   describe "#merge!" do
     before do
       subject.attach([user1, group1])
-      other.attach([user1.clone, user2, group2])
+      other.attach([user1.copy, user2, group2])
     end
 
     let(:other) { Y2Users::Config.new }
@@ -317,13 +338,13 @@ describe Y2Users::Config do
     end
 
     it "modifies the current config object" do
-      users = subject.users
-      groups = subject.groups
+      users = subject.users.all
+      groups = subject.groups.all
 
       subject.merge!(other)
 
-      expect(subject.users).to_not eq(users)
-      expect(subject.groups).to_not eq(groups)
+      expect(subject.users.all).to_not eq(users)
+      expect(subject.groups.all).to_not eq(groups)
     end
 
     it "merges users from the given config into the users of the current config" do

--- a/test/lib/y2users/group_test.rb
+++ b/test/lib/y2users/group_test.rb
@@ -120,7 +120,7 @@ describe Y2Users::Group do
       subject.source = [:ldap]
     end
 
-    let(:other) { subject.clone }
+    let(:other) { subject.copy }
 
     context "when all the attributes are equal" do
       it "returns true" do

--- a/test/lib/y2users/groups_collection_test.rb
+++ b/test/lib/y2users/groups_collection_test.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require_relative "config_element_collection_examples"
+require "y2users"
+require "y2users/groups_collection"
+
+describe Y2Users::GroupsCollection do
+  subject { described_class.new(elements) }
+
+  include_examples "config element collection"
+
+  let(:group1) { Y2Users::Group.new("test1") }
+  let(:group2) { Y2Users::Group.new("test2") }
+  let(:group3) { Y2Users::Group.new("test3") }
+
+  describe "#by_gid" do
+    let(:elements) { [group1, group2, group3] }
+
+    context "if the collection contains groups with the given gid" do
+      before do
+        group2.gid = 100
+        group3.gid = 100
+      end
+
+      it "returns a new collection with all the groups with the given gid" do
+        collection = subject.by_gid(100)
+
+        expect(collection).to be_a(Y2Users::GroupsCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection.ids).to contain_exactly(group2.id, group3.id)
+      end
+    end
+
+    context "if the collection does not contain groups with the given gid" do
+      it "returns a new empty collection" do
+        collection = subject.by_gid(100)
+
+        expect(collection).to be_a(Y2Users::GroupsCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection).to be_empty
+      end
+    end
+  end
+
+  describe "#by_name" do
+    context "if the collection contains a group with the given name" do
+      let(:elements) { [group1, group2, group3] }
+
+      it "returns the group with the given name" do
+        group = subject.by_name("test2")
+
+        expect(group).to be_a(Y2Users::Group)
+        expect(group.id).to eq(group2.id)
+      end
+    end
+
+    context "if the collection does not contain a user with the given name" do
+      let(:elements) { [group1, group3] }
+
+      it "returns nil" do
+        group = subject.by_name("test2")
+
+        expect(group).to be_nil
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -37,7 +37,7 @@ describe Y2Users::Linux::Writer do
       config
     end
 
-    let(:config) { initial_config.clone }
+    let(:config) { initial_config.copy }
 
     let(:users) { [] }
 

--- a/test/lib/y2users/password_test.rb
+++ b/test/lib/y2users/password_test.rb
@@ -45,7 +45,7 @@ describe Y2Users::Password do
     end
   end
 
-  describe "#clone" do
+  describe "#copy" do
     subject { described_class.create_plain("S3cr3T") }
 
     before do
@@ -54,14 +54,14 @@ describe Y2Users::Password do
     end
 
     it "generates a new password with the same values" do
-      password = subject.clone
+      password = subject.copy
 
       expect(password).to be_a(Y2Users::Password)
       expect(password).to eq(subject)
     end
 
     it "generates a new password with an independent password value" do
-      password = subject.clone
+      password = subject.copy
 
       password.value.content = "other"
 
@@ -81,7 +81,7 @@ describe Y2Users::Password do
       subject.account_expiration = Date.today + 100
     end
 
-    let(:other) { subject.clone }
+    let(:other) { subject.copy }
 
     context "when all the attributes are equal" do
       it "returns true" do

--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -245,7 +245,7 @@ describe Y2Users::User do
       subject.password = Y2Users::Password.create_plain("S3cr3T")
     end
 
-    let(:other) { subject.clone }
+    let(:other) { subject.copy }
 
     context "when all the attributes are equal" do
       it "returns true" do

--- a/test/lib/y2users/users_collection_test.rb
+++ b/test/lib/y2users/users_collection_test.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require_relative "config_element_collection_examples"
+require "y2users"
+require "y2users/users_collection"
+
+describe Y2Users::UsersCollection do
+  subject { described_class.new(elements) }
+
+  include_examples "config element collection"
+
+  let(:user1) { Y2Users::User.new("test1") }
+  let(:user2) { Y2Users::User.new("test2") }
+  let(:user3) { Y2Users::User.new("test3") }
+
+  describe "#root" do
+    context "if the collection contains a root user" do
+      let(:elements) { [user1, root, user3] }
+
+      let(:root) { Y2Users::User.new("root") }
+
+      it "returns the root user" do
+        expect(subject.root).to be_a(Y2Users::User)
+        expect(subject.root.id).to eq(root.id)
+      end
+    end
+
+    context "if the collection does not contain a root user" do
+      let(:elements) { [user1, user2, user3] }
+
+      it "returns nil" do
+        expect(subject.root).to be_nil
+      end
+    end
+  end
+
+  describe "#system" do
+    let(:elements) { [user1, user2, user3] }
+
+    context "if the collection contains system users" do
+      before do
+        user1.system = true
+        user2.system = false
+        user3.system = true
+      end
+
+      it "returns a new collection with all the system users" do
+        collection = subject.system
+
+        expect(collection).to be_a(Y2Users::UsersCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection.ids).to contain_exactly(user1.id, user3.id)
+      end
+    end
+
+    context "if the collection does not contain system users" do
+      before do
+        user1.system = false
+        user2.system = false
+        user3.system = false
+      end
+
+      it "returns a new empty collection" do
+        collection = subject.system
+
+        expect(collection).to be_a(Y2Users::UsersCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection).to be_empty
+      end
+    end
+  end
+
+  describe "#by_uid" do
+    let(:elements) { [user1, user2, user3] }
+
+    context "if the collection contains users with the given uid" do
+      before do
+        user2.uid = 1000
+        user3.uid = 1000
+      end
+
+      it "returns a new collection with all the users with the given uid" do
+        collection = subject.by_uid(1000)
+
+        expect(collection).to be_a(Y2Users::UsersCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection.ids).to contain_exactly(user2.id, user3.id)
+      end
+    end
+
+    context "if the collection does not contain users with the given uid" do
+      it "returns a new empty collection" do
+        collection = subject.by_uid(1000)
+
+        expect(collection).to be_a(Y2Users::UsersCollection)
+        expect(collection).to_not eq(subject)
+        expect(collection).to be_empty
+      end
+    end
+  end
+
+  describe "#by_name" do
+    context "if the collection contains a user with the given name" do
+      let(:elements) { [user1, user2, user3] }
+
+      it "returns the user with the given name" do
+        user = subject.by_name("test2")
+
+        expect(user).to be_a(Y2Users::User)
+        expect(user.id).to eq(user2.id)
+      end
+    end
+
+    context "if the collection does not contain a user with the given name" do
+      let(:elements) { [user1, user3] }
+
+      it "returns nil" do
+        user = subject.by_name("test2")
+
+        expect(user).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The API for `Y2Users::Config` provides methods like `#users` and `#groups` which return a ruby *Array*. That arrays are usually walked though in order to get some specific elements. For example, to select the *root* user.

These methods should return richer objects like collections which can be easily queried.


## Solution

Methods like `#users` and `#groups` now return collection classes instead of plain arrays. New classes added: `UsersCollection` and `GroupsCollection`.

Other internal changes:

* Overloaded `#clone` was replaced by `#copy`: `#clone` is kept with its original version (shallow copy) and new `#copy` performs a deep copy.
* `User` and `Group` objects always have an internal id, even for recently created objects that have not been attached yet.
