### PR TITLE
Improve readers API

### DIFF
--- a/src/lib/users/clients/users_finish.rb
+++ b/src/lib/users/clients/users_finish.rb
@@ -145,13 +145,7 @@ module Yast
     #
     # @return [Y2Users::Config]
     def users_simple_config
-      return @users_simple_config if @user_simple_config
-
-      config = Y2Users::Config.new
-      reader = Y2Users::UsersSimple::Reader.new
-      reader.read_to(config)
-
-      @users_simple_config = config
+      @users_simple_config ||= Y2Users::UsersSimple::Reader.new.read
     end
 
     # Reports issues

--- a/src/lib/users/users_database.rb
+++ b/src/lib/users/users_database.rb
@@ -96,8 +96,7 @@ module Users
       shadow = File.join(dir, "shadow")
       return unless File.exist?(passwd) && File.exist?(shadow)
 
-      @config = Y2Users::Config.new
-      Y2Users::Linux::LocalReader.new(root_dir).read_to(config)
+      @config = Y2Users::Linux::LocalReader.new(root_dir).read
 
       self.atime = [File.atime(passwd), File.atime(shadow)].max
     end

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -73,8 +73,11 @@ module Y2Users
     # in the config, see {#attach_element}.
     #
     # @param elements [Array<ConfigElement>]
+    # @return [self]
     def attach(*elements)
       elements.flatten.each { |e| attach_element(e) }
+
+      self
     end
 
     # Detaches users and groups from this config
@@ -82,8 +85,11 @@ module Y2Users
     # The given users and groups must be attached to this config, see {#detach_element}.
     #
     # @param elements [Array<ConfigElement>]
+    # @return [self]
     def detach(*elements)
       elements.flatten.each { |e| detach_element(e) }
+
+      self
     end
 
     # Generates a deep copy of the config

--- a/src/lib/y2users/config_element_collection.rb
+++ b/src/lib/y2users/config_element_collection.rb
@@ -24,7 +24,7 @@ module Y2Users
   class ConfigElementCollection
     extend Forwardable
 
-    def_delegators :@elements, :each, :select, :find, :reject, :map, :any?, :size, :empty?
+    def_delegators :@elements, :each, :select, :find, :reject, :map, :any?, :size, :empty?, :first
 
     # Constructor
     #

--- a/src/lib/y2users/config_manager.rb
+++ b/src/lib/y2users/config_manager.rb
@@ -62,25 +62,24 @@ module Y2Users
     end
 
     # Gets system configuration.
-    # @param [#read_to(config)] reader used to read system configuration.
+    # @param [#read] reader used to read system configuration.
     #   If not specified it will decide itself which one to use.
     # @param [Boolean] force_read if it can get previous result of system or
     #   force re-read from system.
     # @return [Config]
     def system(reader: nil, force_read: false)
-      res = config(:system)
-      return res if res && !force_read
+      config = config(:system)
+      return config if config && !force_read
 
       if !reader
         require "y2users/linux/reader"
         reader = Linux::Reader.new
       end
 
-      res = Config.new
-      reader.read_to(res)
-      register(res, as: :system)
+      config = reader.read
+      register(config, as: :system)
 
-      res
+      config
     end
   end
 end

--- a/src/lib/y2users/inst_users_dialog_helper.rb
+++ b/src/lib/y2users/inst_users_dialog_helper.rb
@@ -39,13 +39,9 @@ module Y2Users
 
     # Config object holding the users and passwords to create
     #
-    # @return [Y2Users::Config]
+    # @return [Config]
     def users_config
-      return @users_config if @users_config
-
-      @users_config = Y2Users::Config.new
-      Y2Users::UsersSimple::Reader.new.read_to(@users_config)
-      @users_config
+      @users_config ||= UsersSimple::Reader.new.read
     end
 
     # All users to be created

--- a/src/lib/y2users/linux/local_reader.rb
+++ b/src/lib/y2users/linux/local_reader.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2users/config"
 require "y2users/parsers/group"
 require "y2users/parsers/passwd"
 require "y2users/parsers/shadow"
@@ -31,10 +32,18 @@ module Y2Users
         @source_dir = source_dir
       end
 
-      def read_to(config)
-        config.attach(read_users + read_groups)
+      # Generates a new config with the users and groups from the /etc files
+      #
+      # @return [Config]
+      def read
+        elements = read_users + read_groups
+
+        config = Config.new.attach(elements)
+
         # read passwords after user, as user has to exist in advance
         read_passwords(config)
+
+        config
       end
 
     private
@@ -61,7 +70,7 @@ module Y2Users
 
         passwords = parser.parse(content)
         passwords.each_pair do |name, password|
-          user = config.users.find { |u| u.name == name }
+          user = config.users.by_name(name)
           if !user
             log.warn "Found password for non existing user #{password.name}."
             next

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2users/config"
 require "y2users/user"
 require "y2users/password"
 require "y2users/parsers/shadow"
@@ -36,15 +37,13 @@ module Y2Users
       ].freeze
       private_constant :SORTED_SHADOW_ATTRS
 
-      # Attaches users to given configuration
+      # Generates a new config with the users from YaST::UsersSimple module
       #
-      # @param config [Config]
-      def read_to(config)
-        # Read new users
-        config.attach(users)
+      # @return [Config]
+      def read
+        elements = [root_user] + users
 
-        # Read also root user settings
-        config.attach(root_user)
+        Config.new.attach(elements)
       end
 
     private

--- a/test/lib/y2users/config_manager_test.rb
+++ b/test/lib/y2users/config_manager_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2021] SUSE LLC
 #
 # All Rights Reserved.

--- a/test/lib/y2users/config_test.rb
+++ b/test/lib/y2users/config_test.rb
@@ -123,6 +123,12 @@ describe Y2Users::Config do
       expect(group1.config).to eq(subject)
     end
 
+    it "returns the config" do
+      result = subject.attach(user1, group1)
+
+      expect(result).to eq(subject)
+    end
+
     context "if a given element is already attached to the config" do
       before do
         subject.attach(user2)
@@ -185,6 +191,12 @@ describe Y2Users::Config do
       subject.detach(user2, group1)
 
       expect(user1.config).to eq(subject)
+    end
+
+    it "returns the config" do
+      result = subject.detach(user2, group1)
+
+      expect(result).to eq(subject)
     end
 
     context "if a given element is not attached yet" do

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -27,10 +27,11 @@ require "y2users/linux/local_reader"
 describe Y2Users::Linux::LocalReader do
   subject { described_class.new(File.join(FIXTURES_PATH, "/root/")) }
 
-  describe "#read_to" do
-    it "fills given config with read data" do
-      config = Y2Users::Config.new
-      subject.read_to(config)
+  describe "#read" do
+    it "generates a config with read data" do
+      config = subject.read
+
+      expect(config).to be_a(Y2Users::Config)
 
       expect(config.users.size).to eq 18
       expect(config.groups.size).to eq 37

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -40,15 +40,16 @@ describe Y2Users::Linux::Reader do
       .and_return(shadow_content)
   end
 
-  describe "#read_to" do
-    it "fills given config with read data" do
-      config = Y2Users::Config.new
-      subject.read_to(config)
+  describe "#read" do
+    it "generates a config with read data" do
+      config = subject.read
+
+      expect(config).to be_a(Y2Users::Config)
 
       expect(config.users.size).to eq 18
       expect(config.groups.size).to eq 37
 
-      root_user = config.users.find { |u| u.uid == "0" }
+      root_user = config.users.by_uid("0").first
       expect(root_user.shell).to eq "/bin/bash"
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true


### PR DESCRIPTION
## Problem

Currently, readers offer a `#read_to` method which receives a config argument. But having a config parameter is not needed and it could cause misunderstandings.  For example, what happens with the elements that the given config already has? Should the reader draw its elements off before reading? Should the current elements be updated somehow?


## Solution

Improve the API by removing the config parameter. Now the `#read` method always generates a new config.
 