### PR TITLE
Manage useradd configuration

### DIFF
--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -32,8 +32,8 @@ BuildRequires:  gcc-c++
 BuildRequires:  libtool
 BuildRequires:  perl-Digest-SHA1
 BuildRequires:  update-desktop-files
-# Yast2::Equatable
-BuildRequires:  yast2 >= 4.4.5
+# Support for umask in Yast::ShadowConfig
+BuildRequires:  yast2 >= 4.4.6
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-perl-bindings
@@ -57,8 +57,8 @@ Requires:       yast2-perl-bindings >= 2.18.0
 # this forces using yast2-ldap with correct LDAP object names (fate#303596)
 Requires:       yast2-ldap >= 3.1.2
 
-# Yast2::SecretAttributes
-Requires:       yast2 >= 4.4.2
+# Support for umask in Yast::ShadowConfig
+Requires:       yast2 >= 4.4.6
 # cryptsha256, cryptsha516
 Requires:       yast2-core >= 2.21.0
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,6 +110,8 @@ ylib_y2users_clients_DATA = \
 
 ylib_y2users_linuxdir = @ylibdir@/y2users/linux
 ylib_y2users_linux_DATA = \
+  lib/y2users/linux/useradd_config_reader.rb \
+  lib/y2users/linux/useradd_config_writer.rb \
   lib/y2users/linux/base_reader.rb \
   lib/y2users/linux/local_reader.rb \
   lib/y2users/linux/reader.rb \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ ylib_y2users_DATA = \
   lib/y2users/password_validator.rb \
   lib/y2users/shadow_date.rb \
   lib/y2users/user.rb \
+  lib/y2users/useradd_config.rb \
   lib/y2users/users_simple.rb \
   lib/y2users/user_validator.rb \
   lib/y2users/validation_config.rb \

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -102,6 +102,7 @@ module Y2Users
 
       config = self.class.new
       config.attach(elements)
+      config.useradd_config = useradd_config.dup
       config
     end
 
@@ -124,6 +125,11 @@ module Y2Users
 
       self
     end
+
+    # Useradd configuration to be applied to the system before creating the users
+    #
+    # @return [UseraddConfig, nil] nil if the configuration is unknown
+    attr_accessor :useradd_config
 
   private
 

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -102,7 +102,7 @@ module Y2Users
 
       config = self.class.new
       config.attach(elements)
-      config.useradd_config = useradd_config.dup
+      config.useradd = useradd.dup
       config
     end
 
@@ -129,7 +129,7 @@ module Y2Users
     # Useradd configuration to be applied to the system before creating the users
     #
     # @return [UseraddConfig, nil] nil if the configuration is unknown
-    attr_accessor :useradd_config
+    attr_accessor :useradd
 
   private
 

--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -22,6 +22,7 @@ require "y2users/config"
 require "y2users/parsers/group"
 require "y2users/parsers/passwd"
 require "y2users/parsers/shadow"
+require "y2users/linux/useradd_config_reader"
 require "users/ssh_authorized_keyring"
 
 module Y2Users
@@ -40,6 +41,7 @@ module Y2Users
 
         read_passwords(config)
         read_authorized_keys(config)
+        read_useradd_config(config)
 
         config
       end
@@ -105,6 +107,13 @@ module Y2Users
 
           user.authorized_keys = Yast::Users::SSHAuthorizedKeyring.new(user.home).read_keys
         end
+      end
+
+      # Reads the configuration for useradd
+      #
+      # @param config [Config]
+      def read_useradd_config(config)
+        config.useradd_config = UseraddConfigReader.new.read
       end
     end
   end

--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -113,7 +113,7 @@ module Y2Users
       #
       # @param config [Config]
       def read_useradd_config(config)
-        config.useradd_config = UseraddConfigReader.new.read
+        config.useradd = UseraddConfigReader.new.read
       end
     end
   end

--- a/src/lib/y2users/linux/useradd_config_reader.rb
+++ b/src/lib/y2users/linux/useradd_config_reader.rb
@@ -1,0 +1,88 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+require "y2users/useradd_config"
+
+module Y2Users
+  module Linux
+    # Reads the useradd configuration from the current system
+    class UseraddConfigReader
+      include Yast::Logger
+      Yast.import "ShadowConfig"
+
+      # Creates a {UseraddConfig} object with the system configuration
+      #
+      # @return [UseraddConfig]
+      def read
+        attrs = read_shadow_config.merge(read_useradd)
+        UseraddConfig.new(attrs)
+      end
+
+    private
+
+      # Command for reading the useradd default values
+      USERADD = "/usr/sbin/useradd".freeze
+      private_constant :USERADD
+
+      # Mapping between useradd keys and {UseraddConfig} attributes
+      USERADD_ATTRS = {
+        group:             "GROUP",
+        home:              "HOME",
+        inactivity_period: "INACTIVE",
+        expiration:        "EXPIRE",
+        shell:             "SHELL",
+        skel:              "SKEL",
+        usrskel:           "USRSKEL",
+        create_mail_spool: "CREATE_MAIL_SPOOL"
+      }.freeze
+      private_constant :USERADD_ATTRS
+
+      # Values from "useradd -D"
+      #
+      # @return [Hash]
+      def read_useradd
+        output = Yast::Execute.on_target!(USERADD, "-D", stdout: :capture)
+        values = output.lines.map(&:strip).map { |line| line.split("=", -1) }.to_h
+        USERADD_ATTRS.keys.map { |attr| [attr, useradd_value(values, attr)] }.to_h
+      rescue Cheetah::ExecutionFailed => e
+        log.warn("Failed to read useradd default values' - #{e.message}")
+        {}
+      end
+
+      # @see #read_useradd
+      def useradd_value(values, attr)
+        value = values[USERADD_ATTRS[attr]]
+        return value unless [:inactivity_period, :create_mail_spool].include?(attr)
+
+        return value.to_i if attr == :inactivity_period
+
+        value == "yes"
+      end
+
+      # Values from login.defs
+      #
+      # @return [Hash]
+      def read_shadow_config
+        { umask: Yast::ShadowConfig.fetch(:umask) }
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/useradd_config_reader.rb
+++ b/src/lib/y2users/linux/useradd_config_reader.rb
@@ -70,11 +70,15 @@ module Y2Users
       # @see #read_useradd
       def useradd_value(values, attr)
         value = values[USERADD_ATTRS[attr]]
-        return value unless [:inactivity_period, :create_mail_spool].include?(attr)
 
-        return value.to_i if attr == :inactivity_period
-
-        value == "yes"
+        case attr
+        when :inactivity_period
+          value.to_i
+        when :create_mail_spool
+          value == "yes"
+        else
+          value
+        end
       end
 
       # Values from login.defs

--- a/src/lib/y2users/linux/useradd_config_writer.rb
+++ b/src/lib/y2users/linux/useradd_config_writer.rb
@@ -31,8 +31,8 @@ module Y2Users
 
       # Constructor
       #
-      # @param config [Y2User::Config] see #config
-      # @param initial_config [Y2User::Config] see #initial_config
+      # @param config [Config] see #config
+      # @param initial_config [Config] see #initial_config
       def initialize(config, initial_config)
         textdomain "y2users"
 
@@ -52,25 +52,25 @@ module Y2Users
 
       # General configuration object containing the useradd configuration to apply to the system
       #
-      # @return [Y2User::Config]
+      # @return [Config]
       attr_reader :config
 
-      # Initial state of the system (usually a Y2User::Config.system in a running system) that will
+      # Initial state of the system (usually a Y2Users::Config.system in a running system) that will
       # be compared with {#config} to know what changes need to be performed.
       #
-      # @return [Y2User::Config]
+      # @return [Config]
       attr_reader :initial_config
 
       # Object containing the useradd configuration
       #
-      # @return [Y2User::UseraddConfig]
+      # @return [UseraddConfig]
       def useradd_config
         config&.useradd_config
       end
 
       # Object containing the useradd configuration fron the initial state
       #
-      # @return [Y2User::UseraddConfig]
+      # @return [UseraddConfig]
       def initial_useradd_config
         initial_config&.useradd_config
       end

--- a/src/lib/y2users/linux/useradd_config_writer.rb
+++ b/src/lib/y2users/linux/useradd_config_writer.rb
@@ -65,14 +65,14 @@ module Y2Users
       #
       # @return [UseraddConfig]
       def useradd_config
-        config&.useradd_config
+        config&.useradd
       end
 
       # Object containing the useradd configuration fron the initial state
       #
       # @return [UseraddConfig]
       def initial_useradd_config
-        initial_config&.useradd_config
+        initial_config&.useradd
       end
 
       # Value for the given attribute in the target useradd configuration

--- a/src/lib/y2users/linux/useradd_config_writer.rb
+++ b/src/lib/y2users/linux/useradd_config_writer.rb
@@ -34,7 +34,7 @@ module Y2Users
       # @param config [Config] see #config
       # @param initial_config [Config] see #initial_config
       def initialize(config, initial_config)
-        textdomain "y2users"
+        textdomain "users"
 
         @config = config
         @initial_config = initial_config

--- a/src/lib/y2users/linux/useradd_config_writer.rb
+++ b/src/lib/y2users/linux/useradd_config_writer.rb
@@ -1,0 +1,174 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/execute"
+
+module Y2Users
+  module Linux
+    # Configures useradd in the target system according to a given {UseraddConfig} object
+    class UseraddConfigWriter
+      include Yast::I18n
+      include Yast::Logger
+      Yast.import "ShadowConfig"
+
+      # Constructor
+      #
+      # @param config [Y2User::Config] see #config
+      # @param initial_config [Y2User::Config] see #initial_config
+      def initialize(config, initial_config)
+        textdomain "y2users"
+
+        @config = config
+        @initial_config = initial_config
+      end
+
+      # Performs the changes in the system
+      #
+      # @param issues [Y2Issues::List] the list of issues found while writing changes
+      def write(issues)
+        write_useradd(issues)
+        write_shadow_config
+      end
+
+    private
+
+      # General configuration object containing the useradd configuration to apply to the system
+      #
+      # @return [Y2User::Config]
+      attr_reader :config
+
+      # Initial state of the system (usually a Y2User::Config.system in a running system) that will
+      # be compared with {#config} to know what changes need to be performed.
+      #
+      # @return [Y2User::Config]
+      attr_reader :initial_config
+
+      # Object containing the useradd configuration
+      #
+      # @return [Y2User::UseraddConfig]
+      def useradd_config
+        config&.useradd_config
+      end
+
+      # Object containing the useradd configuration fron the initial state
+      #
+      # @return [Y2User::UseraddConfig]
+      def initial_useradd_config
+        initial_config&.useradd_config
+      end
+
+      # Value for the given attribute in the target useradd configuration
+      #
+      # @param attr [Symbol]
+      def value(attr)
+        useradd_config&.public_send(attr)
+      end
+
+      # Value for the given attribute in the initial useradd configuration
+      #
+      # @param attr [Symbol]
+      def initial_value(attr)
+        initial_useradd_config&.public_send(attr)
+      end
+
+      # Command for writing the useradd default values
+      USERADD = "/usr/sbin/useradd".freeze
+      private_constant :USERADD
+
+      # Mapping between {UseraddConfig} attributes and useradd arguments
+      USERADD_ATTRS = {
+        group:             "--gid",
+        home:              "--base-dir",
+        shell:             "--shell",
+        expiration:        "--expiredate",
+        inactivity_period: "--inactive"
+      }.freeze
+      private_constant :USERADD_ATTRS
+
+      # Writes the attributes that are handled via "useradd -D"
+      #
+      # @param issues [Y2Issues::List]
+      def write_useradd(issues)
+        return unless write_useradd?
+
+        # Instead of modifying directly the /etc/default/useradd file using the agent
+        # etc.default.useradd, we rely on "useradd -D". That should be more future-proof because:
+        #   - It should keep working if some of the parameters is moved to another file
+        #   - It will report an issue if we write a value that useradd considers to be wrong
+        #
+        # useradd allows to specify several default values at one shot like this:
+        #   useradd -D --base-dir /people --gid users --shell /bin/zsh
+        # But that works on a all-or-nothing fashion, ie. if one of the values is wrong (eg. the
+        # group "users" does not exist) none of the values is written
+        #
+        # To reduce the impact of a wrong value, let's change them one by one
+        USERADD_ATTRS.each do |attr, arg_name|
+          configure_useradd_attr(attr, arg_name, issues)
+        end
+      end
+
+      # Whether executing "useradd -D" is really needed
+      #
+      # @return [Boolean]
+      def write_useradd?
+        return false if useradd_config.nil?
+        return true if initial_useradd_config.nil?
+
+        USERADD_ATTRS.keys.any? { |attr| value(attr) != initial_value(attr) }
+      end
+
+      # Writes the attributes that are handled via login.defs
+      def write_shadow_config
+        return unless write_shadow_config?
+
+        Yast::ShadowConfig.set(:umask, value(:umask))
+        Yast::ShadowConfig.write
+      end
+
+      # Whether writing to login.defs is really needed
+      #
+      # @return [Boolean]
+      def write_shadow_config?
+        return false if value(:umask).nil?
+
+        value(:umask) != initial_value(:umask)
+      end
+
+      # @see #write_useradd
+      #
+      # @param attr [Symbol]
+      # @param arg [String]
+      # @param issues [Y2Issues::List]
+      def configure_useradd_attr(attr, arg, issues)
+        value = value(attr)
+        return if value.nil?
+
+        Yast::Execute.on_target!(USERADD, "-D", arg, value)
+      rescue Cheetah::ExecutionFailed => e
+        issues << Y2Issues::Issue.new(
+          # TRANSLATORS: %s is the name of one of the useradd default values, like 'HOME' or 'GROUP'
+          format(_("Something went wrong writing the useradd default for '%s'"), arg)
+        )
+        log.error("Error configuring useradd' - #{e.message}")
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -85,8 +85,8 @@ module Y2Users
       include Yast::Logger
       # Constructor
       #
-      # @param config [Y2User::Config] see #config
-      # @param initial_config [Y2User::Config] see #initial_config
+      # @param config [Config] see #config
+      # @param initial_config [Config] see #initial_config
       def initialize(config, initial_config)
         textdomain "users"
 
@@ -143,13 +143,13 @@ module Y2Users
 
       # Configuration containing the users and groups that should exist in the system after writing
       #
-      # @return [Y2User::Config]
+      # @return [Config]
       attr_reader :config
 
-      # Initial state of the system (usually a Y2User::Config.system in a running system) that will
+      # Initial state of the system (usually a Y2Users::Config.system in a running system) that will
       # be compared with {#config} to know what changes need to be performed.
       #
-      # @return [Y2User::Config]
+      # @return [Config]
       attr_reader :initial_config
 
       # Writes the useradd configuration to the system
@@ -221,7 +221,7 @@ module Y2Users
 
       # Executes the command for creating the group
       #
-      # @param group [Y2User::Group] the group to be created on the system
+      # @param group [Group] the group to be created on the system
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def add_group(group, issues)
         args = []
@@ -237,7 +237,7 @@ module Y2Users
 
       # Executes the command for creating the user
       #
-      # @param user [Y2User::User] the user to be created on the system
+      # @param user [User] the user to be created on the system
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def add_user(user, issues)
         Yast::Execute.on_target!(USERADD, *useradd_options(user))
@@ -253,7 +253,7 @@ module Y2Users
       # Executes the commands for setting the password and all its associated
       # attributes for the given user
       #
-      # @param user [Y2User::User]
+      # @param user [User]
       # @param issues [Y2Issues::List] a collection for adding issues if something goes wrong
       def change_password(user, issues)
         set_password_value(user, issues)
@@ -264,7 +264,7 @@ module Y2Users
       #
       # @see Yast::Users::SSHAuthorizedKeyring#write_keys
       #
-      # @param user [Y2User::User]
+      # @param user [User]
       # @param issues [Y2Issues::List] a collection for adding issues if something goes wrong
       def write_auth_keys(user, issues)
         return unless user.home
@@ -280,7 +280,7 @@ module Y2Users
 
       # Executes the command for setting the password of given user
       #
-      # @param user [Y2User::User]
+      # @param user [User]
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def set_password_value(user, issues)
         return unless user.password&.value
@@ -296,7 +296,7 @@ module Y2Users
 
       # Executes the command for setting the dates and limits in /etc/shadow
       #
-      # @param user [Y2User::User]
+      # @param user [User]
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def set_password_attributes(user, issues)
         return unless user.password
@@ -319,8 +319,8 @@ module Y2Users
 
       # Edits the user
       #
-      # @param new_user [Y2Users::User] User containing the updated information
-      # @param old_user [Y2Users::User] Original user
+      # @param new_user [User] User containing the updated information
+      # @param old_user [User] Original user
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def edit_user(new_user, old_user, issues)
         usermod_changes = USERMOD_ATTRS.any? do |attr|
@@ -341,7 +341,7 @@ module Y2Users
 
       # Generates and returns the options expected by `useradd` for given user
       #
-      # @param user [Y2Users::User]
+      # @param user [User]
       # @return [Array<String>]
       def useradd_options(user)
         opts = {
@@ -366,8 +366,8 @@ module Y2Users
 
       # Command to modity the user
       #
-      # @param new_user [Y2Users::User] User containing the updated information
-      # @param old_user [Y2Users::User] Original user
+      # @param new_user [User] User containing the updated information
+      # @param old_user [User] Original user
       # @return [Array<String>] usermod options
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/AbcSize
@@ -396,7 +396,7 @@ module Y2Users
 
       # Options for `useradd` to create the home directory
       #
-      # @param _user [Y2Users::User]
+      # @param _user [User]
       # @return [Array<String>]
       def create_home_options(_user)
         # TODO: "--btrfs-subvolume-home" if needed
@@ -405,7 +405,7 @@ module Y2Users
 
       # Generates and returns the options expected by `chpasswd` for the given user
       #
-      # @param user [Y2Users::User]
+      # @param user [User]
       # @return [Array<String, Hash>]
       def chpasswd_options(user)
         opts = []
@@ -419,7 +419,7 @@ module Y2Users
 
       # Generates and returns the options expected by `chage` for the given user
       #
-      # @param user [Y2Users::User]
+      # @param user [User]
       # @return [Array<String>]
       def chage_options(user)
         passwd = user.password

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -101,7 +101,9 @@ module Y2Users
         issues = Y2Issues::List.new
 
         add_groups(issues)
-        # Configure useradd after creating the groups, to make sure the default group exists already
+        # Useradd must be configured before creating the users (for obvious reasons) but after
+        # creating the groups (in order to set a group as the default one for useradd, that group
+        # must already exist in the system)
         write_useradd_config(issues)
         add_users(issues)
         edit_users(issues)

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues"
 require "users/ssh_authorized_keyring"
+require "y2users/linux/useradd_config_writer"
 
 module Y2Users
   module Linux
@@ -100,6 +101,8 @@ module Y2Users
         issues = Y2Issues::List.new
 
         add_groups(issues)
+        # Configure useradd after creating the groups, to make sure the default group exists already
+        write_useradd_config(issues)
         add_users(issues)
         edit_users(issues)
 
@@ -148,6 +151,13 @@ module Y2Users
       #
       # @return [Y2User::Config]
       attr_reader :initial_config
+
+      # Writes the useradd configuration to the system
+      #
+      # @param issues [Y2Issues::List]
+      def write_useradd_config(issues)
+        UseraddConfigWriter.new(config, initial_config).write(issues)
+      end
 
       # Command for creating new users
       USERADD = "/usr/sbin/useradd".freeze

--- a/src/lib/y2users/useradd_config.rb
+++ b/src/lib/y2users/useradd_config.rb
@@ -52,10 +52,6 @@ module Y2Users
   # The "groups", "no_groups" and "skel" attributes from the profile may still be honored by
   # AutoYaST when creating users by any other mechanism other than UseraddConfig.
   class UseraddConfig
-    # @see .writable_attributes
-    WRITABLE_ATTRIBUTES = [:group, :home, :umask, :expiration, :inactivity_period, :shell].freeze
-    private_constant :WRITABLE_ATTRIBUTES
-
     class << self
       # Names of the attributes that can be persisted to the configuration of the system and thus
       # can be used to really modify the default useradd behavior
@@ -64,20 +60,22 @@ module Y2Users
       #
       # @return [Array<Symbol>]
       def writable_attributes
-        WRITABLE_ATTRIBUTES.dup
+        @writable_attributes.dup
       end
 
     private
 
-      # Internal class method to automatically define the setters for all writable attributes
-      def define_setters
-        WRITABLE_ATTRIBUTES.each do |attr|
-          attr_writer attr
-        end
+      # Internal class method to define the setter for a writable attribute
+      # @param [String] name of the attribute
+      # @!macro [attach] attr_setter
+      #   @!attribute [w] $1
+      def attr_setter(name)
+        @writable_attributes ||= []
+        @writable_attributes << name.to_sym
+
+        attr_writer name
       end
     end
-
-    define_setters
 
     # Constructor
     #
@@ -103,6 +101,7 @@ module Y2Users
     #
     # @return [String, nil]
     attr_reader :group
+    attr_setter :group
 
     # This value is used as prefix to calculate the home directory for a new user, if no home
     # directory has been specified
@@ -113,6 +112,7 @@ module Y2Users
     #
     # @return [String, nil]
     attr_reader :home
+    attr_setter :home
 
     # The file mode mask used to create new home directories, if HOME_MODE is not specified in
     # login.defs
@@ -129,6 +129,7 @@ module Y2Users
     #
     # @return [String, nil]
     attr_reader :umask
+    attr_setter :umask
 
     # Password expiration date to use when creating a user, if none was set
     #
@@ -139,6 +140,7 @@ module Y2Users
     #
     # @return [String, nil]
     attr_reader :expiration
+    attr_setter :expiration
 
     # Inactivity period to set when creating a user, if none was set
     #
@@ -148,6 +150,7 @@ module Y2Users
     #
     # @return [Integer, nil]
     attr_reader :inactivity_period
+    attr_setter :inactivity_period
 
     # Login shell to set for a newly created user, if none was specified
     #
@@ -155,6 +158,7 @@ module Y2Users
     #
     # @return [String, nil]
     attr_reader :shell
+    attr_setter :shell
 
     # Skeleton directory from which the files will be copied when creating a home directory for
     # a new user

--- a/src/lib/y2users/useradd_config.rb
+++ b/src/lib/y2users/useradd_config.rb
@@ -1,0 +1,186 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Users
+  # Class to represent the configuration of useradd
+  #
+  # Most attributes correspond to the so-called default values managed by "useradd -D" and
+  # traditionally stored at /etc/default/useradd, but there can be exceptions. For example, the
+  # attribute "umask" is handled by this class because it was originally a regular useradd
+  # default value. If in doubt, check the documentation of each attribute.
+  #
+  # Attributes can be nil to indicate the value is unknown or irrelevant. That can happen if the
+  # UseraddConfig object is constructed from an AutoYaST profile.
+  #
+  # When creating users in the target system, the configuration is written into that system in
+  # advance to make it available for useradd. Note that only the attributes listed at
+  # {.writable_attributes} will be actually persisted to the target system at that point. That is,
+  # those are the only default values that can really be changed in the corresponding UseraddConfig
+  # object to affect how the users are created and, thus, are the only ones with defined setters.
+  #
+  # As a software design decision, attributes that correspond to a key at /etc/default/useradd are
+  # writable only if they can be changed via "adduser -D". For example, "skel" is not writable
+  # because the support to adjust its value via "adduser -D" was removed at some point during the
+  # useradd lifecycle (it was possible to adjust it in version 3.x but not in 4.x).
+  #
+  # Many of the attributes in this class have their counterpart in the <user_defaults> section of
+  # the AutoYaST profile. But note there is not a 1:1 relationship because some of the attributes
+  # from the profile simply don't have an equivalent setter in this class, so (Auto)YaST cannot
+  # change the default value to affect the useradd behavior (eg. "skel").
+  #
+  # Moreover, there are two attributes from that AutoYaST section that don't even have a counterpart
+  # in the useradd configuration: "groups" and "no_groups". The corresponding key GROUPS was dropped
+  # from the useradd configuration with no substitute. Even if the GROUPS key is present in
+  # /etc/default/useradd, its value will be completely ignored by useradd and by YaST.
+  #
+  # The "groups", "no_groups" and "skel" attributes from the profile may still be honored by
+  # AutoYaST when creating users by any other mechanism other than UseraddConfig.
+  class UseraddConfig
+    # @see .writable_attributes
+    WRITABLE_ATTRIBUTES = [:group, :home, :umask, :expiration, :inactivity_period, :shell].freeze
+    private_constant :WRITABLE_ATTRIBUTES
+
+    class << self
+      # Names of the attributes that can be persisted to the configuration of the system and thus
+      # can be used to really modify the default useradd behavior
+      #
+      # Only attributes in this list have a public setter
+      #
+      # @return [Array<Symbol>]
+      def writable_attributes
+        WRITABLE_ATTRIBUTES.dup
+      end
+
+    private
+
+      # Internal class method to automatically define the setters for all writable attributes
+      def define_setters
+        WRITABLE_ATTRIBUTES.each do |attr|
+          attr_writer attr
+        end
+      end
+    end
+
+    define_setters
+
+    # Constructor
+    #
+    # @param attrs [Hash{Symbol => Object}] values of the attributes, including non-writtable ones
+    #   (which makes possible for some readers to set the initial value of all attributes)
+    def initialize(attrs = {})
+      @group = attrs[:group]
+      @home = attrs[:home]
+      @umask = attrs[:umask]
+      @expiration = attrs[:expiration]
+      @inactivity_period = attrs[:inactivity_period]
+      @skel = attrs[:skel]
+      @usrskel = attrs[:usrskel]
+      @shell = attrs[:shell]
+      @create_mail_spool = attrs[:create_mail_spool]
+    end
+
+    # Group name or numeric id of the initial group for a new user, if no group is specified
+    #
+    # @note This is only relevant if the USERGROUPS_ENAB variable in set to "no" in login.defs.
+    #
+    # This attribute corresponds to the GROUP key handled by "useradd -D"
+    #
+    # @return [String, nil]
+    attr_reader :group
+
+    # This value is used as prefix to calculate the home directory for a new user, if no home
+    # directory has been specified
+    #
+    # This string is concatenated with the account name to define the home directory.
+    #
+    # This attribute corresponds to the HOME key handled by "useradd -D"
+    #
+    # @return [String, nil]
+    attr_reader :home
+
+    # The file mode mask used to create new home directories, if HOME_MODE is not specified in
+    # login.defs
+    #
+    # @note This is only relevant for the creation of the user if HOME_MODE is not set. Otherwise,
+    # the mode specified there will be used and this mask will be ignored by useradd and YaST.
+    #
+    # If both this and HOME_MODE are set to nil, useradd will use a fallback mask (tipically 022).
+    #
+    # This attribute corresponds to the UMASK variable in login.defs (see Yast::ShadowConfig).
+    # In the past this was read from the UMASK key handled by "useradd -D", but such value has been
+    # ignored by useradd for years, although YaST kept using it (instead of the value at login.defs)
+    # for some additional time.
+    #
+    # @return [String, nil]
+    attr_reader :umask
+
+    # Password expiration date to use when creating a user, if none was set
+    #
+    # Represented as a string with the format "YYYY-MM-DD". An empty string means user passwords
+    # will be created without expiration date.
+    #
+    # This attribute corresponds to the EXPIRATION key handled by "useradd -D"
+    #
+    # @return [String, nil]
+    attr_reader :expiration
+
+    # Inactivity period to set when creating a user, if none was set
+    #
+    # A value of -1 means no inactivity period will be set.
+    #
+    # This attribute corresponds to the INACTIVE key handled by "useradd -D"
+    #
+    # @return [Integer, nil]
+    attr_reader :inactivity_period
+
+    # Login shell to set for a newly created user, if none was specified
+    #
+    # This attribute corresponds to the SHELL key handled by "useradd -D"
+    #
+    # @return [String, nil]
+    attr_reader :shell
+
+    # Skeleton directory from which the files will be copied when creating a home directory for
+    # a new user
+    #
+    # This attribute corresponds to the SKEL key read (but not written) by "useradd -D"
+    #
+    # @see #usrskel
+    #
+    # @return [String, nil]
+    attr_reader :skel
+
+    # Extra directory from which some files are copied by useradd in an undocumented way
+    # when creating a home directory for a new user
+    #
+    # This attribute corresponds to the undocumented USRSKEL key read by "useradd -D".
+    #
+    # @see #skel
+    #
+    # @return [String, nil]
+    attr_reader :usrskel
+
+    # Whether a mail spool should be created for every new user
+    #
+    # This attribute corresponds to the CREATE_MAIL_SPOOL key read by "useradd -D"
+    #
+    # @return [Boolean, nil]
+    attr_reader :create_mail_spool
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -13,6 +13,7 @@ TESTS = \
   lib/y2users/help_texts_test.rb \
   lib/y2users/config_element_examples.rb \
   lib/y2users/config_element_collection_examples.rb \
+  lib/y2users/useradd_config_test.rb \
   lib/y2users/users_collection_test.rb \
   lib/y2users/groups_collection_test.rb \
   lib/y2users/config_element_examples.rb \

--- a/test/fixtures/root/etc/default/useradd
+++ b/test/fixtures/root/etc/default/useradd
@@ -1,8 +1,8 @@
-# useradd defaults file
 GROUP=100
 HOME=/home
 INACTIVE=-1
 EXPIRE=
 SHELL=/bin/bash
 SKEL=/etc/skel
+USRSKEL=/usr/etc/skel
 CREATE_MAIL_SPOOL=yes

--- a/test/lib/users/dialogs/inst_user_first_test.rb
+++ b/test/lib/users/dialogs/inst_user_first_test.rb
@@ -27,6 +27,7 @@ describe Yast::InstUserFirstDialog do
   before do
     Users::UsersDatabase.all.clear
 
+    allow(Yast::ShadowConfig).to receive(:fetch)
     allow(Yast::ShadowConfig).to receive(:fetch).with(:sys_uid_max).and_return("499")
 
     # Mock access time: files in root2 are more recent than files in root3

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -62,7 +62,7 @@ describe Y2Users::Linux::LocalReader do
       expect(root_user.password.value.content).to match(/^\$6\$pL/)
       expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
 
-      useradd = config.useradd_config
+      useradd = config.useradd
       expect(useradd.group).to eq "100"
       expect(useradd.expiration).to eq ""
       expect(useradd.inactivity_period).to eq(-1)

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -25,11 +25,20 @@ require "y2users/config"
 require "y2users/linux/local_reader"
 
 describe Y2Users::Linux::LocalReader do
-  subject { described_class.new(File.join(FIXTURES_PATH, "/root/")) }
+  subject { described_class.new(root_dir) }
+  let(:root_dir) { File.join(FIXTURES_PATH, "/root/") }
 
   around do |example|
     # Let's use test/fixtures/home as src root for reading authorized keys from there
     change_scr_root(FIXTURES_PATH.join("home")) { example.run }
+  end
+
+  before do
+    useradd_content = File.read(File.join(root_dir, "etc/default/useradd"))
+    allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", anything)
+      .and_return(useradd_content)
+
+    allow(Yast::ShadowConfig).to receive(:fetch).with(:umask).and_return("044")
   end
 
   describe "#read" do
@@ -52,6 +61,13 @@ describe Y2Users::Linux::LocalReader do
       expect(root_user.password.value.encrypted?).to eq true
       expect(root_user.password.value.content).to match(/^\$6\$pL/)
       expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
+
+      useradd = config.useradd_config
+      expect(useradd.group).to eq "100"
+      expect(useradd.expiration).to eq ""
+      expect(useradd.inactivity_period).to eq(-1)
+      expect(useradd.create_mail_spool).to eq true
+      expect(useradd.umask).to eq "044"
     end
   end
 end

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -43,6 +43,12 @@ describe Y2Users::Linux::Reader do
     shadow_content = File.read(File.join(FIXTURES_PATH, "/root/etc/shadow"))
     allow(Yast::Execute).to receive(:on_target!).with(/getent/, "shadow", anything)
       .and_return(shadow_content)
+
+    useradd_content = File.read(File.join(FIXTURES_PATH, "/root/etc/default/useradd"))
+    allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", anything)
+      .and_return(useradd_content)
+
+    allow(Yast::ShadowConfig).to receive(:fetch).with(:umask).and_return("024")
   end
 
   describe "#read" do
@@ -67,6 +73,13 @@ describe Y2Users::Linux::Reader do
       expect(root_user.password.aging.content).to eq("16899")
       expect(root_user.password.account_expiration.content).to eq("")
       expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
+
+      useradd = config.useradd_config
+      expect(useradd.group).to eq "100"
+      expect(useradd.expiration).to eq ""
+      expect(useradd.inactivity_period).to eq(-1)
+      expect(useradd.create_mail_spool).to eq true
+      expect(useradd.umask).to eq "024"
     end
   end
 end

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -74,7 +74,7 @@ describe Y2Users::Linux::Reader do
       expect(root_user.password.account_expiration.content).to eq("")
       expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
 
-      useradd = config.useradd_config
+      useradd = config.useradd
       expect(useradd.group).to eq "100"
       expect(useradd.expiration).to eq ""
       expect(useradd.inactivity_period).to eq(-1)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -71,7 +71,7 @@ describe Y2Users::Linux::Writer do
     end
 
     before do
-      initial_config.useradd_config = initial_useradd
+      initial_config.useradd = initial_useradd
 
       allow(Yast::Execute).to receive(:on_target!)
       allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
@@ -629,7 +629,7 @@ describe Y2Users::Linux::Writer do
         expect(Yast::ShadowConfig).to receive(:set).with(:umask, "321")
         expect(Yast::ShadowConfig).to receive(:write)
 
-        config.useradd_config.umask = "321"
+        config.useradd.umask = "321"
         writer.write
       end
     end
@@ -642,8 +642,8 @@ describe Y2Users::Linux::Writer do
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--expiredate", "")
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--base-dir", "/users")
 
-        config.useradd_config.group = "users"
-        config.useradd_config.expiration = ""
+        config.useradd.group = "users"
+        config.useradd.expiration = ""
         writer.write
       end
 
@@ -651,7 +651,7 @@ describe Y2Users::Linux::Writer do
         allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
           .and_raise(error)
 
-        config.useradd_config.group = "users"
+        config.useradd.group = "users"
         result = writer.write
         expect(result.first.message).to match(/went wrong writing.*--gid/)
       end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -26,6 +26,7 @@ require "y2users/config"
 require "y2users/user"
 require "y2users/group"
 require "y2users/password"
+require "y2users/useradd_config"
 require "y2users/linux/writer"
 
 describe Y2Users::Linux::Writer do
@@ -64,7 +65,14 @@ describe Y2Users::Linux::Writer do
     let(:pwd_value) { Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75$Qg6Pp") }
     let(:keyring) { instance_double(Yast::Users::SSHAuthorizedKeyring, write_keys: true) }
 
+    let(:initial_useradd) { Y2Users::UseraddConfig.new(initial_useradd_attrs) }
+    let(:initial_useradd_attrs) do
+      { group: "150", home: "/users", umask: "123", skel: "/etc/skeleton" }
+    end
+
     before do
+      initial_config.useradd_config = initial_useradd
+
       allow(Yast::Execute).to receive(:on_target!)
       allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
     end
@@ -603,6 +611,49 @@ describe Y2Users::Linux::Writer do
           issues = writer.write
           expect(issues.first.message).to match("The group '#{group.name}' could not be created")
         end
+      end
+    end
+
+    context "when the useradd configuration has not changed" do
+      it "does not alter the useradd configuration" do
+        expect(Yast::Execute).to_not receive(:on_target!).with(/useradd/, any_args)
+        expect(Yast::ShadowConfig).to_not receive(:set)
+        expect(Yast::ShadowConfig).to_not receive(:write)
+
+        writer.write
+      end
+    end
+
+    context "when the umask for useradd has changed" do
+      it "writes the change to login.defs" do
+        expect(Yast::ShadowConfig).to receive(:set).with(:umask, "321")
+        expect(Yast::ShadowConfig).to receive(:write)
+
+        config.useradd_config.umask = "321"
+        writer.write
+      end
+    end
+
+    context "when some useradd configuration parameters have changed" do
+      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+
+      it "writes all the known parameters to the useradd configuration" do
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--expiredate", "")
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--base-dir", "/users")
+
+        config.useradd_config.group = "users"
+        config.useradd_config.expiration = ""
+        writer.write
+      end
+
+      it "reports an issue if writing some parameter fails" do
+        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
+          .and_raise(error)
+
+        config.useradd_config.group = "users"
+        result = writer.write
+        expect(result.first.message).to match(/went wrong writing.*--gid/)
       end
     end
   end

--- a/test/lib/y2users/useradd_config_test.rb
+++ b/test/lib/y2users/useradd_config_test.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env rspec
+
 # Copyright (c) [2021] SUSE LLC
 #
 # All Rights Reserved.
@@ -17,10 +19,17 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2users/config"
-require "y2users/config_manager"
-require "y2users/validation_config"
-require "y2users/useradd_config"
-require "y2users/user"
-require "y2users/password"
-require "y2users/group"
+require_relative "test_helper"
+require "y2users"
+
+describe Y2Users::UseraddConfig do
+  describe ".writable_attributes" do
+    it "returns an array of symbols" do
+      expect(described_class.writable_attributes).to all be_a(Symbol)
+    end
+
+    it "does not include :skel or :usrskel" do
+      expect(described_class.writable_attributes).to_not include(:skel, :usrskel)
+    end
+  end
+end


### PR DESCRIPTION
This adds management of the useradd configuration, which is important for several reasons:

- The AutoYaST profile can contain a `<user_defaults>` section used to configure useradd
- The YaST UI for managing users also contain a tab for configuring useradd
- The useradd default values must be used in the YaST UI to pre-fill several fields

See also https://github.com/yast/yast-yast2/pull/1166 and https://trello.com/c/vhM38X7J/2463-3-manage-useradd-configuration