### PR TITLE
Fix aging issues

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,7 +93,7 @@ ylib_y2users_DATA = \
   lib/y2users/linux.rb \
   lib/y2users/password.rb \
   lib/y2users/password_validator.rb \
-  lib/y2users/shadow_date_helper.rb \
+  lib/y2users/shadow_date.rb \
   lib/y2users/user.rb \
   lib/y2users/users_simple.rb \
   lib/y2users/user_validator.rb \

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -291,6 +291,9 @@ module Y2Users
     end
 
     # Disables the account expiration
+    #
+    # @note There is not a counterpart method called 'enable'. To activate the account expiration,
+    #   use {#date=} to assign an expiration date.
     def disable
       @content = ""
     end

--- a/src/lib/y2users/password.rb
+++ b/src/lib/y2users/password.rb
@@ -18,7 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast2/secret_attributes"
-require "y2users/shadow_date_helper"
+require "y2users/shadow_date"
 require "yast2/equatable"
 
 module Y2Users
@@ -36,31 +36,40 @@ module Y2Users
     # [PasswordAging, nil] nil means information is unknown (eg. new user without a shadow entry)
     attr_accessor :aging
 
-    # The minimum number of days required between password changes
+    # String representation of the minimum number of days required between password changes
     #
-    # @return [Integer] 0 means no restriction
+    # The "" and "0" values mean no restriction.
+    #
+    # @return [String, nil] nil if unknown
     attr_accessor :minimum_age
 
-    # The maximum number of days the password is valid. After that, the password is forced to be
-    # changed.
+    # String representation of the maximum number of days the password is valid. After that, the
+    # password is forced to be changed.
     #
-    # @return [Integer, nil] nil means no restriction
+    # The "" value means no restriction.
+    #
+    # @return [String, nil] nil if unknown
     attr_accessor :maximum_age
 
-    # The number of days before the password is to expire that the user is warned for changing the
-    # password.
+    # String representation of the number of days before the password is to expire that the user is
+    # warned for changing the password.
     #
-    # @return [Integer] 0 means no warning
+    # The "" and "0" values mean no warning.
+    #
+    # @return [String, nil] nil if unknown
     attr_accessor :warning_period
 
-    # The number of days after the password expires that account is disabled
+    # String representation of the number of days after the password expires that account is
+    # disabled.
     #
-    # @return [Integer, nil] nil means no limit
+    # The "" value means no inactivity period.
+    #
+    # @return [String, nil] nil if unknown
     attr_accessor :inactivity_period
 
-    # Date when whole account expires
+    # Information about the account expiration, based on the content of the shadow file
     #
-    # @return [Date, nil]  nil if there is no account expiration
+    # @return [AccountExpiration, nil] nil if unknown
     attr_accessor :account_expiration
 
     # Two passwords are equal if all their attributes are equal
@@ -96,20 +105,71 @@ module Y2Users
     def copy
       password = clone
       password.value = value.clone
+      password.aging = aging.clone
+      password.account_expiration = account_expiration.clone
 
       password
     end
   end
 
-  # Represents a password value. Its specific type is defined as subclass and can be queried.
-  class PasswordValue
-    include Yast2::SecretAttributes
+  # Class to represent a field in the shadow file
+  class ShadowField
     include Yast2::Equatable
 
-    secret_attr :content
+    # Content of the field
+    #
+    # @return [String]
+    attr_reader :content
 
-    # Two password values are equal if their content are equal
     eql_attr :content
+
+    # Constructor
+    #
+    # @param value [String]
+    def initialize(value = "")
+      @content = value
+    end
+
+    def to_s
+      content
+    end
+  end
+
+  # Class to represent a field in the shadow file, which can allocate a date
+  class ShadowDateField < ShadowField
+    # Constructor
+    #
+    # @param value [String, Date]
+    def initialize(value = "")
+      @content = value.is_a?(Date) ? to_shadow(value) : super
+    end
+
+  private
+
+    # Converts a date to the shadow format
+    #
+    # @see ShadowDate
+    #
+    # @return [String]
+    def to_shadow(date)
+      ShadowDate.new(date).to_s
+    end
+
+    # Converts the content to a Date object
+    #
+    # @see ShadowDate
+    #
+    # @return [Date]
+    def to_date
+      ShadowDate.new(content).to_date
+    end
+  end
+
+  # Represents a password value. Its specific type is defined as subclass and can be queried.
+  class PasswordValue < ShadowField
+    include Yast2::SecretAttributes
+
+    secret_attr :content
 
     # Constructor
     #
@@ -163,44 +223,21 @@ module Y2Users
     end
   end
 
-  # Represents one entry in the third field of the shadow file
-  class PasswordAging
-    include ShadowDateHelper
-    include Yast2::Equatable
-
-    eql_attr :content
-
-    # Constructor
-    #
-    # @param value [String, Date] content of the field, automatically converted to the right format
-    #   if provided as a Date object
-    def initialize(value = "")
-      value = date_to_shadow_string(value) if value.is_a?(Date)
-      @content = value
-    end
-
-    # Content of the field
-    #
-    # @return [String]
-    attr_accessor :content
-
-    def to_s
-      content
-    end
-
-    # Whether password aging features are enabled
+  # Represents the last password change field of the shadow file
+  class PasswordAging < ShadowDateField
+    # Whether the password aging feature is enabled
     #
     # @return [Boolean]
     def enabled?
-      content != ""
+      !content.empty?
     end
 
-    # Sets the content to the value that disables password aging features
+    # Disables the password aging feature
     #
     # @note There is not a counterpart method called 'enable'. To activate password aging,
     #   use {#force_change} or {#last_change=}.
     def disable
-      self.content = ""
+      @content = ""
     end
 
     # Whether the user must change the password in the next login
@@ -212,7 +249,7 @@ module Y2Users
 
     # Sets the content to the value that enforces a password change in the next login
     def force_change
-      self.content = "0"
+      @content = "0"
     end
 
     # Date of the latest password change, or nil if that date is irrelevant
@@ -222,21 +259,60 @@ module Y2Users
     #   - password aging features are disabled (see {#enabled?})
     #   - the user is forced to change the password in the next login (see {#force_change?})
     #
+    # @see ShadowDateField#to_date
+    #
     # @return [Date, nil]
     def last_change
       return nil unless enabled?
       return nil if force_change?
 
-      shadow_string_to_date(content)
+      to_date
     end
 
     # Sets the content to the given date
     #
     # @note This enables the password aging features and sets {#force_change?} to false.
     #
+    # @see ShadowDateField#to_shadow
+    #
     # @param date [Date]
     def last_change=(date)
-      self.content = date_to_shadow_string(date)
+      @content = to_shadow(date)
+    end
+  end
+
+  # Represents the account expiration field of the shadow file
+  class AccountExpiration < ShadowDateField
+    # Whether the account has an expiration date
+    #
+    # @return [Boolean]
+    def expire?
+      !content.empty?
+    end
+
+    # Disables the account expiration
+    def disable
+      @content = ""
+    end
+
+    # Expiration date
+    #
+    # @see ShadowDateField#to_date
+    #
+    # @return [Date, nil] nil if the account does not expire
+    def date
+      return nil unless expire?
+
+      to_date
+    end
+
+    # Sets an expiration date
+    #
+    # @see ShadowDateField#to_shadow
+    #
+    # @param [Date] date
+    def date=(date)
+      @content = to_shadow(date)
     end
   end
 end

--- a/src/lib/y2users/shadow_date.rb
+++ b/src/lib/y2users/shadow_date.rb
@@ -20,25 +20,42 @@
 require "date"
 
 module Y2Users
-  # Mixin for converting the strings used to represent dates in the shadow file
-  module ShadowDateHelper
-    # Converts a string representing the number of days since 1970-01-01 into a date
+  # Class that represents a date which is expressed as the number of days since 1970-01-01.
+  class ShadowDate
+    # Constructor
     #
-    # @param string [String]
+    # @param date [String, Date] date in the shadow format (numeric string) or as Date object
+    def initialize(date)
+      date = to_shadow_format(date) if date.is_a?(Date)
+
+      @content = date
+    end
+
+    # String representing the date in the shadow format (number of days since 1970-01-01)
+    #
+    # @return [String]
+    def to_s
+      @content
+    end
+
+    # Converts the number of days into a date
+    #
     # @return [Date]
-    def shadow_string_to_date(string)
+    def to_date
       # We need to expand the days to seconds
-      unix_time = string.to_i * 24 * 60 * 60
+      unix_time = @content.to_i * 24 * 60 * 60
       Date.strptime(unix_time.to_s, "%s")
     end
 
-    # Converts a date to a string representing the number of days since 1970-01-01
+  private
+
+    # Converts the given date to a string representing the number of days since 1970-01-01
     #
     # @param date [Date]
-    # @return [String
-    def date_to_shadow_string(date)
+    # @return [String]
+    def to_shadow_format(date)
       # We need to convert the seconds provided by "%s" to days
-      date.strftime("%s").to_i / (24 * 60 * 60)
+      (date.strftime("%s").to_i / (24 * 60 * 60)).to_s
     end
   end
 end

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -143,7 +143,7 @@ module Y2Users
 
     # @return [Date, nil] date when the account expires or nil if never
     def expire_date
-      password&.account_expiration
+      password&.account_expiration&.date
     end
 
     # User full name

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -21,7 +21,6 @@ require "yast"
 require "y2users/config"
 require "y2users/user"
 require "y2users/password"
-require "y2users/parsers/shadow"
 
 Yast.import "UsersSimple"
 
@@ -29,14 +28,6 @@ module Y2Users
   module UsersSimple
     # Class for reading users configuration from old Yast::UsersSimple module
     class Reader
-      # @see #{shadow_string}
-      SORTED_SHADOW_ATTRS = [
-        # NOTE: bear in mind that, in UsersSimple, "uid" actually refers to the username
-        "uid", "userPassword", "shadowLastChange", "shadowMin", "shadowMax",
-        "shadowWarning", "shadowInactive", "shadowExpire", "shadowFlag"
-      ].freeze
-      private_constant :SORTED_SHADOW_ATTRS
-
       # Generates a new config with the users from YaST::UsersSimple module
       #
       # @return [Config]
@@ -48,14 +39,14 @@ module Y2Users
 
     private
 
-      # Returns the list users
+      # Returns the list of users
       #
       # @return [Array<User>] the collection of users
       def users
         Yast::UsersSimple.GetUsers.map { |u| user(u) }
       end
 
-      # Creates a {User} object based on the data structure of an UsersSimple user
+      # Creates a {User} object based on the data structure of a UsersSimple user
       #
       # @param user_attrs [Hash] a user representation in the format used by UsersSimple
       # @return [User]
@@ -103,27 +94,32 @@ module Y2Users
         value
       end
 
-      # Creates a {Password} object based on the data structure of an UsersSimple user
+      # Creates a {Password} object based on the data structure of a UsersSimple user
       #
       # @param user [Hash] a user representation in the format used by UsersSimple
       # @return [Password]
       def create_password(user)
-        parser = Parsers::Shadow.new
-        content = shadow_string(user)
+        new_password(user["userPassword"], user["encrypted"]).tap do |password|
+          last_change = user["shadowLastChange"]
+          expiration = user["shadowExpire"]
 
-        password = parser.parse(content).values.first
-        password.value = PasswordPlainValue.new(user["userPassword"]) unless user["encrypted"]
-        password
+          password.aging = PasswordAging.new(last_change) if last_change
+          password.minimum_age = user["shadowMin"]
+          password.maximum_age = user["shadowMax"]
+          password.warning_period = user["shadowWarning"]
+          password.inactivity_period = user["shadowInactive"]
+          password.account_expiration = AccountExpiration.new(expiration) if expiration
+        end
       end
 
-      # Entry in /etc/shadow describing the password of the given user
+      # Initializes a new password with the correct value type
       #
-      # @param user [Hash] a user representation in the format used by UsersSimple
-      # @return [String]
-      def shadow_string(user)
-        SORTED_SHADOW_ATTRS.map do |attr|
-          user[attr] || ""
-        end.join(":")
+      # @param value [String]
+      # @param encypted [Boolean]
+      #
+      # @return [Password]
+      def new_password(value, encrypted)
+        encrypted ? Password.create_encrypted(value) : Password.create_plain(value)
       end
     end
   end

--- a/src/lib/y2users/users_simple/reader.rb
+++ b/src/lib/y2users/users_simple/reader.rb
@@ -115,7 +115,7 @@ module Y2Users
       # Initializes a new password with the correct value type
       #
       # @param value [String]
-      # @param encypted [Boolean]
+      # @param encrypted [Boolean]
       #
       # @return [Password]
       def new_password(value, encrypted)

--- a/src/lib/y2users/users_simple/writer.rb
+++ b/src/lib/y2users/users_simple/writer.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2users/shadow_date_helper"
 
 Yast.import "UsersSimple"
 
@@ -26,8 +25,6 @@ module Y2Users
   module UsersSimple
     # Class for writing users configuration into the old UsersSimple Yast Module
     class Writer
-      include ShadowDateHelper
-
       # Constructor
       #
       # @param config [Config]
@@ -86,8 +83,8 @@ module Y2Users
           shadowMax:        password.maximum_age,
           shadowWarning:    password.warning_period,
           shadowInactive:   password.inactivity_period,
-          shadowLastChange: password.aging&.content,
-          shadowExpire:     date_string(password.account_expiration)
+          shadowLastChange: password.aging&.to_s,
+          shadowExpire:     password.account_expiration&.to_s
         }.merge(password_value_attrs(password))
       end
 
@@ -106,17 +103,6 @@ module Y2Users
             encrypted:    true
           }
         end
-      end
-
-      # Converts dates to the string format used by UsersSimple
-      #
-      # @param date [Date]
-      # @return [String]
-      def date_string(date)
-        return nil unless date
-
-        # UsersSimple uses the same format than the shadow file
-        date_to_shadow_string(date)
       end
     end
   end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ TESTS = \
   lib/y2users/password_test.rb \
   lib/y2users/password_validator_test.rb \
   lib/y2users/validation_config_test.rb \
+  lib/y2users/shadow_date_test.rb \
   lib/y2users/help_texts_test.rb \
   lib/y2users/config_element_examples.rb \
   lib/y2users/config_element_collection_examples.rb \

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -64,6 +64,8 @@ describe Y2Users::Linux::Reader do
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true
       expect(root_user.password.value.content).to match(/^\$6\$pL/)
+      expect(root_user.password.aging.content).to eq("16899")
+      expect(root_user.password.account_expiration.content).to eq("")
       expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
     end
   end

--- a/test/lib/y2users/shadow_date_test.rb
+++ b/test/lib/y2users/shadow_date_test.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users/shadow_date"
+require "date"
+
+describe Y2Users::ShadowDate do
+  subject { described_class.new(value) }
+
+  describe "#to_s" do
+    context "when created from a numeric string" do
+      let(:value) { "1111" }
+
+      it "returns the same numeric string" do
+        expect(subject.to_s).to eq(value)
+      end
+    end
+
+    context "when created from a date" do
+      let(:value) { Date.new(1973, 1, 16) }
+
+      it "returns a string representing the date as the number of days since 1970-01-01" do
+        expect(subject.to_s).to eq("1111")
+      end
+    end
+  end
+
+  describe "#to_date" do
+    context "when created from a numeric string" do
+      let(:value) { "1111" }
+
+      it "returns a date object correspoding to the given number" do
+        date = Date.new(1973, 1, 16)
+
+        expect(subject.to_date).to eq(date)
+      end
+    end
+
+    context "when created from a date" do
+      let(:value) { Date.new(1973, 1, 16) }
+
+      it "returns the same date" do
+        expect(subject.to_date).to eq(value)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -227,12 +227,12 @@ describe Y2Users::User do
       end
 
       context "and the password has expiration" do
-        let(:expiration) { today }
+        let(:expiration) { Y2Users::AccountExpiration.new(date) }
 
-        let(:today) { Date.today }
+        let(:date) { Date.new(2021, 1, 2) }
 
         it "returns the password expiration" do
-          expect(subject.expire_date).to eq(today)
+          expect(subject.expire_date).to eq(date)
         end
       end
     end

--- a/test/lib/y2users/users_simple/reader_test.rb
+++ b/test/lib/y2users/users_simple/reader_test.rb
@@ -122,6 +122,28 @@ describe Y2Users::UsersSimple::Reader do
         expect(user.password.warning_period).to be_nil
         expect(user.password.account_expiration).to be_nil
       end
+
+      context "without the root password" do
+        let(:root_pwd) { "" }
+
+        it "leaves it unset" do
+          config = subject.read
+          root = config.users.root
+
+          expect(root.password).to be_nil
+        end
+      end
+
+      context "without the root authorized key" do
+        let(:root_authorized_key) { "" }
+
+        it "leaves it unset" do
+          config = subject.read
+          root = config.users.root
+
+          expect(root.authorized_keys).to eq([])
+        end
+      end
     end
 
     context "for a specific user" do
@@ -308,28 +330,6 @@ describe Y2Users::UsersSimple::Reader do
 
           expect(user.password.account_expiration).to be_a(Y2Users::AccountExpiration)
           expect(user.password.account_expiration.content).to eq("12345")
-        end
-      end
-
-      context "without the root password" do
-        let(:root_pwd) { "" }
-
-        it "leaves it unset" do
-          config = subject.read
-          root = config.users.root
-
-          expect(root.password).to be_nil
-        end
-      end
-
-      context "without the root authorized key" do
-        let(:root_authorized_key) { "" }
-
-        it "leaves it unset" do
-          config = subject.read
-          root = config.users.root
-
-          expect(root.authorized_keys).to eq([])
         end
       end
     end

--- a/test/lib/y2users/users_simple/writer_test.rb
+++ b/test/lib/y2users/users_simple/writer_test.rb
@@ -42,8 +42,8 @@ describe Y2Users::UsersSimple::Writer do
     # Root user
     let(:root) do
       user = Y2Users::User.new("root")
-      user.uid = 0
-      user.gid = 0
+      user.uid = "0"
+      user.gid = "0"
       user.shell = "/bin/bash"
       user.home = "/root"
       user.gecos = ["Root User"]
@@ -154,8 +154,8 @@ describe Y2Users::UsersSimple::Writer do
         user
       end
 
-      let(:uid) { 1000 }
-      let(:gid) { 100 }
+      let(:uid) { "1000" }
+      let(:gid) { "100" }
       let(:shell) { "/bin/zsh" }
       let(:home) { "/home/test1" }
       let(:gecos) { ["Test User1"] }
@@ -164,8 +164,8 @@ describe Y2Users::UsersSimple::Writer do
 
       let(:user2) do
         user = Y2Users::User.new("test2")
-        user.uid = 1001
-        user.gid = 101
+        user.uid = "1001"
+        user.gid = "101"
         user.shell = "/bin/bash"
         user.home = "/home/test2"
         user.gecos = ["Test User2"]
@@ -175,11 +175,10 @@ describe Y2Users::UsersSimple::Writer do
 
       let(:user2_password) do
         passwd = Y2Users::Password.create_encrypted("$1$.QKDPc5E$SWlkjRWexrXYgc98F.")
-        passwd.aging = Y2Users::PasswordAging.new
-        passwd.aging.last_change = Date.new(1977, 5, 7)
-        passwd.minimum_age = 0
-        passwd.maximum_age = 90
-        passwd.account_expiration = Date.new(2021, 5, 7)
+        passwd.aging = Y2Users::PasswordAging.new(Date.new(1977, 5, 7))
+        passwd.minimum_age = "0"
+        passwd.maximum_age = "90"
+        passwd.account_expiration = Y2Users::AccountExpiration.new(Date.new(2021, 5, 7))
         passwd
       end
 


### PR DESCRIPTION
## Problem

When the users information is written to *UsersSimple* module and then it is recovered again, it might result in wrong values for some of the password attributes like the "last change date". When this happens, the user could be forced to change his/her password in the first login attempt after the installation.

## Solution

Use `nil` value to indicate that a password attribute is unknown. When an attribute is `nil`, the linux writer will not pass the attribute to the *chage* commad, keeping the default values set by *chpasswd*. 

Moreover, the users simple reader is now able to keep the `nil` values that comes from the `UsersSimple` module.

## Testing

* Added unit tests.
* Manually tested.
