### PR TITLE
Modify user attributes (home, gecos, shell and groups)

### DIFF
--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -360,6 +360,8 @@ module Y2Users
       # @param old_user [Y2Users::User] Original user
       # @return [Array<String>] usermod options
       # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/PerceivedComplexity
       def usermod_options(new_user, old_user)
         args = []
         args << "--gid" << new_user.gid if new_user.gid != old_user.gid && new_user.gid
@@ -375,6 +377,8 @@ module Y2Users
         args
       end
       # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def different_groups?(user1, user2)
         user1.groups(with_primary: false).sort != user2.groups(with_primary: false).sort

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -328,7 +328,7 @@ module Y2Users
       # @return [Array<String>] usermod options
       def usermod_options(new_user, old_user)
         args = []
-        args << "--comment" << new_user.gecos if new_user.gecos != old_user.gecos && new_user.gecos
+        args << "--comment" << new_user.gecos.join(",") if new_user.gecos != old_user.gecos
         if new_user.home != old_user.home && new_user.home
           args << "--home" << new_user.home << "--move-home"
         end

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -305,7 +305,7 @@ module Y2Users
       end
 
       # Attributes to modify using `usermod`
-      USERMOD_ATTRS = [:home, :shell, :gecos].freeze
+      USERMOD_ATTRS = [:gid, :home, :shell, :gecos].freeze
 
       # Edits the user
       #
@@ -362,6 +362,7 @@ module Y2Users
       # rubocop:disable Metrics/CyclomaticComplexity
       def usermod_options(new_user, old_user)
         args = []
+        args << "--gid" << new_user.gid if new_user.gid != old_user.gid && new_user.gid
         args << "--comment" << new_user.gecos.join(",") if new_user.gecos != old_user.gecos
         if new_user.home != old_user.home && new_user.home
           args << "--home" << new_user.home << "--move-home"

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -96,7 +96,8 @@ module Y2Users
 
     # Only relevant attributes are compared. For example, the config in which the user is attached
     # and the internal user id are not considered.
-    eql_attr :name, :uid, :gid, :shell, :home, :gecos, :source, :password, :authorized_keys
+    eql_attr :name, :uid, :gid, :shell, :home, :gecos, :source, :password, :authorized_keys,
+      :secondary_groups_name
 
     # Constructor
     #
@@ -135,10 +136,17 @@ module Y2Users
     def groups(with_primary: true)
       return [] unless attached?
 
-      groups = config.groups.select { |g| g.users.include?(self) }
+      groups = config.groups.select { |g| g.users.map(&:name).include?(name) }
       groups.reject! { |g| g.gid == gid } if gid && !with_primary
 
       groups
+    end
+
+    # Secondary group names where the user is included
+    #
+    # @return [Array<String>]
+    def secondary_groups_name
+      groups(with_primary: false).map(&:name).sort
     end
 
     # @return [Date, nil] date when the account expires or nil if never

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -197,9 +197,7 @@ describe Y2Users::ConfigMerger do
         it "updates the lhs group with the data from the corresponding rhs group except gid" do
           subject.merge
 
-          expect(lhs_group("test1")).to_not eq(group1)
-          group1.gid = 110
-          expect(lhs_group("test1")).to eq(group1)
+          expect(lhs_group("test1").gid).to eq(100)
         end
       end
     end

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -194,9 +194,11 @@ describe Y2Users::ConfigMerger do
           expect(lhs.groups.map(&:name)).to contain_exactly("test1", "test2", "test3")
         end
 
-        it "updates the lhs group with the data from the corresponding rhs" do
+        it "updates the lhs group with the data from the corresponding rhs group except gid" do
           subject.merge
 
+          expect(lhs_group("test1")).to_not eq(group1)
+          group1.gid = 110
           expect(lhs_group("test1")).to eq(group1)
         end
       end

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -197,8 +197,8 @@ describe Y2Users::ConfigMerger do
         it "updates the lhs group with the data from the corresponding rhs" do
           subject.merge
 
-          expect(lhs_group("test1").gid).to eq(100)
-          expect(lhs_group("test1").users_name).to eq(["test1"])
+          expect(lhs_group("test1")).to eq(group1)
+          expect(lhs_group("test1").users_name).to eq(["test1", "test2"])
         end
       end
     end

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -194,10 +194,11 @@ describe Y2Users::ConfigMerger do
           expect(lhs.groups.map(&:name)).to contain_exactly("test1", "test2", "test3")
         end
 
-        it "updates the lhs group with the data from the corresponding rhs group except gid" do
+        it "updates the lhs group with the data from the corresponding rhs" do
           subject.merge
 
           expect(lhs_group("test1").gid).to eq(100)
+          expect(lhs_group("test1").users_name).to eq(["test1"])
         end
       end
     end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -249,6 +249,21 @@ describe Y2Users::Linux::Writer do
         writer.write
       end
 
+      context "whose gid was changed" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.gid = "1000"
+        end
+
+        it "executes usermod with the new values" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--gid", "1000", user.name
+          )
+
+          writer.write
+        end
+      end
+
       context "whose home was changed" do
         before do
           current_user = config.users.by_id(user.id)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -238,6 +238,66 @@ describe Y2Users::Linux::Writer do
         writer.write
       end
 
+      context "whose home was changed" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.home = "/home/new"
+        end
+
+        it "executes usermod with the new values" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--home", "/home/new", "--move-home", user.name
+          )
+
+          writer.write
+        end
+      end
+
+      context "whose shell was changed" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.shell = "/usr/bin/fish"
+        end
+
+        it "executes usermod with the new values" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--shell", "/usr/bin/fish", user.name
+          )
+
+          writer.write
+        end
+      end
+
+      context "whose gecos was changed" do
+        let(:gecos) { ["Jane", "Doe"] }
+
+        before do
+          user.gecos = ["Admin"]
+          current_user = config.users.by_id(user.id)
+          current_user.gecos = gecos
+        end
+
+        it "executes usermod with the new values" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--comment", "Jane,Doe", user.name
+          )
+
+          writer.write
+        end
+
+        context "and the new value is empty" do
+          let(:gecos) { [] }
+
+          it "executes usermod with the new values" do
+            expect(Yast::Execute).to receive(:on_target!).with(
+              /usermod/, "--comment", "", user.name
+            )
+
+            writer.write
+          end
+        end
+      end
+
       context "whose authorized keys were edited" do
         before do
           current_user = config.users.by_id(user.id)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -298,6 +298,22 @@ describe Y2Users::Linux::Writer do
         end
       end
 
+      context "when modifying a user attribute fails" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.home = "/home/new"
+          allow(Yast::Execute).to receive(:on_target!)
+            .with(/usermod/, any_args)
+            .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
+        end
+
+        it "returns an issue" do
+          expect(writer.log).to receive(:error).with(/Error modifying user '#{user.name}'/)
+          issues = writer.write
+          expect(issues.first.message).to match("The user '#{user.name}' could not be modified")
+        end
+      end
+
       context "whose authorized keys were edited" do
         before do
           current_user = config.users.by_id(user.id)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -24,6 +24,7 @@ require_relative "../test_helper"
 require "date"
 require "y2users/config"
 require "y2users/user"
+require "y2users/group"
 require "y2users/password"
 require "y2users/linux/writer"
 
@@ -34,6 +35,7 @@ describe Y2Users::Linux::Writer do
     let(:initial_config) do
       config = Y2Users::Config.new
       config.attach(users)
+      config.attach(groups)
       config
     end
 
@@ -45,6 +47,15 @@ describe Y2Users::Linux::Writer do
       user = Y2Users::User.new(username)
       user.password = password
       user
+    end
+
+    let(:groups) { [] }
+
+    let(:group) do
+      Y2Users::Group.new("users").tap do |group|
+        group.gid = "100"
+        group.users_name = [user.name]
+      end
     end
 
     let(:password) { Y2Users::Password.new(pwd_value) }
@@ -298,6 +309,28 @@ describe Y2Users::Linux::Writer do
         end
       end
 
+      context "whose groups were changed" do
+        let(:wheel_group) do
+          Y2Users::Group.new("wheel").tap do |group|
+            group.users_name = user.name
+          end
+        end
+        let(:users) { [user] }
+
+        before do
+          config.attach(wheel_group)
+          allow(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args)
+        end
+
+        it "executes usermod with the new values" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--groups", "wheel", user.name
+          )
+
+          writer.write
+        end
+      end
+
       context "when modifying a user attribute fails" do
         before do
           current_user = config.users.by_id(user.id)
@@ -378,6 +411,7 @@ describe Y2Users::Linux::Writer do
         user.gecos = ["First line of", "GECOS"]
 
         config.attach(user)
+        config.attach(group)
       end
 
       include_examples "setting password"
@@ -387,7 +421,9 @@ describe Y2Users::Linux::Writer do
       it "executes useradd with all the parameters, including creation of home directory" do
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
           expect(args.last).to eq username
-          expect(args).to include("--uid", "--gid", "--shell", "--home-dir", "--create-home")
+          expect(args).to include(
+            "--uid", "--gid", "--shell", "--home-dir", "--create-home", "--groups"
+          )
         end
 
         writer.write
@@ -527,6 +563,31 @@ describe Y2Users::Linux::Writer do
         expect(result).to be_a(Y2Issues::List)
         expect(result).to_not be_empty
         expect(result.map(&:message)).to include(/Error writing authorized keys/)
+      end
+    end
+
+    context "for a new group" do
+      before do
+        config.attach(group)
+      end
+
+      it "executes groupadd" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, "--gid", "100")
+        writer.write
+      end
+
+      context "when creating the groupadd fails" do
+        before do
+          allow(Yast::Execute).to receive(:on_target!)
+            .with(/groupadd/, any_args)
+            .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
+        end
+
+        it "returns an issue" do
+          expect(writer.log).to receive(:error).with(/Error creating group '#{group.name}'/)
+          issues = writer.write
+          expect(issues.first.message).to match("The group '#{group.name}' could not be created")
+        end
       end
     end
   end


### PR DESCRIPTION
Bring back be876b7d0cbc28382f6f92c818a645788a1ac043 which added support for `usermod` and was wrongly removed by me when adapting the original PR.