### PR TITLE
Remove dependency of `Y2Users::HelpTexts` on `UsersSimple`

### DIFF
--- a/src/lib/y2users/help_texts.rb
+++ b/src/lib/y2users/help_texts.rb
@@ -26,7 +26,6 @@ module Y2Users
   # moving stuff to the Y2Users namespace
   module HelpTexts
     include Yast::I18n
-    Yast.import "UsersSimple"
 
     # Needed to be able to call textdomain below
     extend Yast::I18n
@@ -47,7 +46,13 @@ module Y2Users
     #
     # @return [String] formatted and localized text
     def valid_password_text
-      Yast::UsersSimple.ValidPasswordHelptext
+      _(
+        "<p>\n" \
+        "For the password, use only characters that can be found on an English keyboard\n" \
+        "layout.  In cases of system error, it may be necessary to log in without a\n" \
+        "localized keyboard layout.\n" \
+        "</p>"
+      )
     end
 
     # Text about the CA constraints, if applicable

--- a/src/lib/y2users/help_texts.rb
+++ b/src/lib/y2users/help_texts.rb
@@ -46,6 +46,8 @@ module Y2Users
     #
     # @return [String] formatted and localized text
     def valid_password_text
+      # NOTE: to avoid dependencies, this help text is a duplicate of
+      #   Yast::UsersSimple.ValidPasswordHelpText. Please, keep them in sync.
       _(
         "<p>\n" \
         "For the password, use only characters that can be found on an English keyboard\n" \

--- a/src/modules/UsersSimple.pm
+++ b/src/modules/UsersSimple.pm
@@ -446,7 +446,8 @@ sub ValidPasswordMessage {
 # Return the part of help text about valid password characters
 BEGIN { $TYPEINFO{ValidPasswordHelptext} = ["function", "string"]; }
 sub ValidPasswordHelptext {
-    # help text (default part shown in more places)
+    # NOTE: To avoid dependencies, this help text has been duplicated at
+    #   Y2Users::HelpTexts#valid_password_text. Please, keep them in sync.
     return __("<p>
 For the password, use only characters that can be found on an English keyboard
 layout.  In cases of system error, it may be necessary to log in without a


### PR DESCRIPTION
### Problem

`Y2Users::HelpTexts` depends on `Yast::UsersSimple` just for the `Yast::UsersSimple.ValidPasswordHelptext`, which simply returns a localized string.

https://trello.com/c/j0t4rJAZ/2430-1-remove-dependency-of-y2usershelptexts-on-userssimple

### Solution

As we agreed, for this special case the simpler solution is just to duplicate the localized string in `Y2Users::HelpText`.

### Tests

Tested manually checking that the translation still working as expected.

![passwords_help_text](https://user-images.githubusercontent.com/1691872/120462034-7590d680-c392-11eb-94a8-13a9cdf246c8.png)
