### PR TITLE
Remove some dead code

### DIFF
--- a/src/include/users/routines.rb
+++ b/src/include/users/routines.rb
@@ -137,42 +137,4 @@ module Yast
       end
     end
   end
-
-  # setup ALL users (included root user, autologin, root aliases,...)
-  # Return: true if there has been added a user
-  def setup_all_users
-    ret = false
-
-    # disable UI (progress)
-    old_gui = Users.GetGUI
-    Users.SetGUI(false)
-
-    # Users.Read has to be called in order to initialize the user hash
-    # in the Users module. This is needed for establishing
-    # the system users (espl. the root user). (bnc#893725)
-    Users.Read
-    Users.ResetCurrentUser
-    # resetting Autologin settings
-    Autologin.Disable
-
-    users = UsersSimple.GetUsers
-
-    if !users.empty?
-
-      Builtins.y2milestone("There are #{users.size} users to import")
-      create_users(users)
-
-      if UsersSimple.AutologinUsed
-        Autologin.user = UsersSimple.GetAutologinUser
-        Autologin.Use(true)
-      end
-
-      root_alias = UsersSimple.GetRootAlias
-      Users.AddRootAlias(root_alias) unless root_alias.empty?
-      ret = true
-    end
-    Users.SetGUI(old_gui)
-    ret
-  end
-
 end

--- a/src/include/users/routines.rb
+++ b/src/include/users/routines.rb
@@ -105,36 +105,4 @@ module Yast
       Builtins.size(output) != 0 && !Mode.config
     end
   end
-
-  # create users from a list
-  def create_users(users)
-    users.each do |user|
-      # check if default group exists
-      if user.has_key?("gidNumber")
-        g = Users.GetGroup(GetInt(Ops.get(user, "gidNumber"), -1), "")
-        if g.empty?
-          g = Users.GetGroupByName(user["groupname"]),
-          if g.empty?
-            user = Builtins.remove(user, "gidNumber")
-          else
-            user["gidNumber"] = g["gidNumber"]
-          end
-        end
-      end
-
-      error = Users.AddUser(user)
-
-      if error.empty?
-        # empty hash means the user added by Users.AddUser call before
-        error = Users.CheckUser({})
-      end
-
-      if error.empty?
-        Users.CommitUser
-      else
-        Builtins.y2error("error while adding user: #{error}")
-        Users.ResetCurrentUser
-      end
-    end
-  end
 end


### PR DESCRIPTION
[`users/routines`](https://github.com/yast/yast-users/blob/8d0a665f1423a4439f143b957e3c96b114c6f6ae/src/include/users/routines.rb#L109-L176) contains two methods that are no longer needed after https://github.com/yast/yast-users/commit/1b6818ce05463a28471171686f0f6a57c69107e3 and https://github.com/yast/yast-users/commit/4a5ec436df0e191c4e13bf43290c793d03008f60. So, let's drop them.

---

Note: the only [client using `#setup_all_users`](https://github.com/yast/yast-firstboot/blob/b550444a77ffc410aec0e130f8ca0e9fdf445c45/src/lib/y2firstboot/clients/user.rb#L44) lives in yast2-firsboot and will be adapted.