### PR TITLE
bsc#118727: fix control center tooltip

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the Comment entry in the desktop file so the tooltip
+  in the control center is properly translated (bsc#1187270).
+- 4.2.12
+
+-------------------------------------------------------------------
 Wed May 13 14:04:35 CEST 2020 - schubi@suse.de
 
 - AY proposal: Fixed crash. Showing user settings only because the

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/desktop/org.opensuse.yast.Users.desktop
+++ b/src/desktop/org.opensuse.yast.Users.desktop
@@ -26,5 +26,5 @@ Exec=xdg-su -c "/sbin/yast2 users"
 
 Name=YaST User and Group Management
 GenericName=User and Group Management
-Comment=Add, Edit and Delete Users or User Groups
+Comment="Add, Edit and Delete Users or User Groups"
 StartupNotify=true


### PR DESCRIPTION
See [bsc#1187270](https://bugzilla.suse.com/show_bug.cgi?id=1187270).

Before:
![control-center-tooltip-wrong](https://user-images.githubusercontent.com/15836/122036159-294e8900-cdcb-11eb-98e3-f203563b6e53.png)

After:
![control-center-tooltip-ok](https://user-images.githubusercontent.com/15836/122036167-2c497980-cdcb-11eb-8941-775a4d61a17b.png)
