### PR TITLE
Third attempt: process user_defaults section from the AutoYaST profile

### DIFF
--- a/src/lib/y2users/autoinst/reader.rb
+++ b/src/lib/y2users/autoinst/reader.rb
@@ -113,7 +113,7 @@ module Y2Users
 
       # Profile section describing the login settings
       #
-      # @return [AutoinstProfile::LoginSettingsSections]
+      # @return [AutoinstProfile::LoginSettingsSection]
       attr_reader :login_settings_section
 
       # Profile section describing the default configuration for new users

--- a/src/lib/y2users/autoinst_profile/user_defaults_section.rb
+++ b/src/lib/y2users/autoinst_profile/user_defaults_section.rb
@@ -39,7 +39,7 @@ module Y2Users
       def self.attributes
         [
           { name: :expire },
-          { name: :group  },
+          { name: :group },
           { name: :groups },
           { name: :home },
           { name: :inactive },
@@ -65,7 +65,7 @@ module Y2Users
       #   @return [String,nil] Default expiration in date format (YYYY-MM-DD)
       #
       # @!attribute inactive
-      #   @return [String,nil] Number of days after password expiration to disable the account
+      #   @return [Integer,nil] Number of days after password expiration to disable the account
       #
       # @!attribute no_groups
       #   @return [Boolean,nil] Do not use secondary groups
@@ -78,6 +78,16 @@ module Y2Users
       #
       # @!attribute umask
       #   @return [String,nil] File creation mode mask for the home directory
+
+      # Method used by {.new_from_hashes} to populate the attributes.
+      #
+      # @param hash [Hash] see {.new_from_hashes}
+      def init_from_hashes(hash)
+        super
+        return unless inactive
+
+        @inactive = inactive.to_i
+      end
     end
   end
 end

--- a/src/lib/y2users/config_merger.rb
+++ b/src/lib/y2users/config_merger.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2users/useradd_config"
 
 module Y2Users
   # Helper class to merge users and groups from one config into another config
@@ -39,8 +40,8 @@ module Y2Users
     # @see merge_login
     def merge
       merge_elements
-
       merge_login
+      merge_useradd
     end
 
   private
@@ -71,6 +72,21 @@ module Y2Users
       return unless rhs.login?
 
       rhs.login.copy_to(lhs)
+    end
+
+    # Merges the useradd configuration
+    #
+    # Basically overwrites all lhs values with the non-null ones coming from rhs
+    def merge_useradd
+      return unless rhs.useradd
+
+      lhs.useradd ||= UseraddConfig.new
+      lhs.useradd.class.writable_attributes.each do |attr|
+        value = rhs.useradd.public_send(attr)
+        next if value.nil?
+
+        lhs.useradd.public_send(:"#{attr}=", value)
+      end
     end
 
     # Merges an element into a config

--- a/src/lib/y2users/linux/login_config_writer.rb
+++ b/src/lib/y2users/linux/login_config_writer.rb
@@ -27,7 +27,7 @@ module Y2Users
 
       # Constructor
       #
-      # @param login [LoginConfig] see #login_config
+      # @param login [LoginConfig, nil] see #login_config
       def initialize(login)
         @login_config = login
       end

--- a/src/lib/y2users/useradd_config.rb
+++ b/src/lib/y2users/useradd_config.rb
@@ -40,17 +40,8 @@ module Y2Users
   # useradd lifecycle (it was possible to adjust it in version 3.x but not in 4.x).
   #
   # Many of the attributes in this class have their counterpart in the <user_defaults> section of
-  # the AutoYaST profile. But note there is not a 1:1 relationship because some of the attributes
-  # from the profile simply don't have an equivalent setter in this class, so (Auto)YaST cannot
-  # change the default value to affect the useradd behavior (eg. "skel").
-  #
-  # Moreover, there are two attributes from that AutoYaST section that don't even have a counterpart
-  # in the useradd configuration: "groups" and "no_groups". The corresponding key GROUPS was dropped
-  # from the useradd configuration with no substitute. Even if the GROUPS key is present in
-  # /etc/default/useradd, its value will be completely ignored by useradd and by YaST.
-  #
-  # The "groups", "no_groups" and "skel" attributes from the profile may still be honored by
-  # AutoYaST when creating users by any other mechanism other than UseraddConfig.
+  # the AutoYaST profile. But note there is not a 1:1 relationship, check {Autoinst::Reader} for
+  # more information.
   class UseraddConfig
     class << self
       # Names of the attributes that can be persisted to the configuration of the system and thus
@@ -125,7 +116,7 @@ module Y2Users
     # This attribute corresponds to the UMASK variable in login.defs (see Yast::ShadowConfig).
     # In the past this was read from the UMASK key handled by "useradd -D", but such value has been
     # ignored by useradd for years, although YaST kept using it (instead of the value at login.defs)
-    # for some additional time.
+    # for some additional time. See bsc#1099153 for more details.
     #
     # @return [String, nil]
     attr_reader :umask

--- a/test/lib/users/users_database_test.rb
+++ b/test/lib/users/users_database_test.rb
@@ -33,6 +33,10 @@ describe Users::UsersDatabase do
     allow(File).to receive(:atime).with(/root/).and_return(Time.new(2016))
     allow(File).to receive(:atime).with(/root2/).and_return(Time.new(2017))
     allow(File).to receive(:atime).with(/root3/).and_return(Time.new(2018))
+
+    # Mock max system uid, it seems to be different in the container running the CI tests
+    allow(Yast::ShadowConfig).to receive(:fetch)
+    allow(Yast::ShadowConfig).to receive(:fetch).with(:sys_uid_max).and_return("499")
   end
 
   describe ".all" do

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -49,6 +49,11 @@ describe Y2Users::Autoinst::Reader do
       expect(root_user.password.account_expiration.expire?).to eq(false)
 
       expect(config.login?).to eq(false)
+
+      expect(config.useradd.expiration).to eq nil
+      expect(config.useradd.inactivity_period).to eq(-1)
+      expect(config.useradd.group).to eq "100"
+      expect(config.useradd.umask).to eq "022"
     end
 
     context "for a specific user" do
@@ -382,6 +387,17 @@ describe Y2Users::Autoinst::Reader do
         config = result.config
 
         expect(config.login?).to eq(false)
+      end
+
+      it "creates an empty useradd configuration" do
+        config = subject.read.config
+
+        expect(config.useradd.group).to be_nil
+        expect(config.useradd.home).to be_nil
+        expect(config.useradd.umask).to be_nil
+        expect(config.useradd.expiration).to be_nil
+        expect(config.useradd.inactivity_period).to be_nil
+        expect(config.useradd.umask).to be_nil
       end
     end
 

--- a/test/lib/y2users/config_merger_test.rb
+++ b/test/lib/y2users/config_merger_test.rb
@@ -223,7 +223,7 @@ describe Y2Users::ConfigMerger do
           lhs.login = Y2Users::LoginConfig.new
         end
 
-        it "replaces the lhs login cofing with a copy of the rhs login config" do
+        it "replaces the lhs login config with a copy of the rhs login config" do
           login_config = lhs.login
 
           subject.merge
@@ -260,5 +260,45 @@ describe Y2Users::ConfigMerger do
         end
       end
     end
+
+    context "when rhs config contains a useradd config" do
+      let(:rhs_useradd) { Y2Users::UseraddConfig.new(rhs_useradd_attrs) }
+      let(:rhs_useradd_attrs) do
+        { group: "150", home: "/users", umask: "123", expiration: "2012-12-21" }
+      end
+
+      before { rhs.useradd = rhs_useradd }
+
+      context "and lhs does not contain a useradd config" do
+        it "copies the rhs useradd config into lhs" do
+          subject.merge
+
+          expect(lhs.useradd).to be_a(Y2Users::UseraddConfig)
+          expect(lhs.useradd.group).to eq "150"
+          expect(lhs.useradd.home).to eq "/users"
+          expect(lhs.useradd.inactivity_period).to be_nil
+        end
+      end
+
+      context "and lhs contains a useradd config" do
+        let(:lhs_useradd) { Y2Users::UseraddConfig.new(lhs_useradd_attrs) }
+        let(:lhs_useradd_attrs) do
+          { group: "100", home: "/home", umask: "022", shell: "/shell" }
+        end
+
+        before { lhs.useradd = lhs_useradd }
+
+        it "replaces the values of the lhs config with the ones from rhs" do
+          subject.merge
+
+          expect(lhs.useradd.group).to eq "150"
+          expect(lhs.useradd.umask).to eq "123"
+          expect(lhs.useradd.shell).to eq "/shell"
+          expect(lhs.useradd.expiration).to eq "2012-12-21"
+          expect(lhs.useradd.inactivity_period).to be_nil
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This replaces #298.

For details, see https://trello.com/c/QU2gDrTK/2486-3-autoyast-userdefaults-section

This processes the <user_defaults> section of AutoYaST, intentionally ignoring the "groups", "no_groups" and "skel" entries. The first two are not longer relevant for the useradd configuration and are ignored by AutoYaST while creating users during installation (verified for SLE-11-SPX, SLE-12-SPX and SLE-15-SPX with extensive manual tests). The latter cannot be changed via `useradd -D` (so we decided to not persist its value to the final system), must be combined with "usrskel" (which currently is not part of the AutoYaST profile) and is mostly useless during the AutoYaST installation (it's very unlikely that a custom skeleton directory exists at that point).

### Included

* `Autoinst::Reader` generates a full-featured `Config#useradd` based on the profile content
* `ConfigMerger` ensures `target_config.user_defaults` makes after merging it with `ay_config`

### Intentionally excluded

A new class to represent all the current fields at <user_defaults> (the ones included as part of the useradd configuration and also the extra ones) and the corresponding `Linux::Writer` support for those  extra attributes (`#secondary_groups` and `#skel`). Those excluded commits are at the currently closed #298.

### Testing

- Unit tests included
- Manual testing WIP