### PR TITLE
Add note about dropping attributes from the schema

### DIFF
--- a/src/autoyast-rnc/users.rnc
+++ b/src/autoyast-rnc/users.rnc
@@ -30,6 +30,12 @@ gr_group = element group {
   )
 }
 
+# TODO: groups, no_groups and skel are not longer read by AutoYaST (see
+# https://github.com/yast/yast-users/pull/306) or documented (see
+# https://github.com/SUSE/doc-sle/pull/901). We should remove them from the
+# schema at some point. We cannot do it yet because the attributes are still
+# exported (export uses old code not yet converted to Y2Users), but that
+# limitation should disappear at some point.
 user_defaults =
   element user_defaults {
     MAP,


### PR DESCRIPTION
With the new implementation (Y2Users), the attributes "groups", "no_groups" and "skel" from the `<user_defaults>` section of the AutoYaST profile are now intentionally ignored.

Making a note (with links) about it because we cannot remove them from the schema yet.