### PR TITLE
Create home as btrfs subvolume

### DIFF
--- a/src/lib/y2users/autoinst/reader.rb
+++ b/src/lib/y2users/autoinst/reader.rb
@@ -155,6 +155,7 @@ module Y2Users
           res.home = user_section.home
           res.shell = user_section.shell
           res.uid = user_section.uid
+          res.btrfs_subvolume_home = user_section.home_btrfs_subvolume
           res.password = create_password(user_section)
           users << res
         end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -80,6 +80,11 @@ module Y2Users
       USERADD = "/usr/sbin/useradd".freeze
       private_constant :USERADD
 
+      # Exit code returned by useradd when the operation is aborted because the home directory could
+      # not be created
+      USERADD_E_HOMEDIR = 12
+      private_constant :USERADD_E_HOMEDIR
+
       # Command for modifying users
       USERMOD = "/usr/sbin/usermod".freeze
       private_constant :USERMOD
@@ -101,19 +106,42 @@ module Y2Users
       CHAGE = "/usr/bin/chage".freeze
       private_constant :CHAGE
 
-      # Executes the command for creating the user
+      # Executes the sequence of commands for creating the user
       #
       # @param user [User] the user to be created on the system
       # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
       def add_user(user, issues)
-        Yast::Execute.on_target!(USERADD, *useradd_options(user))
+        run_useradd(user, issues)
         change_password(user, issues) if user.password
         write_auth_keys(user, issues)
+      end
+
+      # Executes the command for creating the user, retrying in the event of a recoverable error
+      #
+      # @see #add_user
+      #
+      # @param user [User] the user to be created on the system
+      # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
+      def run_useradd(user, issues)
+        try_useradd(user, issues)
       rescue Cheetah::ExecutionFailed => e
         issues << Y2Issues::Issue.new(
           format(_("The user '%{username}' could not be created"), username: user.name)
         )
         log.error("Error creating user '#{user.name}' - #{e.message}")
+      end
+
+      # @see #run_useradd
+      def try_useradd(user, issues)
+        Yast::Execute.on_target!(USERADD, *useradd_options(user))
+      rescue Cheetah::ExecutionFailed => e
+        raise(e) unless e.status.exitstatus == USERADD_E_HOMEDIR
+
+        Yast::Execute.on_target!(USERADD, *useradd_options(user, skip_home: true))
+        issues << Y2Issues::Issue.new(
+          format(_("Failed to create home directory for user '%s'"), user.name)
+        )
+        log.warn("User '#{user.name}' created without home '#{user.home}'")
       end
 
       # Executes the commands for setting the password and all its associated
@@ -124,6 +152,11 @@ module Y2Users
       def change_password(user, issues)
         set_password_value(user, issues)
         set_password_attributes(user, issues)
+      rescue Cheetah::ExecutionFailed => e
+        issues << Y2Issues::Issue.new(
+          format(_("Error setting the password for user '%s'"), user.name)
+        )
+        log.error("Error setting password for '#{user.name}' - #{e.message}")
       end
 
       # Writes authorized keys for given user
@@ -208,8 +241,9 @@ module Y2Users
       # Generates and returns the options expected by `useradd` for given user
       #
       # @param user [User]
+      # @param skip_home [Boolean] whether the home creation should be explicitly avoided
       # @return [Array<String>]
-      def useradd_options(user)
+      def useradd_options(user, skip_home: false)
         opts = {
           "--uid"      => user.uid,
           "--gid"      => user.gid,
@@ -222,6 +256,8 @@ module Y2Users
 
         if user.system?
           opts << "--system"
+        elsif skip_home
+          opts << "--no-create-home"
         else
           opts.concat(create_home_options(user))
         end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -276,11 +276,12 @@ module Y2Users
 
       # Options for `useradd` to create the home directory
       #
-      # @param _user [User]
+      # @param user [User]
       # @return [Array<String>]
-      def create_home_options(_user)
-        # TODO: "--btrfs-subvolume-home" if needed
-        ["--create-home"]
+      def create_home_options(user)
+        opts = ["--create-home"]
+        opts << "--btrfs-subvolume-home" if user.btrfs_subvolume_home
+        opts
       end
 
       # Generates and returns the options expected by `chpasswd` for the given user

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -74,6 +74,13 @@ module Y2Users
     # @return [String, nil] nil if it is not assigned yet
     attr_accessor :home
 
+    # Whether a btrfs subvolume is used as home directory, especially relevant when creating the
+    # user in the system
+    #
+    # @return [Boolean, nil] nil if irrelevant or unknown (some readers may not provide an accurate
+    #   value for this attribute)
+    attr_accessor :btrfs_subvolume_home
+
     # Fields for the GECOS entry
     #
     # @return [Array<String>]

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -274,6 +274,44 @@ describe Y2Users::Autoinst::Reader do
           expect(user.password.account_expiration.content).to eq(shadow_date.to_s)
         end
       end
+
+      context "if home_btrfs_subvolume is not part of the user description" do
+        let(:profile) do
+          { "users" => [{ "username" => "test" }] }
+        end
+
+        it "sets User#btrfs_subvolume_home to nil" do
+          user = subject.read.config.users.by_name("test")
+
+          expect(user.btrfs_subvolume_home).to be_nil
+        end
+      end
+
+      context "if home_btrfs_subvolume is part of the user description" do
+        let(:profile) do
+          { "users" => [{ "username" => "test", "home_btrfs_subvolume" => subvol }] }
+        end
+
+        context "and set to true" do
+          let(:subvol) { true }
+
+          it "sets User#btrfs_subvolume_home to true" do
+            user = subject.read.config.users.by_name("test")
+
+            expect(user.btrfs_subvolume_home).to eq true
+          end
+        end
+
+        context "and set to false" do
+          let(:subvol) { false }
+
+          it "sets User#btrfs_subvolume_home to false" do
+            user = subject.read.config.users.by_name("test")
+
+            expect(user.btrfs_subvolume_home).to eq false
+          end
+        end
+      end
     end
 
     context "when the users list is missing" do

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -577,24 +577,77 @@ describe Y2Users::Linux::Writer do
     end
 
     context "when there is any error adding users" do
+      let(:exit_double) { instance_double(Process::Status) }
+      let(:error) { Cheetah::ExecutionFailed.new("", exit_double, "", "", "initial error") }
+
       before do
         config.attach(user)
+        allow(exit_double).to receive(:exitstatus).and_return exitstatus
+
+        call_count = 0
+        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
+          call_count += 1
+          raise(error) if call_count == 1
+
+          second_call.call(*args)
+        end
       end
 
-      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+      context "and there is no specific handling for the error" do
+        let(:exitstatus) { 1 }
+        let(:second_call) { ->(*args) {} }
 
-      before do
-        allow(Yast::Execute).to receive(:on_target!)
-          .with(/useradd/, any_args)
-          .and_raise(error)
+        it "returns an issue notifying the user was not created" do
+          result = writer.write
+
+          expect(result).to be_a(Y2Issues::List)
+          expect(result).to_not be_empty
+          expect(result.map(&:message)).to include(/user.*could not be created/)
+        end
+
+        it "does not perform a second attempt to call useradd" do
+          expect(second_call).to_not receive(:call)
+          writer.write
+        end
       end
 
-      it "returns an issues list containing the issue" do
-        result = writer.write
+      context "and the error was a problem creating the home" do
+        let(:exitstatus) { 12 }
+        let(:second_call) do
+          lambda do |*args|
+            expect(args.last).to eq user.name
+            expect(args).to_not include "--create-home"
+            expect(args).to include "--no-create-home"
+          end
+        end
 
-        expect(result).to be_a(Y2Issues::List)
-        expect(result).to_not be_empty
-        expect(result.map(&:message)).to include(/user.*could not be created/)
+        it "executes useradd again explicitly avoiding the home creation" do
+          expect(second_call).to receive(:call).and_call_original
+          writer.write
+        end
+
+        context "and the second useradd calls succeeds" do
+          it "returns an issue notifying the user was created without home" do
+            result = writer.write
+
+            expect(result).to be_a(Y2Issues::List)
+            expect(result.to_a.size).to eq 1
+            expect(result.first.message).to match(/create home/)
+          end
+        end
+
+        context "and the second useradd call also fails" do
+          let(:second_error) { Cheetah::ExecutionFailed.new("", "", "", "", "second error") }
+          let(:second_call) { ->(*_args) { raise(second_error) } }
+
+          it "returns an issue notifying the user was not created" do
+            result = writer.write
+
+            expect(result).to be_a(Y2Issues::List)
+            expect(result.to_a.size).to eq 1
+            expect(result.first.message).to match(/could not be created/)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Support in `Y2Users` for the AutoYaST attribute `<home_btrfs_subvolume>` (and for creating home as subvolumes in general).

As a bonus, this also makes YaST work in a more backwards-compatible way when the home directory (or subvolume) cannot be created. Instead of aborting the whole creation of the user, YaST now tries to create the user without home directory (which is basically what the old perl-based YaST used to do).

See https://trello.com/c/QHeTE0GY/2505-5-recover-autoyast-home-btrfs-support

### Testing

- Unit tests included
- Manual tests:
  - AutoYaST with a btrfs filesystem and some users using subvolumes. Works as expected.
  - AutoYaST with a non-btrfs home and some users using subvolumes. WIP