### PR TITLE
System settings warning

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 14 14:18:32 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Show warning when reading system settings (e.g., login.defs)
+  fails (bsc#1177183).
+- 4.3.13
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -49,7 +49,8 @@ Requires:       yast2-country
 # CFA::Nsswitch
 Requires:       yast2-pam >= 4.3.0
 
-Requires:       yast2-security
+# Security::SafeRead
+Requires:       yast2-security >= 4.3.17
 
 # y2usernote, y2useritem
 Requires:       yast2-perl-bindings >= 2.18.0

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.12
+Version:        4.3.13
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -1321,11 +1321,13 @@ sub ReadSystemDefaults {
     my $self		= shift;
     my $force		= shift;
 
-    return if ($system_defaults_read && !$force);
+    if ($system_defaults_read && !$force) {
+	return Security->read_error || "";
+    }
 
     if (! Security->GetModified ()) {
 	my $progress_orig = Progress->set (0);
-	Security->Read ();
+	Security->SafeRead ();
 	Progress->set ($progress_orig);
     }
     $security_modified 		= $security_modified || Security->GetModified ();
@@ -1336,9 +1338,9 @@ sub ReadSystemDefaults {
     $pass_max_days	= $security{"PASS_MAX_DAYS"}	|| $pass_max_days;
 
     # command to call before/after adding/deleting user
-    $useradd_cmd 	= $security{"USERADD_CMD"};
-    $userdel_precmd 	= $security{"USERDEL_PRECMD"};
-    $userdel_postcmd 	= $security{"USERDEL_POSTCMD"};
+    $useradd_cmd 	= $security{"USERADD_CMD"} 	|| $useradd_cmd;
+    $userdel_precmd 	= $security{"USERDEL_PRECMD"} 	|| $userdel_precmd;
+    $userdel_postcmd 	= $security{"USERDEL_POSTCMD"}	|| $userdel_postcmd;
 
     # command to call after adding group
     $groupadd_cmd       = ShadowConfig->fetch("GROUPADD_CMD") || "";
@@ -1370,6 +1372,8 @@ sub ReadSystemDefaults {
 
     UsersCache->InitConstants (\%security);
     $system_defaults_read	= 1;
+
+    return Security->read_error || "";
 }
 
 ##------------------------------------
@@ -1627,7 +1631,13 @@ sub Read {
     # default system settings
     if ($use_gui) { Progress->NextStage (); }
 
-    $self->ReadSystemDefaults (1);
+    $error_msg = $self->ReadSystemDefaults (1);
+
+    if ($use_gui && $error_msg ne "") {
+	my $message = __("It was not possible to read some system settings. Some default values will be used. \n\nSee Details for more information.");
+
+	Popup->WarningDetails ($message, $error_msg);
+    }
 
     $self->ReadAllShells();
 

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -172,8 +172,8 @@ my $pass_min_days		= "0";
 my $pass_max_days		= "99999";
 
 # password encryption method
-my $encryption_method		= "des";
-my $group_encryption_method	= "des";
+my $encryption_method		= "sha512";
+my $group_encryption_method	= "sha512";
 
 # User/group names must match the following regex expression. (/etc/login.defs)
 my $character_class 		= "[[:alpha:]_][[:alnum:]_.-]*[[:alnum:]_.\$-]\\?";


### PR DESCRIPTION
## Problem

System settings are read when the *users* client starts. But the client is not aware of failures when reading the system settings. The client silently continues, and it applies its own default values for the system settings (e.g., for login.defs values). Everything happens without noticing to the user.

Moreover, the default encryption method is md5 when *login.defs* cannot be read. This is insecure, and sha512 should be the default encryption method.

* https://bugzilla.suse.com/show_bug.cgi?id=1177183

## Solution

A warning popup is shown when reading system settings fails. And sha512 is the default encryption method now. 

* Requires https://github.com/yast/yast-security/pull/111

## Testing

* Manually tested

## Screenshots

![Screenshot from 2021-07-14 15-31-06](https://user-images.githubusercontent.com/1112304/125640042-014b4587-dd7e-4cbd-bc2a-98a1bbb093cc.png)

![Screenshot from 2021-07-14 15-31-30](https://user-images.githubusercontent.com/1112304/125640055-c468a1be-bb70-43bb-abb3-fd979574e7ce.png)

