### PR TITLE
Improve knowing when first user is being created or edited

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 16 13:13:26 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Use a more reliable way of knowing if editing a user (related to
+  bsc#1188068).
+- 4.4.4
+
+-------------------------------------------------------------------
 Wed Jul 14 14:18:32 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Show warning when reading system settings (e.g., login.defs)

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Jul 16 13:13:26 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
-- Use a more reliable way of knowing if editing a user (related to
-  bsc#1188068).
+- Use a more reliable way of knowing if a user is being
+  edited (related to bsc#1188068).
 - 4.4.4
 
 -------------------------------------------------------------------

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/dialogs/inst_user_first.rb
+++ b/src/lib/users/dialogs/inst_user_first.rb
@@ -61,6 +61,11 @@ module Yast
       # The dialog does not support to have both at the same time, imported users and a new user.
       @user = user unless imported_users?
 
+      # NOTE: the only way to know if the user is going to be created or edited is through
+      # {Y2Users::ConfigElement#attached?} method BEFORE the #user method attaches it to the current
+      # #config for validation purposes. See #editing_user?
+      @editing_user = !!user&.attached?
+
       @login_modified = false
       # do not open package progress wizard window
       @progress_orig = Progress.set(false)
@@ -232,11 +237,12 @@ module Yast
 
     # Whether the user is being edited
     #
-    # It is assumed that the user is going to be edited if it already has a password.
+    # It is considered that the user is going to be edited if it was not attached to a configuration
+    # when the dialog was initialized
     #
     # @return [Boolean]
     def editing_user?
-      !user.password.nil?
+      @editing_user
     end
 
     # Checks whether the current information of the user is valid, reporting the problem otherwise


### PR DESCRIPTION
### Problem

Reported [bsc#1188068](https://bugzilla.suse.com/show_bug.cgi?id=1188068#c12) has revealed that `InstUserFirstDialog` is using a not optimal way to know if the user is going to be created or edited (see comment#12). In fact, changes introduced at https://github.com/yast/yast-firstboot/pull/126 broken it in a way that [`init_pw_for_root`](https://github.com/yast/yast-users/blob/61c0bc6bf2bb595f2d86fe37807868194c44d865/src/lib/users/dialogs/inst_user_first.rb#L195-L209) starts failing.

### Solution

To use the [`Y2Users::ConfigElement#attached?`](https://github.com/yast/yast-users/blob/61c0bc6bf2bb595f2d86fe37807868194c44d865/src/lib/y2users/config_element.rb#L65) method instead of relying on the password value, which looks prone to false positives.

However, the check has to be performed and stored at the time to initialize the dialog because the private [InstUserFirsDialogt#user](https://github.com/yast/yast-users/blob/61c0bc6bf2bb595f2d86fe37807868194c44d865/src/lib/users/dialogs/inst_user_first.rb#L211-L220) method attaches the user to the current configuration for validation purposes.


### Tests

* Already unit tests still passing
* Manual tests: done via driver update in a TW installation. Everything seems work as expected.
