### PR TITLE
Improve handling of authorized_keys

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 20 15:09:28 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not rewrite authorized_keys unless it is needed (bsc#1188361).
+- 4.2.13
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/ssh_authorized_keyring.rb
+++ b/src/lib/users/ssh_authorized_keyring.rb
@@ -218,13 +218,8 @@ module Yast
       def write_file(owner, group)
         file = SSHAuthorizedKeysFile.new(authorized_keys_path)
         file.keys = keys
-
         log.info "Writing #{keys.size} keys in #{authorized_keys_path}"
-
-        return unless file.save
-
-        FileUtils::Chown("#{owner}:#{group}", authorized_keys_path, false)
-        FileUtils::Chmod(AUTHORIZED_KEYS_PERMS, authorized_keys_path, false)
+        file.save && FileUtils::Chown("#{owner}:#{group}", authorized_keys_path, false)
       rescue SSHAuthorizedKeysFile::NotRegularFile
         raise NotRegularAuthorizedKeysFile, authorized_keys_path
       end

--- a/src/lib/users/ssh_authorized_keyring.rb
+++ b/src/lib/users/ssh_authorized_keyring.rb
@@ -218,8 +218,13 @@ module Yast
       def write_file(owner, group)
         file = SSHAuthorizedKeysFile.new(authorized_keys_path)
         file.keys = keys
+
         log.info "Writing #{keys.size} keys in #{authorized_keys_path}"
-        file.save && FileUtils::Chown("#{owner}:#{group}", authorized_keys_path, false)
+
+        return unless file.save
+
+        FileUtils::Chown("#{owner}:#{group}", authorized_keys_path, false)
+        FileUtils::Chmod(AUTHORIZED_KEYS_PERMS, authorized_keys_path, false)
       rescue SSHAuthorizedKeysFile::NotRegularFile
         raise NotRegularAuthorizedKeysFile, authorized_keys_path
       end

--- a/src/lib/users/ssh_authorized_keyring.rb
+++ b/src/lib/users/ssh_authorized_keyring.rb
@@ -106,7 +106,7 @@ module Yast
       #
       # @return [Array<String>] Registered authorized keys
       def add_keys(new_keys)
-        keys.concat(new_keys)
+        @keys |= new_keys.compact
       end
 
       # Determines if the keyring is empty

--- a/src/lib/users/ssh_authorized_keyring.rb
+++ b/src/lib/users/ssh_authorized_keyring.rb
@@ -163,8 +163,6 @@ module Yast
       AUTHORIZED_KEYS_FILE = "authorized_keys".freeze
       # @return [String] Permissions to be set on SSH_DIR directory
       SSH_DIR_PERMS = "0700".freeze
-      # @return [String] Permissions to be set on `authorized_keys` file
-      AUTHORIZED_KEYS_PERMS = "0600".freeze
 
       # Determine the path to the user's SSH directory
       #

--- a/src/lib/users/ssh_authorized_keyring.rb
+++ b/src/lib/users/ssh_authorized_keyring.rb
@@ -95,6 +95,7 @@ module Yast
       # Constructor
       def initialize(home)
         @keys = []
+        @old_keys = []
         @home = home
       end
 
@@ -115,14 +116,21 @@ module Yast
         keys.empty?
       end
 
+      # Determines if the keyring has changed
+      #
+      # @return [Boolean] +true+ if it has changed; +false+ otherwise
+      def changed?
+        @keys != @old_keys
+      end
+
       # Read keys from a given home directory and add them to the keyring
       #
       # @return [Array<String>] List of authorized keys
       def read_keys
         path = authorized_keys_path
-        @keys = FileUtils::Exists(path) ? SSHAuthorizedKeysFile.new(path).keys : []
-        log.info "Read #{@keys.size} keys from #{path}"
-        @keys
+        @old_keys = FileUtils::Exists(path) ? SSHAuthorizedKeysFile.new(path).keys : []
+        log.info "Read #{@old_keys.size} keys from #{path}"
+        @keys = @old_keys.dup
       end
 
       # Write user keys to the given file
@@ -130,12 +138,17 @@ module Yast
       # If SSH_DIR does not exist in the given directory, it will be
       # created inheriting owner/group and setting permissions to SSH_DIR_PERM.
       def write_keys
+        return unless changed?
+
         remove_authorized_keys_file
+
         return if keys.empty?
+
         if !FileUtils::Exists(home)
           log.error("Home directory '#{home}' does not exist!")
           raise HomeDoesNotExist, home
         end
+
         user = FileUtils::GetOwnerUserID(home)
         group = FileUtils::GetOwnerGroupID(home)
         create_ssh_dir(user, group)

--- a/src/lib/users/ssh_authorized_keys_file.rb
+++ b/src/lib/users/ssh_authorized_keys_file.rb
@@ -71,6 +71,10 @@ module Yast
       # @return [Boolean] +true+ if the key was added; +false+ otherwise
       def add_key(key)
         new_key = key.strip
+
+        # Ignores comments or empty lines given as key
+        return if new_key.empty? || new_key.start_with?("#")
+
         if valid_key?(new_key)
           keys << new_key
           true

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5929,7 +5929,8 @@ sub ImportUser {
 		"gidNumber"	=> $gid,
 		"homeDirectory"	=> $user->{"homeDirectory"} || $user->{"home"} || $existing{"homeDirectory"} || $home,
 		"type"		=> $type,
-		"modified"	=> "imported"
+		"modified"	=> "imported",
+		"authorized_keys"	=> $user->{"authorized_keys"} || $existing{"authorized_keys"} || []
 	    );
 	}
     }
@@ -5951,7 +5952,8 @@ sub ImportUser {
 	"grouplist"	  => \%grouplist,
 	"homeDirectory"	  => $user->{"homeDirectory"} || $user->{"home"} || $home,
 	"type"		  => $type,
-	"modified"	  => "imported"
+	"modified"	  => "imported",
+	"authorized_keys"	=> $user->{"authorized_keys"} || []
 	);
     }
     my %translated = (
@@ -5981,14 +5983,6 @@ sub ImportUser {
 	$ret{"shadowLastChange"} eq "") {
 	$ret{"shadowLastChange"}	= LastChangeIsNow ();
     }
-
-  # Import authorized keys from profile (FATE#319471)
-  if (defined($user->{"authorized_keys"})) {
-    $ret{"authorized_keys"} = $user->{"authorized_keys"},
-  } else {
-    my @authorized_keys = ();
-    $ret{"authorized_keys"} = \@authorized_keys;
-  }
 
     # AutoYaST-imported users don't go through AddUser(). This means we have
     # to replicate some of that logic here:

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -52,6 +52,24 @@ describe Yast::Users::SSHAuthorizedKeyring do
     end
   end
 
+  describe "#changed?" do
+    before { keyring.read_keys }
+
+    context "when new keys has been added" do
+      before { keyring.add_keys(["ssh-rsa 123ABC"]) }
+
+      it "returns true" do
+        expect(keyring.changed?).to eq(true)
+      end
+    end
+
+    context "when no new keys has been added" do
+      it "returns false" do
+        expect(keyring.changed?).to eq(false)
+      end
+    end
+  end
+
   describe "#empty?" do
     context "when keyring is empty" do
       it "returns true" do

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -50,7 +50,7 @@ describe Yast::Users::SSHAuthorizedKeyring do
     context "if some keys are present in the given home directory" do
       let(:expected_keys) { authorized_keys_from_home(home) }
 
-      it "returns true" do
+      it "returns read keys" do
         expect(keyring.read_keys).to eq(expected_keys)
       end
 

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -90,122 +90,179 @@ describe Yast::Users::SSHAuthorizedKeyring do
   describe "#write_keys" do
     let(:tmpdir) { Dir.mktmpdir }
     let(:home) { File.join(tmpdir, "/home/user") }
-    let(:file) { double("file", save: true) }
+    let(:file) { Yast::Users::SSHAuthorizedKeysFile.new(authorized_keys_path) }
     let(:ssh_dir) { File.join(home, ".ssh") }
     let(:key) { "ssh-rsa 123ABC" }
     let(:authorized_keys_path) { File.join(home, ".ssh", "authorized_keys") }
 
-    before { FileUtils.mkdir_p(home) }
+    before do
+      FileUtils.mkdir_p(ssh_dir)
+
+      allow(Yast::Users::SSHAuthorizedKeysFile).to receive(:new).and_return(file)
+    end
+
     after { FileUtils.rm_rf(tmpdir) if File.exist?(tmpdir) }
 
-    context "if no keys are registered for the given home" do
+    context "when there are not registered keys for the given home" do
       it "does not try to write the keys" do
         expect(file).to_not receive(:save)
+
         keyring.write_keys
       end
     end
 
-    context "if some keys are registered for the given home" do
+    context "when there are registered keys for the given home" do
       let(:uid) { 1001 }
       let(:gid) { 101 }
       let(:home_dir_exists) { true }
       let(:ssh_dir_exists) { false }
 
       before do
-        allow(Yast::SCR).to receive(:Execute).and_call_original
         allow(Yast::SCR).to receive(:Read).and_call_original
+        allow(Yast::SCR).to receive(:Execute).and_call_original
+        allow(Yast::SCR).to receive(:Execute)
+          .with(Yast::Path.new(".target.remove"), authorized_keys_path)
+
         allow(Yast::FileUtils).to receive(:Exists).and_call_original
         allow(Yast::FileUtils).to receive(:Exists).with(ssh_dir).and_return(ssh_dir_exists)
         allow(Yast::FileUtils).to receive(:Exists).with(home).and_return(home_dir_exists)
-        allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-          .and_return(true)
-        keyring.add_keys([key])
+        allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir).and_return(true)
+        allow(Yast::FileUtils).to receive(:Chmod).and_call_original
+
+        # Load some authorized_keys
+        FileUtils.cp_r(
+          FIXTURES_PATH.join("home", "user1", ".ssh", "authorized_keys"),
+          authorized_keys_path
+        )
+        keyring.read_keys
       end
 
-      it "writes the keys" do
-        keyring.write_keys
-        expect(File).to exist(authorized_keys_path)
-      end
-
-      it "SSH directory and authorized_keys inherits owner/group from home" do
-        allow(Yast::FileUtils).to receive(:GetOwnerUserID).with(home).and_return(uid)
-        allow(Yast::FileUtils).to receive(:GetOwnerGroupID).with(home).and_return(gid)
-        expect(Yast::FileUtils).to receive(:Chown).with("#{uid}:#{gid}", ssh_dir, false)
-        expect(Yast::FileUtils).to receive(:Chown)
-          .with("#{uid}:#{gid}", authorized_keys_path, false)
-
-        keyring.write_keys
-      end
-
-      it "sets SSH directory permissions to 0700" do
-        keyring.write_keys
-        mode = File.stat(ssh_dir).mode.to_s(8)
-        expect(mode).to eq("40700")
-      end
-
-      it "sets authorized_keys permissions to 0600" do
-        keyring.write_keys
-        mode = File.stat(authorized_keys_path).mode.to_s(8)
-        expect(mode).to eq("100600")
-      end
-
-      context "when home directory does not exist" do
-        let(:home_dir_exists) { false }
-
-        it "raises a HomeDoesNotExist exception and does not write authorized_keys" do
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist)
-        end
-      end
-
-      context "when SSH directory could not be created" do
-        it "raises a CouldNotCreateSSHDirectory exception and does not write authorized_keys" do
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect(Yast::SCR).to receive(:Execute)
-            .with(Yast::Path.new(".target.mkdir"), anything)
-            .and_return(false)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::CouldNotCreateSSHDirectory)
-        end
-      end
-
-      context "when SSH directory is not a regular directory" do
-        let(:ssh_dir_exists) { true }
-
-        it "raises a NotRegularSSHDirectory and does not write authorized_keys" do
-          allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-            .and_return(false)
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularSSHDirectory)
-        end
-      end
-
-      context "when SSH directory already exists" do
-        let(:ssh_dir_exists) { true }
-
-        it "does not create the directory" do
-          allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-            .and_return(true)
+      context "but no new keys are added" do
+        it "does not write keys again" do
           expect(Yast::SCR).to_not receive(:Execute)
-            .with(Yast::Path.new(".target.mkdir"), anything)
+            .with(Yast::Path.new(".target.remove"), authorized_keys_path)
+          expect(file).to_not receive(:save)
+
           keyring.write_keys
         end
       end
 
-      context "when authorized_keys is not a regular file" do
-        let(:ssh_dir_exists) { true }
-        let(:file) { double("file") }
+      context "but new keys are added" do
+        before do
+          keyring.add_keys([key])
+        end
 
-        it "raises a NotRegularAuthorizedKeysFile" do
-          allow(Yast::Users::SSHAuthorizedKeysFile).to receive(:new).and_return(file)
-          allow(file).to receive(:keys=)
-          allow(file).to receive(:save)
-            .and_raise(Yast::Users::SSHAuthorizedKeysFile::NotRegularFile)
+        it "deletes old authorized_keys file" do
+          expect(Yast::SCR).to receive(:Execute)
+            .with(Yast::Path.new(".target.remove"), authorized_keys_path)
 
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularAuthorizedKeysFile)
+          keyring.write_keys
+        end
+
+        it "writes the keys" do
+          expect(file).to receive(:save)
+
+          keyring.write_keys
+
+          expect(File).to exist(authorized_keys_path)
+        end
+
+        it "SSH directory and authorized_keys inherits owner/group from home" do
+          allow(Yast::FileUtils).to receive(:GetOwnerUserID).with(home).and_return(uid)
+          allow(Yast::FileUtils).to receive(:GetOwnerGroupID).with(home).and_return(gid)
+          expect(Yast::FileUtils).to receive(:Chown).with("#{uid}:#{gid}", ssh_dir, false)
+          expect(Yast::FileUtils).to receive(:Chown)
+            .with("#{uid}:#{gid}", authorized_keys_path, false)
+
+          keyring.write_keys
+        end
+
+        it "sets authorized_keys permissions to 0600" do
+          keyring.write_keys
+          mode = File.stat(authorized_keys_path).mode.to_s(8)
+          expect(mode).to eq("100600")
+        end
+
+        context "when home directory does not exist" do
+          let(:home_dir_exists) { false }
+
+          it "raises a HomeDoesNotExist exception and does not write authorized_keys" do
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist)
+          end
+        end
+
+        context "when SSH directory could not be created" do
+          it "raises a CouldNotCreateSSHDirectory exception and does not write authorized_keys" do
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect(Yast::SCR).to receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), anything)
+              .and_return(false)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::CouldNotCreateSSHDirectory)
+          end
+        end
+
+        context "when SSH directory is not a regular directory" do
+          let(:ssh_dir_exists) { true }
+
+          it "raises a NotRegularSSHDirectory and does not write authorized_keys" do
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
+              .and_return(false)
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularSSHDirectory)
+          end
+        end
+
+        context "when SSH directory already exists" do
+          let(:ssh_dir_exists) { true }
+
+          it "does not create the directory" do
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
+              .and_return(true)
+            expect(Yast::SCR).to_not receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), anything)
+            keyring.write_keys
+          end
+
+          it "does not set the SSH directory permissions" do
+            expect(Yast::FileUtils).to_not receive(:Chmod).with(anything, ssh_dir, false)
+
+            keyring.write_keys
+          end
+        end
+
+        context "when SSH directory does not exists yet" do
+          it "creates the directory" do
+            expect(Yast::SCR).to receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), ssh_dir)
+
+            keyring.write_keys
+          end
+
+          it "sets the SSH directory permissions to 0700" do
+            FileUtils.rm_r(ssh_dir) # Force to remove the mock, if exists
+
+            expect(Yast::FileUtils).to receive(:Chmod).with("0700", ssh_dir, false)
+
+            keyring.write_keys
+            mode = File.stat(ssh_dir).mode.to_s(8)
+            expect(mode).to eq("40700")
+          end
+        end
+
+        context "when authorized_keys is not a regular file" do
+          let(:ssh_dir_exists) { true }
+
+          it "raises a NotRegularAuthorizedKeysFile" do
+            allow(file).to receive(:save)
+              .and_raise(Yast::Users::SSHAuthorizedKeysFile::NotRegularFile)
+
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularAuthorizedKeysFile)
+          end
         end
       end
     end

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -182,8 +182,6 @@ describe Yast::Users::SSHAuthorizedKeyring do
         let(:key) { keyring.keys.first }
 
         it "does not write keys again" do
-          expect(Yast::SCR).to_not receive(:Execute)
-            .with(Yast::Path.new(".target.remove"), authorized_keys_path)
           expect(file).to_not receive(:save)
 
           keyring.write_keys
@@ -191,13 +189,6 @@ describe Yast::Users::SSHAuthorizedKeyring do
       end
 
       context "but new keys are added" do
-        it "deletes old authorized_keys file" do
-          expect(Yast::SCR).to receive(:Execute)
-            .with(Yast::Path.new(".target.remove"), authorized_keys_path)
-
-          keyring.write_keys
-        end
-
         it "writes the keys" do
           expect(file).to receive(:save)
 
@@ -214,12 +205,6 @@ describe Yast::Users::SSHAuthorizedKeyring do
             .with("#{uid}:#{gid}", authorized_keys_path, false)
 
           keyring.write_keys
-        end
-
-        it "sets authorized_keys permissions to 0600" do
-          keyring.write_keys
-          mode = File.stat(authorized_keys_path).mode.to_s(8)
-          expect(mode).to eq("100600")
         end
 
         context "when home directory does not exist" do


### PR DESCRIPTION
### Problem

As [stated in the documentation](https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-configuration-installation-options.html#id-1.7.5.2.35.3.5), the `$HOME/.ssh/authorized_keys` file will be overwritten when auto-installing the product via an AutoYaST profile defining a set of authorized_keys

> If the profile defines a set of SSH authorized keys for a user in the authorized_keys section, an existing $HOME/.ssh/authorized_keys file will be overwritten. If not existing, the file will be created with the content specified. Avoid overwriting an existing authorized_keys file by not specifying the respective section in the AutoYaST control file. 


However, as reported at https://bugzilla.suse.com/show_bug.cgi?id=1188361, looks like the file is overwritten even when the profile does not define authorized keys

### Solution

* [x] Do not overwrite the file when none authorized keys has been defined

### Tests

* [x] Unit tests
* [x] Manual testing when (auto)installing with a profile defining authorized_keys for a user already having a `$HOME/.ssh/authorized_keys` file
* [x] Manual testing when (auto)installing with a profile not defining authorized_keys for a user already having a `$HOME/.ssh/authorized_keys` file
* [x] Manual test in a running system to check that everything work as expected while editing the SSH authorized keys for a user.

