### PR TITLE
[SLE-15-SP3] Improve handling of authorized_keys

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 20 15:09:28 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not rewrite authorized_keys unless it is needed (bsc#1188361).
+- 4.3.14
+
+-------------------------------------------------------------------
 Wed Jul 14 14:18:32 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Show warning when reading system settings (e.g., login.defs)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/ssh_authorized_keys_file.rb
+++ b/src/lib/users/ssh_authorized_keys_file.rb
@@ -71,6 +71,10 @@ module Yast
       # @return [Boolean] +true+ if the key was added; +false+ otherwise
       def add_key(key)
         new_key = key.strip
+
+        # Ignores comments or empty lines given as key
+        return if new_key.empty? || new_key.start_with?("#")
+
         if valid_key?(new_key)
           keys << new_key
           true

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5937,7 +5937,8 @@ sub ImportUser {
 		"gidNumber"	=> $gid,
 		"homeDirectory"	=> $user->{"homeDirectory"} || $user->{"home"} || $existing{"homeDirectory"} || $home,
 		"type"		=> $type,
-		"modified"	=> "imported"
+		"modified"	=> "imported",
+		"authorized_keys"	=> $user->{"authorized_keys"} || $existing{"authorized_keys"} || []
 	    );
 	}
     }
@@ -5959,7 +5960,8 @@ sub ImportUser {
 	"grouplist"	  => \%grouplist,
 	"homeDirectory"	  => $user->{"homeDirectory"} || $user->{"home"} || $home,
 	"type"		  => $type,
-	"modified"	  => "imported"
+	"modified"	  => "imported",
+	"authorized_keys"	=> $user->{"authorized_keys"} || []
 	);
     }
     my %translated = (
@@ -5989,14 +5991,6 @@ sub ImportUser {
 	$ret{"shadowLastChange"} eq "") {
 	$ret{"shadowLastChange"}	= LastChangeIsNow ();
     }
-
-  # Import authorized keys from profile (FATE#319471)
-  if (defined($user->{"authorized_keys"})) {
-    $ret{"authorized_keys"} = $user->{"authorized_keys"},
-  } else {
-    my @authorized_keys = ();
-    $ret{"authorized_keys"} = \@authorized_keys;
-  }
 
     # AutoYaST-imported users don't go through AddUser(). This means we have
     # to replicate some of that logic here:

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -41,7 +41,7 @@ describe Yast::Users::SSHAuthorizedKeyring do
 
       expect(keyring.keys).to include(new_key)
       expect(keyring.keys).to include(known_key)
-      expect(keyring.keys).to_not include(known_key).twice
+      expect(keyring.keys).to eq(keyring.keys.uniq)
     end
 
     it "preserves the keys order" do

--- a/test/lib/users/ssh_authorized_keyring_test.rb
+++ b/test/lib/users/ssh_authorized_keyring_test.rb
@@ -30,6 +30,46 @@ describe Yast::Users::SSHAuthorizedKeyring do
     File.read(file_path).lines.map(&:strip).grep(/ssh-/)
   end
 
+  describe "#add_keys" do
+    let(:known_key) { keyring.keys.first }
+    let(:new_key) { "ssh-rsa 123ABC" }
+
+    before { keyring.read_keys }
+
+    it "adds only keys not already present in the keyring" do
+      keyring.add_keys([known_key, new_key])
+
+      expect(keyring.keys).to include(new_key)
+      expect(keyring.keys).to include(known_key)
+      expect(keyring.keys).to_not include(known_key).twice
+    end
+
+    it "preserves the keys order" do
+      keyring.add_keys([new_key, known_key])
+
+      expect(keyring.keys.first).to eq(known_key)
+      expect(keyring.keys.last).to eq(new_key)
+    end
+  end
+
+  describe "#changed?" do
+    before { keyring.read_keys }
+
+    context "when new keys has been added" do
+      before { keyring.add_keys(["ssh-rsa 123ABC"]) }
+
+      it "returns true" do
+        expect(keyring.changed?).to eq(true)
+      end
+    end
+
+    context "when no new keys has been added" do
+      it "returns false" do
+        expect(keyring.changed?).to eq(false)
+      end
+    end
+  end
+
   describe "#empty?" do
     context "when keyring is empty" do
       it "returns true" do
@@ -50,7 +90,7 @@ describe Yast::Users::SSHAuthorizedKeyring do
     context "if some keys are present in the given home directory" do
       let(:expected_keys) { authorized_keys_from_home(home) }
 
-      it "returns true" do
+      it "returns read keys" do
         expect(keyring.read_keys).to eq(expected_keys)
       end
 
@@ -90,122 +130,163 @@ describe Yast::Users::SSHAuthorizedKeyring do
   describe "#write_keys" do
     let(:tmpdir) { Dir.mktmpdir }
     let(:home) { File.join(tmpdir, "/home/user") }
-    let(:file) { double("file", save: true) }
+    let(:file) { Yast::Users::SSHAuthorizedKeysFile.new(authorized_keys_path) }
     let(:ssh_dir) { File.join(home, ".ssh") }
     let(:key) { "ssh-rsa 123ABC" }
     let(:authorized_keys_path) { File.join(home, ".ssh", "authorized_keys") }
 
-    before { FileUtils.mkdir_p(home) }
+    before do
+      FileUtils.mkdir_p(ssh_dir)
+
+      allow(Yast::Users::SSHAuthorizedKeysFile).to receive(:new).and_return(file)
+    end
+
     after { FileUtils.rm_rf(tmpdir) if File.exist?(tmpdir) }
 
-    context "if no keys are registered for the given home" do
+    context "when there are not registered keys for the given home" do
       it "does not try to write the keys" do
         expect(file).to_not receive(:save)
+
         keyring.write_keys
       end
     end
 
-    context "if some keys are registered for the given home" do
+    context "when there are registered keys for the given home" do
       let(:uid) { 1001 }
       let(:gid) { 101 }
       let(:home_dir_exists) { true }
       let(:ssh_dir_exists) { false }
 
       before do
-        allow(Yast::SCR).to receive(:Execute).and_call_original
         allow(Yast::SCR).to receive(:Read).and_call_original
+        allow(Yast::SCR).to receive(:Execute).and_call_original
+        allow(Yast::SCR).to receive(:Execute)
+          .with(Yast::Path.new(".target.remove"), authorized_keys_path)
+
         allow(Yast::FileUtils).to receive(:Exists).and_call_original
         allow(Yast::FileUtils).to receive(:Exists).with(ssh_dir).and_return(ssh_dir_exists)
         allow(Yast::FileUtils).to receive(:Exists).with(home).and_return(home_dir_exists)
-        allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-          .and_return(true)
+        allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir).and_return(true)
+        allow(Yast::FileUtils).to receive(:Chmod).and_call_original
+
+        # Load some authorized_keys
+        FileUtils.cp_r(
+          FIXTURES_PATH.join("home", "user1", ".ssh", "authorized_keys"),
+          authorized_keys_path
+        )
+        keyring.read_keys
         keyring.add_keys([key])
       end
 
-      it "writes the keys" do
-        keyring.write_keys
-        expect(File).to exist(authorized_keys_path)
-      end
+      context "but no new keys are added" do
+        let(:key) { keyring.keys.first }
 
-      it "SSH directory and authorized_keys inherits owner/group from home" do
-        allow(Yast::FileUtils).to receive(:GetOwnerUserID).with(home).and_return(uid)
-        allow(Yast::FileUtils).to receive(:GetOwnerGroupID).with(home).and_return(gid)
-        expect(Yast::FileUtils).to receive(:Chown).with("#{uid}:#{gid}", ssh_dir, false)
-        expect(Yast::FileUtils).to receive(:Chown)
-          .with("#{uid}:#{gid}", authorized_keys_path, false)
+        it "does not write keys again" do
+          expect(file).to_not receive(:save)
 
-        keyring.write_keys
-      end
-
-      it "sets SSH directory permissions to 0700" do
-        keyring.write_keys
-        mode = File.stat(ssh_dir).mode.to_s(8)
-        expect(mode).to eq("40700")
-      end
-
-      it "sets authorized_keys permissions to 0600" do
-        keyring.write_keys
-        mode = File.stat(authorized_keys_path).mode.to_s(8)
-        expect(mode).to eq("100600")
-      end
-
-      context "when home directory does not exist" do
-        let(:home_dir_exists) { false }
-
-        it "raises a HomeDoesNotExist exception and does not write authorized_keys" do
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist)
-        end
-      end
-
-      context "when SSH directory could not be created" do
-        it "raises a CouldNotCreateSSHDirectory exception and does not write authorized_keys" do
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect(Yast::SCR).to receive(:Execute)
-            .with(Yast::Path.new(".target.mkdir"), anything)
-            .and_return(false)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::CouldNotCreateSSHDirectory)
-        end
-      end
-
-      context "when SSH directory is not a regular directory" do
-        let(:ssh_dir_exists) { true }
-
-        it "raises a NotRegularSSHDirectory and does not write authorized_keys" do
-          allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-            .and_return(false)
-          expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularSSHDirectory)
-        end
-      end
-
-      context "when SSH directory already exists" do
-        let(:ssh_dir_exists) { true }
-
-        it "does not create the directory" do
-          allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
-            .and_return(true)
-          expect(Yast::SCR).to_not receive(:Execute)
-            .with(Yast::Path.new(".target.mkdir"), anything)
           keyring.write_keys
         end
       end
 
-      context "when authorized_keys is not a regular file" do
-        let(:ssh_dir_exists) { true }
-        let(:file) { double("file") }
+      context "but new keys are added" do
+        it "writes the keys" do
+          expect(file).to receive(:save)
 
-        it "raises a NotRegularAuthorizedKeysFile" do
-          allow(Yast::Users::SSHAuthorizedKeysFile).to receive(:new).and_return(file)
-          allow(file).to receive(:keys=)
-          allow(file).to receive(:save)
-            .and_raise(Yast::Users::SSHAuthorizedKeysFile::NotRegularFile)
+          keyring.write_keys
 
-          expect { keyring.write_keys }
-            .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularAuthorizedKeysFile)
+          expect(File).to exist(authorized_keys_path)
+        end
+
+        it "SSH directory and authorized_keys inherits owner/group from home" do
+          allow(Yast::FileUtils).to receive(:GetOwnerUserID).with(home).and_return(uid)
+          allow(Yast::FileUtils).to receive(:GetOwnerGroupID).with(home).and_return(gid)
+          expect(Yast::FileUtils).to receive(:Chown).with("#{uid}:#{gid}", ssh_dir, false)
+          expect(Yast::FileUtils).to receive(:Chown)
+            .with("#{uid}:#{gid}", authorized_keys_path, false)
+
+          keyring.write_keys
+        end
+
+        context "when home directory does not exist" do
+          let(:home_dir_exists) { false }
+
+          it "raises a HomeDoesNotExist exception and does not write authorized_keys" do
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist)
+          end
+        end
+
+        context "when SSH directory could not be created" do
+          it "raises a CouldNotCreateSSHDirectory exception and does not write authorized_keys" do
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect(Yast::SCR).to receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), anything)
+              .and_return(false)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::CouldNotCreateSSHDirectory)
+          end
+        end
+
+        context "when SSH directory is not a regular directory" do
+          let(:ssh_dir_exists) { true }
+
+          it "raises a NotRegularSSHDirectory and does not write authorized_keys" do
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
+              .and_return(false)
+            expect(Yast::Users::SSHAuthorizedKeysFile).to_not receive(:new)
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularSSHDirectory)
+          end
+        end
+
+        context "when SSH directory already exists" do
+          let(:ssh_dir_exists) { true }
+
+          it "does not create the directory" do
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(ssh_dir)
+              .and_return(true)
+            expect(Yast::SCR).to_not receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), anything)
+            keyring.write_keys
+          end
+
+          it "does not set the SSH directory permissions" do
+            expect(Yast::FileUtils).to_not receive(:Chmod).with(anything, ssh_dir, false)
+
+            keyring.write_keys
+          end
+        end
+
+        context "when SSH directory does not exists yet" do
+          it "creates the directory" do
+            expect(Yast::SCR).to receive(:Execute)
+              .with(Yast::Path.new(".target.mkdir"), ssh_dir)
+
+            keyring.write_keys
+          end
+
+          it "sets the SSH directory permissions to 0700" do
+            FileUtils.rm_r(ssh_dir) # Force to remove the mock, if exists
+
+            expect(Yast::FileUtils).to receive(:Chmod).with("0700", ssh_dir, false)
+
+            keyring.write_keys
+            mode = File.stat(ssh_dir).mode.to_s(8)
+            expect(mode).to eq("40700")
+          end
+        end
+
+        context "when authorized_keys is not a regular file" do
+          let(:ssh_dir_exists) { true }
+
+          it "raises a NotRegularAuthorizedKeysFile" do
+            allow(file).to receive(:save)
+              .and_raise(Yast::Users::SSHAuthorizedKeysFile::NotRegularFile)
+
+            expect { keyring.write_keys }
+              .to raise_error(Yast::Users::SSHAuthorizedKeyring::NotRegularAuthorizedKeysFile)
+          end
         end
       end
     end

--- a/test/lib/users/ssh_authorized_keys_file_test.rb
+++ b/test/lib/users/ssh_authorized_keys_file_test.rb
@@ -18,6 +18,7 @@
 #  you may find current contact information at www.suse.com
 require_relative "../../test_helper"
 require "users/ssh_authorized_keys_file"
+require "tmpdir"
 
 describe Yast::Users::SSHAuthorizedKeysFile do
   subject(:file) { Yast::Users::SSHAuthorizedKeysFile.new(path) }
@@ -66,29 +67,34 @@ describe Yast::Users::SSHAuthorizedKeysFile do
     let(:key1) { "ssh-rsa 456DEF" }
     let(:expected_content) { "ssh-dsa 123ABC\nssh-rsa 456DEF\n" }
 
-    let(:path) { "/tmp/home/user" }
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:ssh_dir) { File.join(tmpdir, "/home/user/.ssh/") }
+    let(:path) { File.join(ssh_dir, "authorized_keys") }
     let(:dir)  { File.dirname(path) }
     let(:file_exists) { false }
 
-    before do
-      allow(Yast::FileUtils).to receive(:Exists).with(dir)
-        .and_return(dir_exists)
-      allow(Yast::FileUtils).to receive(:Exists).with(path)
-        .and_return(file_exists)
-    end
+    after { FileUtils.rm_rf(tmpdir) if File.exist?(tmpdir) }
 
     context "if the directory exists" do
-      let(:dir_exists) { true }
+      before { FileUtils.mkdir_p(ssh_dir) }
 
-      it "creates the file with the registered keys and returns true" do
-        expect(Yast::SCR).to receive(:Write)
-          .with(Yast::Path.new(".target.string"), path, expected_content)
-        file.keys = [key0, key1]
-        file.save
+      context "and the file does not exist" do
+        it "creates the file with the registered keys and returns true" do
+          expect(Yast::SCR).to receive(:Write)
+            .with(Yast::Path.new(".target.string"), path, expected_content)
+          file.keys = [key0, key1]
+          file.save
+        end
+
+        it "sets permissions to 0600" do
+          file.save
+          mode = File.stat(path).mode.to_s(8)
+          expect(mode).to eq("100600")
+        end
       end
 
       context "and the file exists and it is a regular one" do
-        let(:file_exists) { true }
+        before { FileUtils.touch(path) }
 
         it "updates the file with the registered keys and returns true" do
           allow(Yast::FileUtils).to receive(:IsFile).with(path)
@@ -102,7 +108,7 @@ describe Yast::Users::SSHAuthorizedKeysFile do
       end
 
       context "and the file exists but it is not a regular one" do
-        let(:file_exists) { true }
+        before { FileUtils.mkdir(path) }
 
         it "raises NotRegularFile exception and does not update the file" do
           allow(Yast::FileUtils).to receive(:IsFile).with(path)
@@ -117,8 +123,6 @@ describe Yast::Users::SSHAuthorizedKeysFile do
     end
 
     context "if the directory does not exist" do
-      let(:dir_exists) { false }
-
       it "returns false" do
         file.keys = [key0, key1]
         expect(file.save).to eq(false)
@@ -127,23 +131,65 @@ describe Yast::Users::SSHAuthorizedKeysFile do
   end
 
   describe "#add_key" do
-    let(:key) { "ssh-dsa 123ABC" }
-
-    context "when the contains keys" do
-      let(:path) { FIXTURES_PATH.join("home", "user1", ".ssh", "authorized_keys") }
+    context "when a valid key is given" do
+      let(:key) { "ssh-dsa 123ABC" }
 
       it "adds the new key" do
         file.add_key(key)
+
         expect(file.keys).to include(key)
       end
     end
 
-    context "when the file does not contain keys" do
-      let(:path) { FIXTURES_PATH.join("home", "user2", ".ssh", "authorized_keys") }
+    context "when a not valid key is given" do
+      let(:key) { "AAA-DSA 123ABC" }
 
-      it "adds the new key" do
+      it "does not add the new key" do
         file.add_key(key)
-        expect(file.keys).to eq([key])
+
+        expect(file.keys).to_not include(key)
+      end
+
+      it "logs an error" do
+        expect(subject.log).to receive(:warn).with(/.*#{key}.*does not look.*valid.*/)
+
+        file.add_key(key)
+      end
+    end
+
+    context "when given key actually represents an empty line" do
+      let(:key) { " " }
+
+      it "ignores it" do
+        expect(file).to_not receive(:valid_key?).with(key)
+
+        file.add_key(key)
+
+        expect(file.keys).to_not include(key)
+      end
+
+      it "does not logs an error" do
+        expect(subject.log).to_not receive(:warn).with(/.*#{key}.*/)
+
+        file.add_key(key)
+      end
+    end
+
+    context "when given key actually is a comment" do
+      let(:key) { "# Just a comment, not a key " }
+
+      it "ignores it" do
+        expect(file).to_not receive(:valid_key?).with(key)
+
+        file.add_key(key)
+
+        expect(file.keys).to_not include(key)
+      end
+
+      it "does not logs an error" do
+        expect(subject.log).to_not receive(:warn).with(/.*#{key}.*/)
+
+        file.add_key(key)
       end
     end
   end


### PR DESCRIPTION
This is a sync of https://github.com/yast/yast-users/pull/320 for `SLE-15-SP3` branch. It fix https://bugzilla.suse.com/show_bug.cgi?id=1188361 by preventing to overwrite the `$HOME/.ssh/authorized_keys` file during auto-installation when none authorized keys have been defined in the profile.

---

This sync PR has been tested manually using a `SLE-15-SP3-Full-x86_64-GM` iso and 

* an AutoYaST profile defining authorized keys for root user
* an AutoYaST profile **not defining** authorized keys

In both cases tests worked as expected.