### PR TITLE
Extend Linux writer

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 12 14:35:20 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Allow to edit the name of an existing user (bsc#1188612).
+- Allow to remove the password of an existing user(bsc#1189402).
+- 4.4.6
+
+-------------------------------------------------------------------
 Tue Jul 20 15:09:28 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not rewrite authorized_keys unless it is needed (bsc#1188361).

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/widgets.rb
+++ b/src/lib/users/widgets.rb
@@ -102,11 +102,18 @@ module Users
       Yast::UI.ChangeWidget(Id(:pw2), :Value, current_password)
     end
 
+    # FIXME: Validation methods should only check values. Note that with the current implementation,
+    #   this method is taking care of setting/removing the user's password. This method should not
+    #   modify the user.
     # rubocop:disable Metrics/CyclomaticComplexity
     def validate
       password1 = Yast::UI.QueryWidget(Id(:pw1), :Value)
       password2 = Yast::UI.QueryWidget(Id(:pw2), :Value)
-      return true if allow_empty? && password1.empty?
+
+      if allow_empty? && password1.empty?
+        @user.password = nil
+        return true
+      end
 
       if password1 != password2
         # report misspellings of the password

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -29,9 +29,7 @@ module Y2Users
     # Writes users and groups to the system using Yast2::Execute and standard
     # linux tools.
     #
-    # NOTE: currently it only creates new users or modifies the password value
-    # of existing ones.  Removing or fully modifying users is still not covered.
-    # No group management or passowrd configuration either.
+    # NOTE: Removing or fully modifying users is still not covered.
     #
     # A brief history of the differences with the Yast::Users (perl) module:
     #

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -286,6 +286,21 @@ describe Y2Users::Linux::Writer do
         writer.write
       end
 
+      context "whose name has changed" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.name = "test2"
+        end
+
+        it "executes usermod with --login option" do
+          expect(Yast::Execute).to receive(:on_target!).with(
+            /usermod/, "--login", "test2", user.name
+          )
+
+          writer.write
+        end
+      end
+
       context "whose gid was changed" do
         before do
           current_user = config.users.by_id(user.id)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -463,6 +463,19 @@ describe Y2Users::Linux::Writer do
         end
       end
 
+      context "whose password was removed" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.password = nil
+        end
+
+        it "executes passwd with --delete option" do
+          expect(Yast::Execute).to receive(:on_target!).with(/passwd/, "--delete", user.name)
+
+          writer.write
+        end
+      end
+
       context "whose password was not edited" do
         it "does not execute chpasswd" do
           expect(Yast::Execute).to_not receive(:on_target!).with(/chpasswd/, any_args)


### PR DESCRIPTION
### Problem

Right now, the `Linux::Writer` class only supports (auto)installation and firstboot use cases. During the installation, users can only be created. And for firstboot and auto-installation, users can be edited too. In firstboot, even the name of the user can be changed when you go back, but the `Linux::Writer` does not modify it in the system.

* https://bugzilla.suse.com/show_bug.cgi?id=1188612

Moreover, the root password is not properly deleted if you go back to the wizard step for setting the root password and remove password (only an authorized key is selected). This affects to both: installation and firstboot.

* https://bugzilla.suse.com/show_bug.cgi?id=1189402

### Solution

Extend `Linux::Writer` in order to support the use cases mentioning above.

See also https://github.com/yast/yast-firstboot/pull/127.

### Testing

* Added unit tests.
* Manually tested.