### PR TITLE
Edit users

### DIFF
--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -8,48 +8,22 @@ The YaST UI for creating and editing a user offers the following attributes:
 
 | UI Field | Y2Users attr | Only when adding | Only when editing | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| full name | gecos | | | |
-| name | name | | | |
-| password | password | | | |
-| system mail | | | | |
+| full name | `#gecos` | | | |
+| name | `#name` | | | |
+| password | `#password` | | | |
+| system mail | `#receive_system_mail` | | | See `MailAliases` module |
 | disable login | * password starting by `!` | | | |
-| uid | uid | | | |
-| home dir | home | | | | |
-| home dir permission | | | | |
-| empty home | | yes | | |
-| Move to new location | | | yes |  |
-| Btrfs subvolume | btrfs_subvolume_home | | | |
-| Additional info | gecos | | | |
-| login shell | shell | | | |
-| group | primary_group | | | |
-| additional groups | groups | | | |
-| ssh public keys | authorized_keys | | | |
-
-### Home management
-
-### Creating a user
-
-* A user can be created with or without home.
-* To create a user without home, the *home dir* path should be set to empty.
-* The home can be created with or without default content (*empty home* checkbox).
-* The home can be created as Btrfs subvolume (*Btrfs subvol* checkbox).
-
-### Editing a user
-
-* If the home path is changed, then a new home is created with the default content.
-* There is no way to create a new home without content (*empty home* checkbox is not available).
-* If the *Move to new location* checkbox is marked, then the content of the old home is moved to the new one and the old home is removed.
-* If the *Move to new location* checkbox is not marked, then the old home is kept.
-* If the old home was a directory, then the new home is created as a directory again.
-* If the old home was a subvolume, then the new home is created as a subvolume again.
-* Side effects of *Move to new location* checkbox:
-  * If the old home was a subvolume and *Move to new location* is not checked, then the new home is created as a directory instead of a subvolume.
-* If the home path is removed, then the home is removed from the user but the home itself (directory or subvolume) is kept.
-* There is no way to remove the home directory/subvolume.
-
-### Deleting a user
-
-* The home is removed too.
+| uid | `#uid` | | | |
+| home dir | `Home#path` | | | | |
+| home dir permission | `Home#permissions` | yes | | `useradd -K HOME_MODE=0755` |
+| empty home | `CommitConfig#home_without_skel` | yes | | `rm -rf` after creating. No way to ignore `/usr/etc/skel` |
+| Move to new location | `CommitConfig#move_home` | | yes |  |
+| Btrfs subvolume | `Home#btrfs_subvol` | | | |
+| Additional info | `#gecos` | | | |
+| login shell | `#shell` | | | |
+| group | `#primary_group` | | | |
+| additional groups | `#groups` | | | |
+| ssh public keys | `#authorized_keys` | | | |
 
 
 ## Password
@@ -64,3 +38,69 @@ The YaST UI for creating and editing a user offers the following attributes for 
 | max days same password | maximum_age | | | |
 | min days same password | minimum_age | | | |
 | expiration date | account_expiration | | | |
+
+
+## Home management
+
+This section describes how the YaST users client behaves when dealing with the user home.
+
+#### Creating a user
+
+* A user can be created with or without home.
+* To create a user without home, the *home dir* path should be set to empty.
+* The home can be created with or without default content (*empty home* checkbox).
+* The home can be created as Btrfs subvolume (*Btrfs subvol* checkbox).
+* The home can be created with custom permissions (*Home permissions* field).
+* If the home already exists, it asks for adapting ownership.
+
+#### Editing a user
+
+* If the home path is changed, then a new home is created with the default content.
+* If the home already exists, it asks for adapting ownership.
+* There is no way to create a new home without content (*empty home* checkbox is not available).
+* If the *Move to new location* checkbox is marked, then the content of the old home is moved to the new one and the old home is removed.
+* If the *Move to new location* checkbox is not marked, then the old home is kept.
+* If the old home was a directory, then the new home is created as a directory again.
+* If the old home was a subvolume, then the new home is created as a subvolume again.
+* Side effects of *Move to new location* checkbox:
+  * If the old home was a subvolume and *Move to new location* is not checked, then the new home is created as a directory instead of a subvolume.
+* If the home path is removed, then the home is removed from the user but the home itself (directory or subvolume) is kept.
+* There is no way to remove the home directory/subvolume.
+
+#### Deleting a user
+
+* The user is asked whether to keep or remove home.
+
+#### Home representation in `Y2Users`
+
+~~~
+Y2Users::Home
+  #path
+  #btrfs_subvol
+  #mode
+~~~
+
+* Use cases
+  * create a new user with a home (`Home#path` is not empty)
+    * if the path already exists:
+      * re-use existing home
+      * adapt ownership (`CommitConfig#adapt_home_ownership`)
+    * if the path does not exist:
+      * create new home as dir/subvolume (`Home#btrfs_subvol`)
+      * create with/without content (`CommitConfig#use_skel`)
+      * create with custom permissions (`Home#permissions`)
+  * create a new user without a home (`Home#path` is empty)
+    * do not create a home on disk
+  * edit a user and change the home (`Home#path` changes)
+    * if the path already exists:
+      * re-use existing home
+      * adapt ownership (`CommitConfig#adapt_home_ownership`)
+    * if the path does not exist:
+      * if the home should be moved (`CommitConfig#move_home`)
+        * move home
+      * if the home should not be moved:
+        * create a home (TODO: Not supported by shadow tools)
+        * do not remove old home from disk
+  * edit a user and remove the home (`Home#path` is empty)
+    * do not remove old home from disk
+  * delete a user (TODO)

--- a/doc/attributes.md
+++ b/doc/attributes.md
@@ -6,38 +6,38 @@ This document describes the attributes that can be indicated for users and group
 
 The YaST UI for creating and editing a user offers the following attributes:
 
-| UI Field | Y2Users attr | Only when adding | Only when editing | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| full name | `#gecos` | | | |
-| name | `#name` | | | |
-| password | `#password` | | | |
-| system mail | `#receive_system_mail` | | | See `MailAliases` module |
-| disable login | * password starting by `!` | | | |
-| uid | `#uid` | | | |
-| home dir | `Home#path` | | | | |
-| home dir permission | `Home#permissions` | yes | | `useradd -K HOME_MODE=0755` |
-| empty home | `CommitConfig#home_without_skel` | yes | | `rm -rf` after creating. No way to ignore `/usr/etc/skel` |
-| Move to new location | `CommitConfig#move_home` | | yes |  |
-| Btrfs subvolume | `Home#btrfs_subvol` | | | |
-| Additional info | `#gecos` | | | |
-| login shell | `#shell` | | | |
-| group | `#primary_group` | | | |
-| additional groups | `#groups` | | | |
-| ssh public keys | `#authorized_keys` | | | |
+| UI Field | Y2Users attr | Usage | Description |
+| :--- | :--- | :--- | :--- |
+| full name | `#gecos` | add && edit | |
+| name | `#name` | add && edit  | |
+| password | `#password` | add && edit  |
+| system mail | `#receive_system_mail` | add && edit | See `MailAliases` module |
+| disable login | * password starting by `!` | add && edit | |
+| uid | `#uid` | add && edit | |
+| home dir | `Home#path` | add && edit | |
+| home dir permission | `Home#permissions` | add | | `useradd -K HOME_MODE=0755` |
+| empty home | `CommitConfig#home_without_skel` | add | | `rm -rf` after creating. No way to ignore `/usr/etc/skel` |
+| Move to new location | `CommitConfig#move_home` | edit |  |
+| Btrfs subvolume | `Home#btrfs_subvol` | add && edit | |
+| Additional info | `#gecos` | add && edit | |
+| login shell | `#shell` | add && edit | |
+| group | `#primary_group` | add && edit | |
+| additional groups | `#groups` | add && edit | |
+| ssh public keys | `#authorized_keys` | add && edit | |
 
 
 ## Password
 
 The YaST UI for creating and editing a user offers the following attributes for the password:
 
-| UI Field | Y2Users attr | Only when adding | Only when editing | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| force change  | aging == 0  | | | |
-| days to warning | warning_period | | | |
-| days usable after expiration | inactivity_period | | | |
-| max days same password | maximum_age | | | |
-| min days same password | minimum_age | | | |
-| expiration date | account_expiration | | | |
+| UI Field | Y2Users attr | Usage | Description |
+| :--- | :--- | :--- | :--- |
+| force change  | aging == 0  | add && edit | |
+| days to warning | warning_period | add && edit | |
+| days usable after expiration | inactivity_period | add && edit | |
+| max days same password | maximum_age | add && edit | |
+| min days same password | minimum_age | add && edit | |
+| expiration date | account_expiration | add && edit | |
 
 
 ## Home management
@@ -76,8 +76,8 @@ This section describes how the YaST users client behaves when dealing with the u
 ~~~
 Y2Users::Home
   #path
+  #permissions
   #btrfs_subvol
-  #mode
 ~~~
 
 * Use cases
@@ -87,7 +87,7 @@ Y2Users::Home
       * adapt ownership (`CommitConfig#adapt_home_ownership`)
     * if the path does not exist:
       * create new home as dir/subvolume (`Home#btrfs_subvol`)
-      * create with/without content (`CommitConfig#use_skel`)
+      * create with/without content (`CommitConfig#home_without_skel`)
       * create with custom permissions (`Home#permissions`)
   * create a new user without a home (`Home#path` is empty)
     * do not create a home on disk

--- a/src/lib/y2users/autoinst/reader.rb
+++ b/src/lib/y2users/autoinst/reader.rb
@@ -21,6 +21,7 @@ require "date"
 require "y2users/parsers/shadow"
 require "y2users/collision_checker"
 require "y2users/user"
+require "y2users/home"
 require "y2users/group"
 require "y2users/password"
 require "y2users/useradd_config"
@@ -154,10 +155,10 @@ module Y2Users
           res.gecos = [user_section.fullname]
           # TODO: handle forename/lastname
           res.gid = user_section.gid
-          res.home = user_section.home
+          res.home = Home.new(user_section.home)
+          res.home.btrfs_subvol = user_section.home_btrfs_subvolume
           res.shell = user_section.shell
           res.uid = user_section.uid
-          res.btrfs_subvolume_home = user_section.home_btrfs_subvolume
           res.password = create_password(user_section)
           res.authorized_keys = user_section.authorized_keys
           users << res

--- a/src/lib/y2users/collection.rb
+++ b/src/lib/y2users/collection.rb
@@ -1,0 +1,102 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "forwardable"
+
+module Y2Users
+  # Base class for collections
+  #
+  # A collection is similar to a ruby Array class, but the collection is intended to provide query
+  # methods to make easier to work with the collected elements.
+  #
+  # @example
+  #   # Collection of named elements (respond to #name method)
+  #   class ExampleCollection < Collection
+  #     def by_name(value)
+  #       selection = elements.select { |e| e.name == value }
+  #
+  #       self.class.new(selection)
+  #     end
+  #   end
+  #
+  #   obj1 = NamedObject.new("foo")
+  #   obj2 = NamedObject.new("bar")
+  #   obj3 = NamedObject.new("foo")
+  #
+  #   collection = ExampleCollection.new([obj1, obj2, obj3])
+  #   collection.by_name("foo")   #=> ExampleCollection<obj1, obj3>
+  #   collection.empty?           #=> false
+  class Collection
+    extend Forwardable
+
+    def_delegators :@elements, :each, :select, :find, :reject, :map, :any?, :size, :empty?, :first
+
+    # Constructor
+    #
+    # @param elements [Array<Object>]
+    def initialize(elements = [])
+      @elements = elements
+    end
+
+    # Adds an element to the collection
+    #
+    # @raise [FrozenError] see {#check_editable}
+    #
+    # @param element [Object]
+    # @return [self]
+    def add(element)
+      check_editable
+
+      @elements << element
+
+      self
+    end
+
+    # List with all the elements
+    #
+    # @return [Array<Object>]
+    def all
+      @elements.dup
+    end
+
+    alias_method :to_a, :all
+
+    # Generates a new collection with the sum of elements
+    #
+    # @param other [Collection]
+    # @return [Collection]
+    def +(other)
+      self.class.new(all + other.all)
+    end
+
+  private
+
+    # Checks whether the collection can be modified
+    #
+    # Modifications in the list of elements should be prevented when the collection is frozen.
+    #
+    # @raise [FrozenError] if the collection is frozen
+    # @return [Boolean]
+    def check_editable
+      return true unless frozen?
+
+      raise FrozenError, "can't modify frozen #{self.class}: #{inspect}"
+    end
+  end
+end

--- a/src/lib/y2users/commit_config.rb
+++ b/src/lib/y2users/commit_config.rb
@@ -1,0 +1,63 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Users
+  # Class for configuring the commit action for a user
+  #
+  # Writers can receive a collection of objects of this class (see {CommitConfigCollection}) in
+  # order to decide what actions to perform over the user. For example, a writer can use the commit
+  # config to check whether the content of the home directory should be moved or not.
+  class CommitConfig
+    # Name of the user this commit config applies to
+    #
+    # @return [String]
+    attr_accessor :username
+
+    # Whether the home should be empty after the creation (i.e., do not use skels)
+    #
+    # @return [Boolean]
+    attr_writer :home_without_skel
+
+    # Whether to move the content of the current home directory to the new location
+    #
+    # @return [Boolean]
+    attr_writer :move_home
+
+    # Whether this user should own the home. This is useful when changing the home to reuse an
+    # existing directory/subvolume.
+    #
+    # @return [Boolean]
+    attr_writer :adapt_home_ownership
+
+    # @return [Boolean]
+    def home_without_skel?
+      !!@home_without_skel
+    end
+
+    # @return [Boolean]
+    def move_home?
+      !!@move_home
+    end
+
+    # @return [Boolean]
+    def adapt_home_ownership?
+      !!@adapt_home_ownership
+    end
+  end
+end

--- a/src/lib/y2users/commit_config_collection.rb
+++ b/src/lib/y2users/commit_config_collection.rb
@@ -1,0 +1,43 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/collection"
+
+module Y2Users
+  # Collection of commit configs
+  #
+  # @see CommitConfig
+  class CommitConfigCollection < Collection
+    # Constructor
+    #
+    # @param commit_configs [Array<CommitConfig>]
+    def initialize(commit_configs = [])
+      super
+    end
+
+    # Commit config for the given user
+    #
+    # @param value [String] username
+    # @return [CommitConfig, nil] nil if the collection does not include a commit config for the
+    #   given username
+    def by_username(value)
+      find { |c| c.username == value }
+    end
+  end
+end

--- a/src/lib/y2users/config_element_collection.rb
+++ b/src/lib/y2users/config_element_collection.rb
@@ -17,34 +17,16 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "forwardable"
+require "y2users/collection"
 
 module Y2Users
   # Base class for collection of config elements (e.g., {User}, {Group}).
-  class ConfigElementCollection
-    extend Forwardable
-
-    def_delegators :@elements, :each, :select, :find, :reject, :map, :any?, :size, :empty?, :first
-
+  class ConfigElementCollection < Collection
     # Constructor
     #
     # @param elements [Array<ConfigElement>]
     def initialize(elements = [])
       @elements = elements
-    end
-
-    # Adds an element to the collection
-    #
-    # @raise [FrozenError] see {#check_editable}
-    #
-    # @param element [ConfigElement]
-    # @return [self]
-    def add(element)
-      check_editable
-
-      @elements << element
-
-      self
     end
 
     # Deletes the element with the given id from the collection
@@ -59,23 +41,6 @@ module Y2Users
       @elements.reject! { |e| e.id == id }
 
       self
-    end
-
-    # List with all the elements
-    #
-    # @return [Array<ConfigElement>]
-    def all
-      @elements.dup
-    end
-
-    alias_method :to_a, :all
-
-    # Generates a new collection with the sum of elements
-    #
-    # @param other [Collection]
-    # @return [Collection]
-    def +(other)
-      self.class.new(all + other.all)
     end
 
     # Generates a new collection without the elements whose id is included in the list of ids
@@ -124,20 +89,6 @@ module Y2Users
     # @return [Array<Integer>]
     def ids
       map(&:id)
-    end
-
-  private
-
-    # Checks whether the collection can be modified
-    #
-    # Modifications in the list of elements should be prevented when the collection is frozen.
-    #
-    # @raise [FrozenError] if the collection is frozen
-    # @return [Boolean]
-    def check_editable
-      return true unless frozen?
-
-      raise FrozenError, "can't modify frozen #{self.class}: #{inspect}"
     end
   end
 end

--- a/src/lib/y2users/home.rb
+++ b/src/lib/y2users/home.rb
@@ -1,0 +1,60 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/equatable"
+
+module Y2Users
+  # Class for representing a user home
+  class Home
+    include Yast2::Equatable
+
+    # Home path (e.g., "/home/username")
+    #
+    # @return [String, nil] nil if unknown
+    attr_accessor :path
+
+    # Home permissions
+    #
+    # It represents an octal number starting by 0 (e.g., "0755")
+    #
+    # @return [String, nil] nil if unknown
+    attr_accessor :permissions
+
+    # Sets whether home is a btrfs subvolume
+    #
+    # @return [Boolean]
+    attr_accessor :btrfs_subvol
+
+    eql_attr :path, :permissions, :btrfs_subvol
+
+    # Constructor
+    #
+    # @param path [String, nil] home path
+    def initialize(path = nil)
+      @path = path
+    end
+
+    # Whether home is a btrfs subvolume
+    #
+    # @return [Boolean]
+    def btrfs_subvol?
+      !!@btrfs_subvol
+    end
+  end
+end

--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -116,7 +116,7 @@ module Y2Users
         config.users.each do |user|
           next unless user.home
 
-          user.authorized_keys = Yast::Users::SSHAuthorizedKeyring.new(user.home).read_keys
+          user.authorized_keys = Yast::Users::SSHAuthorizedKeyring.new(user.home.path).read_keys
         end
       end
 

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2users/commit_config_collection"
 require "y2issues/with_issues"
 require "y2users/linux/useradd_config_writer"
 require "y2users/linux/login_config_writer"
@@ -85,9 +86,11 @@ module Y2Users
       #
       # @param config [Config] see #config
       # @param initial_config [Config] see #initial_config
-      def initialize(config, initial_config)
+      # @param commit_configs [CommitConfigCollection] configuration to address the commit process
+      def initialize(config, initial_config, commit_configs = nil)
         @config = config
         @initial_config = initial_config
+        @commit_configs = commit_configs || CommitConfigCollection.new
       end
 
       # Performs the changes in the system
@@ -150,6 +153,11 @@ module Y2Users
       # @return [Config]
       attr_reader :initial_config
 
+      # Collection of commit configs to address the commit actions for each user
+      #
+      # @return [CommitConfigCollection]
+      attr_reader :commit_configs
+
       # Writes the useradd configuration to the system
       #
       # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
@@ -175,7 +183,7 @@ module Y2Users
       #
       # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
       def write_users
-        UsersWriter.new(config, initial_config).write
+        UsersWriter.new(config, initial_config, commit_configs).write
       end
     end
   end

--- a/src/lib/y2users/parsers/passwd.rb
+++ b/src/lib/y2users/parsers/passwd.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "y2users/user"
+require "y2users/home"
 
 module Y2Users
   module Parsers
@@ -46,7 +47,7 @@ module Y2Users
           user.gid =   values[PASSWD_MAPPING["gid"]]
           user.shell = values[PASSWD_MAPPING["shell"]]
           user.gecos = values[PASSWD_MAPPING["gecos"]].to_s.split(",")
-          user.home =  values[PASSWD_MAPPING["home"]]
+          user.home =  Home.new(values[PASSWD_MAPPING["home"]])
           user
         end
       end

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -20,6 +20,7 @@
 require "y2users/config_element"
 require "y2users/user_validator"
 require "y2users/password_validator"
+require "y2users/home"
 require "yast2/equatable"
 
 module Y2Users
@@ -69,17 +70,10 @@ module Y2Users
     # @return [String, nil] nil if unknown
     attr_accessor :shell
 
-    # Path to the home directory
+    # User home
     #
-    # @return [String, nil] nil if unknown
+    # @return [Home, nil] nil if unknown
     attr_accessor :home
-
-    # Whether a btrfs subvolume is used as home directory, especially relevant when creating the
-    # user in the system
-    #
-    # @return [Boolean, nil] nil if irrelevant or unknown (some readers may not provide an accurate
-    #   value for this attribute)
-    attr_accessor :btrfs_subvolume_home
 
     # Fields for the GECOS entry
     #
@@ -115,7 +109,7 @@ module Y2Users
       new("root").tap do |root|
         root.uid = "0"
         root.gecos = ["root"]
-        root.home = "/root"
+        root.home = Home.new("/root")
       end
     end
 
@@ -249,6 +243,7 @@ module Y2Users
     # @return [User]
     def copy
       user = super
+      user.home = home.dup if home
       user.password = password.copy if password
       user.authorized_keys = authorized_keys.map(&:dup)
 

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -95,10 +95,15 @@ module Y2Users
     # @return [Array<String>]
     attr_accessor :authorized_keys
 
+    # Whether the user should receive system mails (i.e., be a root alias)
+    #
+    # @return [Boolean]
+    attr_accessor :receive_system_mail
+
     # Only relevant attributes are compared. For example, the config in which the user is attached
     # and the internal user id are not considered.
     eql_attr :name, :uid, :gid, :shell, :home, :gecos, :source, :password, :authorized_keys,
-      :secondary_groups_name
+      :receive_system_mail, :secondary_groups_name
 
     # Creates a prototype root user
     #
@@ -234,6 +239,13 @@ module Y2Users
       raise "The uid (#{uid}) is already defined" if uid
 
       @system = value
+    end
+
+    # @see receive_system_mail
+    #
+    # @return [Boolean]
+    def receive_system_mail?
+      !!@receive_system_mail
     end
 
     # Generates a deep copy of the user

--- a/src/lib/y2users/users_module/commit_config_reader.rb
+++ b/src/lib/y2users/users_module/commit_config_reader.rb
@@ -1,0 +1,93 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2users/commit_config_collection"
+require "y2users/commit_config"
+
+Yast.import "Users"
+
+module Y2Users
+  module UsersModule
+    # Class for reading the commit configs from Yast::Users module
+    #
+    # @see CommitConfig
+    class CommitConfigReader
+      # Generates a collection of commit configs with the information from YaST::Users module
+      #
+      # @return [CommitConfigCollection]
+      def read
+        CommitConfigCollection.new.tap do |collection|
+          users.each do |user|
+            collection.add(commit_config(user))
+          end
+        end
+      end
+
+    private
+
+      # Local users from the Yast::Users module
+      #
+      # @return [Array<Hash>]
+      def users
+        Yast::Users.GetUsers("uid", "local").values +
+          Yast::Users.GetUsers("uid", "system").values
+      end
+
+      # Generates a commit config from the given user
+      #
+      # @param user [Hash] a user representation in the format used by Yast::Users
+      # @return [CommitConfig]
+      def commit_config(user)
+        CommitConfig.new.tap do |config|
+          config.username = user["uid"]
+          config.home_without_skel = user["no_skeleton"]
+          config.move_home = move_home?(user)
+          config.adapt_home_ownership = user["chown_home"]
+        end
+      end
+
+      # Whether the home should be moved
+      #
+      # @param user [Hash] a user representation in the format used by Yast::Users
+      # @return [Boolean]
+      def move_home?(user)
+        previous_home = user_attr(user, "org_homeDirectory")
+        home = user_attr(user, "homeDirectory")
+
+        return false if previous_home.nil? || home.nil?
+
+        user["modified"] == "edited" && previous_home != home && user["create_home"]
+      end
+
+      # Value of the given attribute
+      #
+      # @param user [Hash] a user representation in the format used by Yast::Users
+      # @param attr [#to_s] name of the attribute
+      #
+      # @return [String, nil] nil if the value is missing or empty
+      def user_attr(user, attr)
+        value = user[attr.to_s]
+        return nil if value == ""
+
+        value
+      end
+    end
+  end
+end

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -281,10 +281,10 @@ describe Y2Users::Autoinst::Reader do
           { "users" => [{ "username" => "test" }] }
         end
 
-        it "sets User#btrfs_subvolume_home to nil" do
+        it "sets Home#btrfs_subvol to nil" do
           user = subject.read.config.users.by_name("test")
 
-          expect(user.btrfs_subvolume_home).to be_nil
+          expect(user.home.btrfs_subvol).to be_nil
         end
       end
 
@@ -296,20 +296,20 @@ describe Y2Users::Autoinst::Reader do
         context "and set to true" do
           let(:subvol) { true }
 
-          it "sets User#btrfs_subvolume_home to true" do
+          it "sets Home#btrfs_subvol to true" do
             user = subject.read.config.users.by_name("test")
 
-            expect(user.btrfs_subvolume_home).to eq true
+            expect(user.home.btrfs_subvol).to eq true
           end
         end
 
         context "and set to false" do
           let(:subvol) { false }
 
-          it "sets User#btrfs_subvolume_home to false" do
+          it "sets Home#btrfs_subvol to false" do
             user = subject.read.config.users.by_name("test")
 
-            expect(user.btrfs_subvolume_home).to eq false
+            expect(user.home.btrfs_subvol?).to eq false
           end
         end
       end

--- a/test/lib/y2users/commit_config_collection_test.rb
+++ b/test/lib/y2users/commit_config_collection_test.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users/commit_config_collection"
+require "y2users/commit_config"
+
+describe Y2Users::CommitConfigCollection do
+  subject { described_class.new(elements) }
+
+  let(:commit_config1) { Y2Users::CommitConfig.new.tap { |c| c.username = "test1" } }
+  let(:commit_config2) { Y2Users::CommitConfig.new.tap { |c| c.username = "test2" } }
+
+  describe "#by_username" do
+    context "if the collection contains a commit config for the given username" do
+      let(:elements) { [commit_config1, commit_config2] }
+
+      it "returns the commit config for the given username" do
+        expect(subject.by_username("test2")).to eq(commit_config2)
+      end
+    end
+
+    context "if the collection does not contain a commit config for the given username" do
+      let(:elements) { [commit_config1] }
+
+      it "returns nil" do
+        expect(subject.by_username("test2")).to be_nil
+      end
+    end
+  end
+end

--- a/test/lib/y2users/commit_config_test.rb
+++ b/test/lib/y2users/commit_config_test.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users/commit_config"
+
+describe Y2Users::CommitConfig do
+  subject { described_class.new }
+
+  describe "#home_without_skel?" do
+    before do
+      subject.home_without_skel = value
+    end
+
+    context "when the value is set to nil" do
+      let(:value) { nil }
+
+      it "returns false" do
+        expect(subject.home_without_skel?).to eq(false)
+      end
+    end
+
+    context "when the value is set to false" do
+      let(:value) { false }
+
+      it "returns false" do
+        expect(subject.home_without_skel?).to eq(false)
+      end
+    end
+
+    context "when the value is set to true" do
+      let(:value) { true }
+
+      it "returns true" do
+        expect(subject.home_without_skel?).to eq(true)
+      end
+    end
+  end
+
+  describe "#move_home?" do
+    before do
+      subject.move_home = value
+    end
+
+    context "when the value is set to nil" do
+      let(:value) { nil }
+
+      it "returns false" do
+        expect(subject.move_home?).to eq(false)
+      end
+    end
+
+    context "when the value is set to false" do
+      let(:value) { false }
+
+      it "returns false" do
+        expect(subject.move_home?).to eq(false)
+      end
+    end
+
+    context "when the value is set to true" do
+      let(:value) { true }
+
+      it "returns true" do
+        expect(subject.move_home?).to eq(true)
+      end
+    end
+  end
+
+  describe "#adapt_home_ownership?" do
+    before do
+      subject.adapt_home_ownership = value
+    end
+
+    context "when the value is set to nil" do
+      let(:value) { nil }
+
+      it "returns false" do
+        expect(subject.adapt_home_ownership?).to eq(false)
+      end
+    end
+
+    context "when the value is set to false" do
+      let(:value) { false }
+
+      it "returns false" do
+        expect(subject.adapt_home_ownership?).to eq(false)
+      end
+    end
+
+    context "when the value is set to true" do
+      let(:value) { true }
+
+      it "returns true" do
+        expect(subject.adapt_home_ownership?).to eq(true)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/home_test.rb
+++ b/test/lib/y2users/home_test.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "y2users/home"
+
+describe Y2Users::Home do
+  subject { described_class.new }
+
+  describe "#btrfs_subvol?" do
+    before do
+      subject.btrfs_subvol = value
+    end
+
+    context "when the value is set to nil" do
+      let(:value) { nil }
+
+      it "returns false" do
+        expect(subject.btrfs_subvol?).to eq(false)
+      end
+    end
+
+    context "when the value is set to false" do
+      let(:value) { false }
+
+      it "returns false" do
+        expect(subject.btrfs_subvol?).to eq(false)
+      end
+    end
+
+    context "when the value is set to true" do
+      let(:value) { true }
+
+      it "returns true" do
+        expect(subject.btrfs_subvol?).to eq(true)
+      end
+    end
+  end
+
+  describe "#==" do
+    before do
+      subject.path = "/home/test"
+      subject.permissions = "0777"
+      subject.btrfs_subvol = true
+    end
+
+    context "when all the attributes are equal" do
+      let(:other) { subject.dup }
+
+      it "returns true" do
+        expect(subject == other).to eq(true)
+      end
+    end
+
+    context "when the #path does not match" do
+      let(:other) do
+        subject.dup.tap { |h| h.path = "/home/other" }
+      end
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+
+    context "when the #permissions does not match" do
+      let(:other) do
+        subject.dup.tap { |h| h.permissions = "0744" }
+      end
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+
+    context "when the #btrfs_subvol does not match" do
+      let(:other) do
+        subject.dup.tap { |h| h.btrfs_subvol = false }
+      end
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/base_reader_test.rb
+++ b/test/lib/y2users/linux/base_reader_test.rb
@@ -56,7 +56,7 @@ describe Y2Users::Linux::BaseReader do
 
       root_user = config.users.root
       expect(root_user.uid).to eq "0"
-      expect(root_user.home).to eq "/root"
+      expect(root_user.home.path).to eq "/root"
       expect(root_user.shell).to eq "/bin/bash"
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -55,7 +55,7 @@ describe Y2Users::Linux::LocalReader do
 
       root_user = config.users.root
       expect(root_user.uid).to eq "0"
-      expect(root_user.home).to eq "/root"
+      expect(root_user.home.path).to eq "/root"
       expect(root_user.shell).to eq "/bin/bash"
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -65,7 +65,7 @@ describe Y2Users::Linux::Reader do
 
       root_user = config.users.root
       expect(root_user.uid).to eq "0"
-      expect(root_user.home).to eq "/root"
+      expect(root_user.home.path).to eq "/root"
       expect(root_user.shell).to eq "/bin/bash"
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true

--- a/test/lib/y2users/linux/writer_authorized_keys_test.rb
+++ b/test/lib/y2users/linux/writer_authorized_keys_test.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "date"
+require "y2users/config"
+require "y2users/user"
+require "y2users/linux/writer"
+require "y2users/commit_config_collection"
+
+describe Y2Users::Linux::Writer do
+  subject(:writer) { described_class.new(config, initial_config, commit_configs) }
+
+  describe "#write" do
+    let(:initial_config) do
+      config = Y2Users::Config.new
+      config.attach(users)
+      config
+    end
+    let(:config) { initial_config.copy }
+
+    let(:user) do
+      user = Y2Users::User.new("testuser")
+      user.home = home
+      user
+    end
+
+    let(:commit_configs) { Y2Users::CommitConfigCollection.new }
+    let(:users) { [] }
+    let(:keyring) { instance_double(Yast::Users::SSHAuthorizedKeyring, write_keys: true) }
+
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+      allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
+    end
+
+    RSpec.shared_examples "writing authorized keys" do
+      context "when home is defined" do
+        let(:home) { Y2Users::Home.new("/home/testuser") }
+
+        it "requests to write authorized keys" do
+          expect(keyring).to receive(:write_keys)
+
+          writer.write
+        end
+      end
+
+      context "when home is not defined" do
+        let(:home) { nil }
+
+        it "does not request to write authorized keys" do
+          expect(keyring).to_not receive(:write_keys)
+
+          writer.write
+        end
+      end
+    end
+
+    context "for an existing user" do
+      let(:users) { [user] }
+
+      context "whose authorized keys have not been modified" do
+        # Let's ensure there is a home to write the authorized keys to
+        let(:home) { Y2Users::Home.new("/home/testuser") }
+
+        it "does not request to write authorized keys" do
+          expect(keyring).to_not receive(:write_keys)
+
+          writer.write
+        end
+      end
+
+      context "whose authorized keys were edited" do
+        before do
+          current_user = config.users.by_id(user.id)
+          current_user.authorized_keys = ["ssh-rsa new-key"]
+        end
+
+        include_examples "writing authorized keys"
+      end
+    end
+
+    context "for a new regular user" do
+      before { config.attach(user) }
+
+      include_examples "writing authorized keys"
+    end
+
+    context "for a new system user" do
+      before do
+        user.system = true
+        config.attach(user)
+      end
+
+      include_examples "writing authorized keys"
+    end
+  end
+end

--- a/test/lib/y2users/linux/writer_errors_test.rb
+++ b/test/lib/y2users/linux/writer_errors_test.rb
@@ -1,0 +1,259 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/config"
+require "y2users/user"
+require "y2users/group"
+require "y2users/password"
+require "y2users/linux/writer"
+require "y2users/commit_config_collection"
+
+describe Y2Users::Linux::Writer do
+  subject(:writer) { described_class.new(config, initial_config, commit_configs) }
+
+  describe "Handling exit codes on #write" do
+    let(:initial_config) do
+      config = Y2Users::Config.new
+      config.attach(users)
+      config
+    end
+    let(:config) { initial_config.copy }
+
+    let(:commit_configs) { Y2Users::CommitConfigCollection.new }
+
+    let(:users) { [] }
+
+    let(:user) do
+      user = Y2Users::User.new("testuser")
+      user.password = Y2Users::Password.new(pwd_value)
+      user.receive_system_mail = false
+      user
+    end
+    let(:pwd_value) { Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75$Qg6Pp") }
+
+    let(:keyring) { instance_double(Yast::Users::SSHAuthorizedKeyring, write_keys: true) }
+
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+      allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
+      allow(Yast::MailAliases).to receive(:SetRootAlias).and_return true
+    end
+
+    context "when #write is executed with no errors" do
+      before do
+        config.attach(user)
+      end
+
+      it "returns an empty issues list" do
+        result = writer.write
+
+        expect(result).to be_a(Y2Issues::List)
+        expect(result).to be_empty
+      end
+    end
+
+    context "when there is any error adding users" do
+      let(:exit_double) { instance_double(Process::Status) }
+      let(:error) { Cheetah::ExecutionFailed.new("", exit_double, "", "", "initial error") }
+
+      before do
+        config.attach(user)
+        allow(exit_double).to receive(:exitstatus).and_return exitstatus
+
+        call_count = 0
+        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
+          call_count += 1
+          raise(error) if call_count == 1
+
+          second_call.call(*args)
+        end
+      end
+
+      context "and there is no specific handling for the error" do
+        let(:exitstatus) { 1 }
+        let(:second_call) { ->(*args) {} }
+
+        it "returns an issue notifying the user was not created" do
+          result = writer.write
+
+          expect(result).to be_a(Y2Issues::List)
+          expect(result).to_not be_empty
+          expect(result.map(&:message)).to include(/user.*could not be created/)
+        end
+
+        it "does not perform a second attempt to call useradd" do
+          expect(second_call).to_not receive(:call)
+          writer.write
+        end
+      end
+
+      context "and the error was a problem creating the home" do
+        let(:exitstatus) { 12 }
+        let(:second_call) do
+          lambda do |*args|
+            expect(args.last).to eq user.name
+            expect(args).to_not include "--create-home"
+            expect(args).to include "--no-create-home"
+          end
+        end
+
+        it "executes useradd again explicitly avoiding the home creation" do
+          expect(second_call).to receive(:call).and_call_original
+          writer.write
+        end
+
+        context "and the second useradd calls succeeds" do
+          it "returns an issue notifying the user was created without home" do
+            result = writer.write
+
+            expect(result).to be_a(Y2Issues::List)
+            expect(result.to_a.size).to eq 1
+            expect(result.first.message).to match(/create home/)
+          end
+        end
+
+        context "and the second useradd call also fails" do
+          let(:second_error) { Cheetah::ExecutionFailed.new("", "", "", "", "second error") }
+          let(:second_call) { ->(*_args) { raise(second_error) } }
+
+          it "returns an issue notifying the user was not created" do
+            result = writer.write
+
+            expect(result).to be_a(Y2Issues::List)
+            expect(result.to_a.size).to eq 1
+            expect(result.first.message).to match(/could not be created/)
+          end
+        end
+      end
+    end
+
+    context "when there is any error setting passwords" do
+      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+
+      before do
+        config.attach(user)
+
+        allow(Yast::Execute).to receive(:on_target!)
+          .with(/chpasswd/, any_args)
+          .and_raise(error)
+      end
+
+      it "returns an issues list containing the issue" do
+        result = writer.write
+
+        expect(result).to be_a(Y2Issues::List)
+        expect(result).to_not be_empty
+        expect(result.map(&:message)).to include(/password.*could not be set/)
+      end
+    end
+
+    context "when there is any error setting the password attributes" do
+      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+      let(:aging) do
+        age = Y2Users::PasswordAging.new
+        age.force_change
+        age
+      end
+
+      before do
+        user.password.aging = aging
+        config.attach(user)
+
+        allow(Yast::Execute).to receive(:on_target!)
+          .with(/chage/, any_args)
+          .and_raise(error)
+      end
+
+      it "returns an issues list containing the issue" do
+        result = writer.write
+
+        expect(result).to be_a(Y2Issues::List)
+        expect(result).to_not be_empty
+        expect(result.map(&:message)).to include(/Error setting the properties of the password/)
+      end
+    end
+
+    context "when there is any error writing the authorized keys" do
+      let(:error) { Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist.new user.home }
+
+      before do
+        user.home = Y2Users::Home.new("/home/y2test")
+        config.attach(user)
+
+        allow(keyring).to receive(:write_keys).and_raise(error)
+      end
+
+      it "returns an issues list containing the issue" do
+        result = writer.write
+
+        expect(result).to be_a(Y2Issues::List)
+        expect(result).to_not be_empty
+        expect(result.map(&:message)).to include(/Error writing authorized keys/)
+      end
+    end
+
+    context "when there is any error creating a new group" do
+      let(:group) do
+        Y2Users::Group.new("users").tap do |group|
+          group.gid = "100"
+          group.users_name = [user.name]
+        end
+      end
+
+      before do
+        config.attach(group)
+
+        allow(Yast).to receive(:y2_logger)
+        allow(Yast::Execute).to receive(:on_target!)
+          .with(/groupadd/, any_args)
+          .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
+      end
+
+      it "returns an issue" do
+        expect(Yast).to receive(:y2_logger).with(any_args, /Error creating group '#{group.name}'/)
+        issues = writer.write
+        expect(issues.first.message).to match("The group '#{group.name}' could not be created")
+      end
+    end
+
+    context "when there is any error modifying a user attribute" do
+      let(:users) { [user] }
+      let(:current_user) { config.users.by_id(user.id) }
+
+      before do
+        allow(Yast).to receive(:y2_logger)
+
+        current_user.home = Y2Users::Home.new("/home/new")
+        allow(Yast::Execute).to receive(:on_target!)
+          .with(/usermod/, any_args)
+          .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
+      end
+
+      it "returns an issue" do
+        expect(Yast).to receive(:y2_logger).with(any_args, /Error modifying user '#{user.name}'/)
+        issues = writer.write
+        expect(issues.first.message).to match("The user '#{user.name}' could not be modified")
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/writer_root_aliases_test.rb
+++ b/test/lib/y2users/linux/writer_root_aliases_test.rb
@@ -1,0 +1,331 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/config"
+require "y2users/user"
+require "y2users/password"
+require "y2users/linux/writer"
+
+describe Y2Users::Linux::Writer do
+  subject(:writer) { described_class.new(config, initial_config) }
+
+  describe "Writing root aliases" do
+    subject(:writer) { Y2Users::Linux::Writer.new(config, initial_config) }
+
+    let(:initial_config) { Y2Users::Config.new }
+    let(:config) { initial_config.copy }
+
+    let(:user) do
+      user = Y2Users::User.new(username)
+      user.password = Y2Users::Password.new(pwd_value)
+      user.password.maximum_age = 30
+      user.receive_system_mail = receiving_system_mails
+      user.system = system_user
+      user.authorized_keys = ["ssh-rsa key"]
+      user
+    end
+    let(:pwd_value) { Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75$Qg6Pp") }
+    let(:system_user) { false }
+
+    def raise_error_for(command)
+      exit_double = instance_double(Process::Status)
+      allow(exit_double).to receive(:exitstatus).and_return(2)
+      allow(Yast::Execute).to receive(:on_target!)
+        .with(/#{command}/, any_args)
+        .and_raise(Cheetah::ExecutionFailed.new("", exit_double, "", "", "error"))
+    end
+
+    def raise_authorized_keys_error
+      keyring = instance_double(Yast::Users::SSHAuthorizedKeyring, write_keys: true)
+      error = Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist.new("/home/user")
+
+      allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
+      allow(keyring).to receive(:write_keys).and_return(error)
+    end
+
+    RSpec.shared_examples "set root alias for" do |username|
+      it "includes #{username} as root alias" do
+        expect(Yast::MailAliases).to receive(:SetRootAlias).with(kind_of(String)) do |arg|
+          expect(arg).to include(username)
+        end
+
+        writer.write
+      end
+    end
+
+    RSpec.shared_examples "does not set root alias for" do |username|
+      it "does not include #{username} as root alias" do
+        expect(Yast::MailAliases).to receive(:SetRootAlias).with(kind_of(String)) do |arg|
+          expect(arg).to_not include(username)
+        end
+
+        writer.write
+      end
+    end
+
+    RSpec.shared_examples "creates new user" do |type|
+      let(:system_user) { type == :system }
+
+      let(:username) { "new-user" }
+
+      before { config.attach(user) }
+
+      context "which has not been set to receive system mails" do
+        let(:receiving_system_mails) { false }
+
+        include_examples "does not set root alias for", "new-user"
+      end
+
+      context "which has been set to receive system mails" do
+        let(:receiving_system_mails) { true }
+
+        context "and it was created successfully" do
+          include_examples "set root alias for", "new-user"
+
+          context "but setting password value fails" do
+            before { raise_error_for(:chpasswd) }
+
+            include_examples "set root alias for", "new-user"
+          end
+
+          context "but setting password attributes fails" do
+            before { raise_error_for(:chage) }
+
+            include_examples "set root alias for", "new-user"
+          end
+
+          context "but setting authorized keys fails" do
+            before { raise_authorized_keys_error }
+
+            include_examples "set root alias for", "new-user"
+          end
+        end
+
+        context "but it couldn't be created" do
+          before { raise_error_for(:useradd) }
+
+          include_examples "does not set root alias for", "new-user"
+        end
+      end
+    end
+
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    describe "when creating a new system user" do
+      include_examples "creates new user", :system
+    end
+
+    describe "when creating a new regular user" do
+      include_examples "creates new user", :regular
+    end
+
+    describe "when editing an existing user" do
+      let(:username) { "existing-user" }
+      let(:edited_user) { config.users.by_id(user.id) }
+
+      before do
+        initial_config.attach(user)
+        edited_user.name = "edited-user"
+        edited_user.receive_system_mail =  should_receive_system_mails
+        edited_user.password.value = Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75")
+        edited_user.password.maximum_age = 60
+        edited_user.authorized_keys = ["ssh-rsa new-key"]
+      end
+
+      context "which was already set as root alias" do
+        let(:receiving_system_mails) { true }
+
+        context "and has been changed to stop receiving system mails" do
+          let(:should_receive_system_mails) { false }
+
+          context "and it was updated successfully" do
+            include_examples "does not set root alias for", "edited-user"
+
+            context "but setting password value fails" do
+              before { raise_error_for(:chpasswd) }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+
+            context "but setting password attributes fails" do
+              before { raise_error_for(:chage) }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+
+            context "but setting authorized keys fails" do
+              before { raise_authorized_keys_error }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+          end
+
+          context "but it couldn't be updated" do
+            before { raise_error_for(:usermod) }
+
+            include_examples "set root alias for", "existing-user"
+            include_examples "does not set root alias for", "edited-user"
+          end
+        end
+
+        context "and it should keep receiving system mails" do
+          let(:should_receive_system_mails) { true }
+
+          context "and it was updated successfully" do
+            include_examples "set root alias for", "edited-user"
+            include_examples "does not set root alias for", "existing-user"
+
+            context "but setting password value fails" do
+              before { raise_error_for(:chpasswd) }
+
+              include_examples "set root alias for", "edited-user"
+              include_examples "does not set root alias for", "existing-user"
+            end
+
+            context "but setting password attributes fails" do
+              before { raise_error_for(:chage) }
+
+              include_examples "set root alias for", "edited-user"
+              include_examples "does not set root alias for", "existing-user"
+            end
+
+            context "but setting authorized keys fails" do
+              before { raise_authorized_keys_error }
+
+              include_examples "set root alias for", "edited-user"
+              include_examples "does not set root alias for", "existing-user"
+            end
+          end
+
+          context "but it couldn't be updated" do
+            before { raise_error_for(:usermod) }
+
+            include_examples "set root alias for", "existing-user"
+            include_examples "does not set root alias for", "edited-user"
+          end
+        end
+      end
+
+      context "which was not set as root alias" do
+        let(:receiving_system_mails) { false }
+
+        context "and has been changed to start receiving system mails" do
+          let(:should_receive_system_mails) { true }
+
+          context "and it was updated successfully" do
+            include_examples "set root alias for", "edited-user"
+
+            context "but setting password value fails" do
+              before { raise_error_for(:chpasswd) }
+
+              include_examples "set root alias for", "edited-user"
+            end
+
+            context "but setting password attributes fails" do
+              before { raise_error_for(:chage) }
+
+              include_examples "set root alias for", "edited-user"
+            end
+
+            context "but setting authorized keys fails" do
+              before { raise_authorized_keys_error }
+
+              include_examples "set root alias for", "edited-user"
+            end
+          end
+
+          context "but it couldn't be updated" do
+            before { raise_error_for(:usermod) }
+
+            include_examples "does not set root alias for", "existing-user"
+            include_examples "does not set root alias for", "edited-user"
+          end
+        end
+
+        context "and it should keep not receiving system mails" do
+          let(:should_receive_system_mails) { false }
+
+          context "and it was updated successfully" do
+            include_examples "does not set root alias for", "edited-user"
+
+            context "but setting password value fails" do
+              before { raise_error_for(:chpasswd) }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+
+            context "but setting password attributes fails" do
+              before { raise_error_for(:chage) }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+
+            context "but setting authorized keys fails" do
+              before { raise_authorized_keys_error }
+
+              include_examples "does not set root alias for", "edited-user"
+            end
+          end
+
+          context "but it couldn't be updated" do
+            before { raise_error_for(:usermod) }
+
+            include_examples "does not set root alias for", "existing-user"
+            include_examples "does not set root alias for", "edited-user"
+          end
+        end
+      end
+    end
+
+    describe "handling the result of SetRootAlias" do
+      before do
+        allow(Yast::MailAliases).to receive(:SetRootAlias).and_return(set_root_alias_result)
+      end
+
+      context "when setting root aliases returns true" do
+        let(:set_root_alias_result) { true }
+
+        it "returns an empty issues list" do
+          result = writer.write
+
+          expect(result).to be_a(Y2Issues::List)
+          expect(result).to be_empty
+        end
+      end
+
+      context "when setting root aliases returns false" do
+        let(:set_root_alias_result) { false }
+
+        it "returns an empty list holding an explanatory issue" do
+          result = writer.write
+
+          expect(result).to be_a(Y2Issues::List)
+          expect(result).to_not be_empty
+          expect(result.first.message).to match(/Error.*root mail aliases/)
+        end
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/writer_settings_test.rb
+++ b/test/lib/y2users/linux/writer_settings_test.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/config"
+require "y2users/user"
+require "y2users/useradd_config"
+require "y2users/login_config"
+require "y2users/linux/writer"
+require "y2users/commit_config_collection"
+
+describe Y2Users::Linux::Writer do
+  subject(:writer) { described_class.new(config, initial_config, commit_configs) }
+
+  describe "Modifying the system configuration via #write" do
+    let(:initial_config) do
+      config = Y2Users::Config.new
+      config
+    end
+
+    let(:config) { initial_config.copy }
+
+    let(:commit_configs) { Y2Users::CommitConfigCollection.new }
+
+    let(:initial_useradd) { Y2Users::UseraddConfig.new(initial_useradd_attrs) }
+    let(:initial_useradd_attrs) do
+      { group: "150", home: "/users", umask: "123", skel: "/etc/skeleton" }
+    end
+
+    before do
+      initial_config.useradd = initial_useradd
+
+      allow(Yast::Execute).to receive(:on_target!)
+      allow(Yast::Autologin).to receive(:Write)
+    end
+
+    context "when there are no login settings" do
+      before do
+        config.login = nil
+      end
+
+      it "does not write auto-login config" do
+        expect(Yast::Autologin).to_not receive(:Write)
+
+        writer.write
+      end
+    end
+
+    context "when there are login settings" do
+      before do
+        config.login = Y2Users::LoginConfig.new
+        config.login.autologin_user = Y2Users::User.new("test")
+        config.login.passwordless = true
+      end
+
+      it "configures auto-login according to the settings" do
+        writer.write
+
+        expect(Yast::Autologin.user).to eq("test")
+        expect(Yast::Autologin.pw_less).to eq(true)
+      end
+
+      it "writes auto-login config" do
+        expect(Yast::Autologin).to receive(:Write)
+
+        writer.write
+      end
+    end
+
+    context "when the useradd configuration has not changed" do
+      it "does not alter the useradd configuration" do
+        expect(Yast::Execute).to_not receive(:on_target!).with(/useradd/, any_args)
+        expect(Yast::ShadowConfig).to_not receive(:set)
+        expect(Yast::ShadowConfig).to_not receive(:write)
+
+        writer.write
+      end
+    end
+
+    context "when the umask for useradd has changed" do
+      it "writes the change to login.defs" do
+        expect(Yast::ShadowConfig).to receive(:set).with(:umask, "321")
+        expect(Yast::ShadowConfig).to receive(:write)
+
+        config.useradd.umask = "321"
+        writer.write
+      end
+    end
+
+    context "when some useradd configuration parameters have changed" do
+      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
+
+      it "writes all the known parameters to the useradd configuration" do
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--expiredate", "")
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--base-dir", "/users")
+
+        config.useradd.group = "users"
+        config.useradd.expiration = ""
+        writer.write
+      end
+
+      it "reports an issue if writing some parameter fails" do
+        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
+          .and_raise(error)
+
+        config.useradd.group = "users"
+        result = writer.write
+        expect(result.first.message).to match(/went wrong writing.*--gid/)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -26,12 +26,12 @@ require "y2users/config"
 require "y2users/user"
 require "y2users/group"
 require "y2users/password"
-require "y2users/useradd_config"
-require "y2users/login_config"
 require "y2users/linux/writer"
+require "y2users/commit_config"
+require "y2users/commit_config_collection"
 
 describe Y2Users::Linux::Writer do
-  subject(:writer) { described_class.new(config, initial_config) }
+  subject(:writer) { described_class.new(config, initial_config, commit_configs) }
 
   describe "#write" do
     let(:initial_config) do
@@ -42,6 +42,8 @@ describe Y2Users::Linux::Writer do
     end
 
     let(:config) { initial_config.copy }
+
+    let(:commit_configs) { Y2Users::CommitConfigCollection.new }
 
     let(:users) { [] }
 
@@ -64,55 +66,19 @@ describe Y2Users::Linux::Writer do
 
     let(:username) { "testuser" }
     let(:pwd_value) { Y2Users::PasswordEncryptedValue.new("$6$3HkB4uLKri75$Qg6Pp") }
-    let(:keyring) { instance_double(Yast::Users::SSHAuthorizedKeyring, write_keys: true) }
-
-    let(:initial_useradd) { Y2Users::UseraddConfig.new(initial_useradd_attrs) }
-    let(:initial_useradd_attrs) do
-      { group: "150", home: "/users", umask: "123", skel: "/etc/skeleton" }
-    end
 
     before do
-      initial_config.useradd = initial_useradd
-
+      allow(File).to receive(:exist?)
       allow(Yast::Execute).to receive(:on_target!)
-      allow(Yast::Users::SSHAuthorizedKeyring).to receive(:new).and_return(keyring)
-      allow(Yast::Autologin).to receive(:Write)
-    end
-
-    RSpec.shared_examples "writing authorized keys" do
-      let(:home) { "/home/y2test" }
-
-      before do
-        current_user = config.users.by_id(user.id)
-        current_user.home = home
-      end
-
-      context "when home is defined" do
-        it "requests to write authorized keys" do
-          expect(keyring).to receive(:write_keys)
-
-          writer.write
-        end
-      end
-
-      context "when home is not defined" do
-        let(:home) { nil }
-
-        it "does not request to write authorized keys" do
-          expect(keyring).to_not receive(:write_keys)
-
-          writer.write
-        end
-      end
     end
 
     RSpec.shared_examples "using btrfs subvolume" do
       context "when a btrfs subvolume must be used as home" do
         before do
-          config.users.by_id(user.id).btrfs_subvolume_home = true
+          config.users.by_id(user.id).home&.btrfs_subvol = true
         end
 
-        it "executes useradd with the right --btrfs-subvolume-home argument" do
+        it "executes useradd with with --btrfs-subvolume-home argument" do
           expect(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
             expect(args.last).to eq user.name
             expect(args).to include("--btrfs-subvolume-home")
@@ -277,7 +243,7 @@ describe Y2Users::Linux::Writer do
       end
     end
 
-    context "for an existing user" do
+    describe "editing an existing user" do
       let(:users) { [user] }
 
       it "does not execute useradd" do
@@ -317,17 +283,48 @@ describe Y2Users::Linux::Writer do
       end
 
       context "whose home was changed" do
+        let(:current_user) { config.users.by_id(user.id) }
+
         before do
-          current_user = config.users.by_id(user.id)
-          current_user.home = "/home/new"
+          user.gid = group.gid
+          current_user.home = Y2Users::Home.new("/home/new")
+          commit_configs.add(commit_config)
+
+          allow(File).to receive(:exist?).with(current_user.home.path).and_return(true)
         end
+
+        let(:commit_config) { Y2Users::CommitConfig.new.tap { |c| c.username = user.name } }
 
         it "executes usermod with the new values" do
           expect(Yast::Execute).to receive(:on_target!).with(
-            /usermod/, "--home", "/home/new", "--move-home", user.name
+            /usermod/, "--home", "/home/new", user.name
           )
 
           writer.write
+        end
+
+        context "and set for moving content to the new location" do
+          before { commit_config.move_home = true }
+
+          it "executes usermod with --move-home argument" do
+            expect(Yast::Execute).to receive(:on_target!).with(
+              /usermod/, "--home", "/home/new", "--move-home", user.name
+            )
+
+            writer.write
+          end
+        end
+
+        context "and set for taking ownership of new location" do
+          before { commit_config.adapt_home_ownership = true }
+
+          it "executes chown over home path" do
+            expect(Yast::Execute).to receive(:on_target!).with(
+              /chown/, "-R", "testuser:100", current_user.home.path
+            )
+
+            writer.write
+          end
         end
       end
 
@@ -405,33 +402,6 @@ describe Y2Users::Linux::Writer do
         end
       end
 
-      context "when modifying a user attribute fails" do
-        before do
-          allow(Yast).to receive(:y2_logger)
-
-          current_user = config.users.by_id(user.id)
-          current_user.home = "/home/new"
-          allow(Yast::Execute).to receive(:on_target!)
-            .with(/usermod/, any_args)
-            .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
-        end
-
-        it "returns an issue" do
-          expect(Yast).to receive(:y2_logger).with(any_args, /Error modifying user '#{user.name}'/)
-          issues = writer.write
-          expect(issues.first.message).to match("The user '#{user.name}' could not be modified")
-        end
-      end
-
-      context "whose authorized keys were edited" do
-        before do
-          current_user = config.users.by_id(user.id)
-          current_user.authorized_keys = ["ssh-rsa new-key"]
-        end
-
-        include_examples "writing authorized keys"
-      end
-
       context "whose password was edited" do
         before do
           current_user = config.users.by_id(user.id)
@@ -491,13 +461,14 @@ describe Y2Users::Linux::Writer do
       end
     end
 
-    context "for a new regular user with all the attributes" do
+    describe "creating a new regular user with all the attributes" do
       before do
         user.uid = "1001"
         user.gid = "2001"
         user.shell = "/bin/y2shell"
-        user.home = "/home/y2test"
         user.gecos = ["First line of", "GECOS"]
+        user.home = Y2Users::Home.new("/home/y2test")
+        user.home.permissions = "777"
 
         config.attach(user)
         config.attach(group)
@@ -505,7 +476,6 @@ describe Y2Users::Linux::Writer do
 
       include_examples "setting password"
       include_examples "setting password attributes"
-      include_examples "writing authorized keys"
       include_examples "using btrfs subvolume"
 
       it "executes useradd with all the parameters, including creation of home directory" do
@@ -514,37 +484,161 @@ describe Y2Users::Linux::Writer do
           expect(args).to include(
             "--uid", "--gid", "--shell", "--home-dir", "--create-home", "--groups"
           )
+          expect(args.join(" ")).to include "--key HOME_MODE=777"
         end
 
         writer.write
       end
+
+      describe "reusing an existing home set for ownershiping it" do
+        let(:commit_config) do
+          Y2Users::CommitConfig.new.tap do |config|
+            config.username = user.name
+          end
+        end
+
+        before do
+          allow(File).to receive(:exist?).with(user.home.path).and_return(true)
+
+          commit_config.adapt_home_ownership = adapt_home_ownership
+          commit_configs.add(commit_config)
+        end
+
+        context "and set for taking ownership" do
+          let(:adapt_home_ownership) { true }
+
+          it "executes chown over home path" do
+            expect(Yast::Execute).to receive(:on_target!).with(
+              /chown/, "-R", "testuser:2001", user.home.path
+            )
+
+            writer.write
+          end
+        end
+
+        context "but not set for taking ownership" do
+          let(:adapt_home_ownership) { false }
+
+          it "does not execute chown over home path" do
+            expect(Yast::Execute).to_not receive(:on_target!).with(
+              /chown/, "-R", "testuser:2001", user.home.path
+            )
+
+            writer.write
+          end
+        end
+      end
+
+      describe "skipping copy of skel files" do
+        let(:commit_config) do
+          Y2Users::CommitConfig.new.tap do |config|
+            config.username = user.name
+            config.home_without_skel = skip_skel
+          end
+        end
+
+        before do
+          commit_configs.add(commit_config)
+        end
+
+        context "when creating a home directory" do
+          before do
+            # The first call checks that the home can be created and the second that
+            # it was already created
+            allow(File).to receive(:exist?).with(user.home.path).and_return(false, true)
+          end
+
+          context "and the user specified skel files are not wanted" do
+            let(:skip_skel) { true }
+
+            it "removes all the home content" do
+              expect(Yast::Execute).to receive(:on_target!).with(/find/, any_args) do |*args|
+                expect(args).to include(user.home.path)
+                expect(args).to include("-delete")
+              end
+
+              writer.write
+            end
+          end
+
+          context "and there is no special setting for skel files" do
+            let(:skip_skel) { false }
+
+            it "does not remove home content" do
+              expect(Yast::Execute).to_not receive(:on_target!).with(/find/, any_args)
+
+              writer.write
+            end
+          end
+        end
+
+        context "when home already existed" do
+          before do
+            allow(File).to receive(:exist?).with(user.home.path).and_return(true)
+          end
+
+          context "and the user specified skel files are not wanted" do
+            let(:skip_skel) { true }
+
+            it "does not try to remove home content" do
+              expect(Yast::Execute).to_not receive(:on_target!).with(/find/, any_args)
+
+              writer.write
+            end
+          end
+
+          context "and there is no special setting for skel files" do
+            let(:skip_skel) { false }
+
+            it "does not try to remove home content" do
+              expect(Yast::Execute).to_not receive(:on_target!).with(/find/, any_args)
+
+              writer.write
+            end
+          end
+        end
+
+        context "when no home is wanted" do
+          before do
+            user.home = nil
+          end
+
+          let(:skip_skel) { true }
+
+          it "does not try to remove home content" do
+            expect(Yast::Execute).to_not receive(:on_target!).with(/find/, any_args)
+
+            writer.write
+          end
+        end
+      end
     end
 
-    context "for a new regular user with no optional attributes specified" do
+    describe "creating a new regular user with no optional attributes specified" do
       before do
         config.attach(user)
       end
 
       include_examples "setting password"
       include_examples "setting password attributes"
-      include_examples "using btrfs subvolume"
 
-      it "executes useradd only with the argument to create the home directory" do
-        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "--create-home", username)
+      it "does not create the user home" do
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "--no-create-home", username)
 
         writer.write
       end
     end
 
-    context "for mix of user with specified uid and without uid" do
+    describe "creating users both with specified uid and without uid" do
       before do
         user2 = Y2Users::User.new("testuser2")
 
         user.uid = "1001"
         user.gid = "2001"
         user.shell = "/bin/y2shell"
-        user.home = "/home/y2test"
+        user.home = Y2Users::Home.new("/home/y2test")
         user.gecos = ["First line of", "GECOS"]
+        user.password = nil # not needed for this test
 
         config.attach(user2)
         config.attach(user)
@@ -560,21 +654,19 @@ describe Y2Users::Linux::Writer do
         end
 
         expect(Yast::Execute).to receive(:on_target!).ordered
-          .with(/useradd/, "--create-home", "testuser2")
+          .with(/useradd/, "--no-create-home", "testuser2")
 
         writer.write
       end
     end
 
-    context "for a new system user" do
+    describe "creating a new system user" do
       before do
-        user.home = "/var/lib/y2test"
+        user.home = Y2Users::Home.new("/var/lib/y2test")
         user.system = true
 
         config.attach(user)
       end
-
-      include_examples "writing authorized keys"
 
       it "executes useradd with the 'system' parameter and without creating a home directory" do
         expect(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
@@ -588,260 +680,13 @@ describe Y2Users::Linux::Writer do
       end
     end
 
-    context "when there are no login settings" do
-      before do
-        config.login = nil
-      end
-
-      it "does not write auto-login config" do
-        expect(Yast::Autologin).to_not receive(:Write)
-
-        writer.write
-      end
-    end
-
-    context "when there are login settings" do
-      before do
-        config.login = Y2Users::LoginConfig.new
-        config.login.autologin_user = Y2Users::User.new("test")
-        config.login.passwordless = true
-      end
-
-      it "configures auto-login according to the settings" do
-        writer.write
-
-        expect(Yast::Autologin.user).to eq("test")
-        expect(Yast::Autologin.pw_less).to eq(true)
-      end
-
-      it "writes auto-login config" do
-        expect(Yast::Autologin).to receive(:Write)
-
-        writer.write
-      end
-    end
-
-    context "when executed with no errors" do
-      before do
-        config.attach(user)
-      end
-
-      it "returns an empty issues list" do
-        result = writer.write
-
-        expect(result).to be_a(Y2Issues::List)
-        expect(result).to be_empty
-      end
-    end
-
-    context "when there is any error adding users" do
-      let(:exit_double) { instance_double(Process::Status) }
-      let(:error) { Cheetah::ExecutionFailed.new("", exit_double, "", "", "initial error") }
-
-      before do
-        config.attach(user)
-        allow(exit_double).to receive(:exitstatus).and_return exitstatus
-
-        call_count = 0
-        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
-          call_count += 1
-          raise(error) if call_count == 1
-
-          second_call.call(*args)
-        end
-      end
-
-      context "and there is no specific handling for the error" do
-        let(:exitstatus) { 1 }
-        let(:second_call) { ->(*args) {} }
-
-        it "returns an issue notifying the user was not created" do
-          result = writer.write
-
-          expect(result).to be_a(Y2Issues::List)
-          expect(result).to_not be_empty
-          expect(result.map(&:message)).to include(/user.*could not be created/)
-        end
-
-        it "does not perform a second attempt to call useradd" do
-          expect(second_call).to_not receive(:call)
-          writer.write
-        end
-      end
-
-      context "and the error was a problem creating the home" do
-        let(:exitstatus) { 12 }
-        let(:second_call) do
-          lambda do |*args|
-            expect(args.last).to eq user.name
-            expect(args).to_not include "--create-home"
-            expect(args).to include "--no-create-home"
-          end
-        end
-
-        it "executes useradd again explicitly avoiding the home creation" do
-          expect(second_call).to receive(:call).and_call_original
-          writer.write
-        end
-
-        context "and the second useradd calls succeeds" do
-          it "returns an issue notifying the user was created without home" do
-            result = writer.write
-
-            expect(result).to be_a(Y2Issues::List)
-            expect(result.to_a.size).to eq 1
-            expect(result.first.message).to match(/create home/)
-          end
-        end
-
-        context "and the second useradd call also fails" do
-          let(:second_error) { Cheetah::ExecutionFailed.new("", "", "", "", "second error") }
-          let(:second_call) { ->(*_args) { raise(second_error) } }
-
-          it "returns an issue notifying the user was not created" do
-            result = writer.write
-
-            expect(result).to be_a(Y2Issues::List)
-            expect(result.to_a.size).to eq 1
-            expect(result.first.message).to match(/could not be created/)
-          end
-        end
-      end
-    end
-
-    context "when there is any error setting passwords" do
-      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
-
-      before do
-        config.attach(user)
-
-        allow(Yast::Execute).to receive(:on_target!)
-          .with(/chpasswd/, any_args)
-          .and_raise(error)
-      end
-
-      it "returns an issues list containing the issue" do
-        result = writer.write
-
-        expect(result).to be_a(Y2Issues::List)
-        expect(result).to_not be_empty
-        expect(result.map(&:message)).to include(/password.*could not be set/)
-      end
-    end
-
-    context "when there is any error setting the password attributes" do
-      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
-      let(:aging) do
-        age = Y2Users::PasswordAging.new
-        age.force_change
-        age
-      end
-
-      before do
-        user.password.aging = aging
-        config.attach(user)
-
-        allow(Yast::Execute).to receive(:on_target!)
-          .with(/chage/, any_args)
-          .and_raise(error)
-      end
-
-      it "returns an issues list containing the issue" do
-        result = writer.write
-
-        expect(result).to be_a(Y2Issues::List)
-        expect(result).to_not be_empty
-        expect(result.map(&:message)).to include(/Error setting the properties of the password/)
-      end
-    end
-
-    context "when there is any error writing the authorized keys" do
-      let(:error) { Yast::Users::SSHAuthorizedKeyring::HomeDoesNotExist.new user.home }
-
-      before do
-        user.home = "/home/y2test"
-        config.attach(user)
-
-        allow(keyring).to receive(:write_keys).and_raise(error)
-      end
-
-      it "returns an issues list containing the issue" do
-        result = writer.write
-
-        expect(result).to be_a(Y2Issues::List)
-        expect(result).to_not be_empty
-        expect(result.map(&:message)).to include(/Error writing authorized keys/)
-      end
-    end
-
-    context "for a new group" do
-      before do
-        config.attach(group)
-      end
+    describe "creating a new group" do
+      before { config.attach(group) }
 
       it "executes groupadd" do
         expect(Yast::Execute).to receive(:on_target!)
           .with(/groupadd/, "--non-unique", "--gid", "100", "users")
         writer.write
-      end
-
-      context "when creating the groupadd fails" do
-        before do
-          allow(Yast).to receive(:y2_logger)
-
-          allow(Yast::Execute).to receive(:on_target!)
-            .with(/groupadd/, any_args)
-            .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
-        end
-
-        it "returns an issue" do
-          expect(Yast).to receive(:y2_logger).with(any_args, /Error creating group '#{group.name}'/)
-          issues = writer.write
-          expect(issues.first.message).to match("The group '#{group.name}' could not be created")
-        end
-      end
-    end
-
-    context "when the useradd configuration has not changed" do
-      it "does not alter the useradd configuration" do
-        expect(Yast::Execute).to_not receive(:on_target!).with(/useradd/, any_args)
-        expect(Yast::ShadowConfig).to_not receive(:set)
-        expect(Yast::ShadowConfig).to_not receive(:write)
-
-        writer.write
-      end
-    end
-
-    context "when the umask for useradd has changed" do
-      it "writes the change to login.defs" do
-        expect(Yast::ShadowConfig).to receive(:set).with(:umask, "321")
-        expect(Yast::ShadowConfig).to receive(:write)
-
-        config.useradd.umask = "321"
-        writer.write
-      end
-    end
-
-    context "when some useradd configuration parameters have changed" do
-      let(:error) { Cheetah::ExecutionFailed.new("", "", "", "", "error") }
-
-      it "writes all the known parameters to the useradd configuration" do
-        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
-        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--expiredate", "")
-        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--base-dir", "/users")
-
-        config.useradd.group = "users"
-        config.useradd.expiration = ""
-        writer.write
-      end
-
-      it "reports an issue if writing some parameter fails" do
-        allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", "--gid", "users")
-          .and_raise(error)
-
-        config.useradd.group = "users"
-        result = writer.write
-        expect(result.first.message).to match(/went wrong writing.*--gid/)
       end
     end
   end

--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -340,6 +340,7 @@ describe Y2Users::User do
       subject.home = Y2Users::Home.new("/home/test1")
       subject.gecos = ["User Test1", "Other"]
       subject.source = [:ldap]
+      subject.receive_system_mail = true
       subject.password = Y2Users::Password.create_plain("S3cr3T")
     end
 
@@ -414,6 +415,16 @@ describe Y2Users::User do
     context "when the #source does not match" do
       before do
         other.source = :local
+      end
+
+      it "returns false" do
+        expect(subject == other).to eq(false)
+      end
+    end
+
+    context "when #receive_system_mail does not match" do
+      before do
+        other.receive_system_mail = false
       end
 
       it "returns false" do
@@ -581,6 +592,36 @@ describe Y2Users::User do
 
           expect(subject.system?).to eq(false)
         end
+      end
+    end
+  end
+
+  describe "#receive_system_mail?" do
+    before do
+      subject.receive_system_mail = value
+    end
+
+    context "when the value is set to nil" do
+      let(:value) { nil }
+
+      it "returns false" do
+        expect(subject.receive_system_mail?).to eq(false)
+      end
+    end
+
+    context "when the value is set to false" do
+      let(:value) { false }
+
+      it "returns false" do
+        expect(subject.receive_system_mail?).to eq(false)
+      end
+    end
+
+    context "when the value is set to true" do
+      let(:value) { true }
+
+      it "returns true" do
+        expect(subject.receive_system_mail?).to eq(true)
       end
     end
   end

--- a/test/lib/y2users/users_module/commit_config_reader_test.rb
+++ b/test/lib/y2users/users_module/commit_config_reader_test.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2users/users_module/commit_config_reader"
+
+describe Y2Users::UsersModule::CommitConfigReader do
+  subject { described_class.new }
+
+  describe "#read" do
+    let(:users) do
+      [
+        {
+          "uid"               => "test1",
+          "chown_home"        => true,
+          "create_home"       => true,
+          "homeDirectory"     => "/home/test",
+          "org_homeDirectory" => "/home/test1",
+          "home_mode"         => "755",
+          "modified"          => "edited",
+          "no_skeleton"       => true
+        },
+        {
+          "uid"               => "test2",
+          "chown_home"        => false,
+          "create_home"       => false,
+          "homeDirectory"     => "/home/test2",
+          "org_homeDirectory" => "/home/test2",
+          "home_mode"         => "755",
+          "modified"          => "edited",
+          "no_skeleton"       => false
+        }
+      ]
+    end
+
+    before do
+      mapped_users = Hash[users.map { |u| [u["uid"], u] }]
+      allow(Yast::Users).to receive(:GetUsers).and_return(mapped_users, {})
+    end
+
+    it "generates a commit config collection with the read data" do
+      commit_configs = subject.read
+
+      expect(commit_configs).to be_a(Y2Users::CommitConfigCollection)
+
+      expect(commit_configs.size).to eq(2)
+
+      commit_config1 = commit_configs.by_username("test1")
+      expect(commit_config1.username).to eq("test1")
+      expect(commit_config1.home_without_skel?).to eq(true)
+      expect(commit_config1.move_home?).to eq(true)
+      expect(commit_config1.adapt_home_ownership?).to eq(true)
+
+      commit_config2 = commit_configs.by_username("test2")
+      expect(commit_config2.username).to eq("test2")
+      expect(commit_config2.home_without_skel?).to eq(false)
+      expect(commit_config2.move_home?).to eq(false)
+      expect(commit_config2.adapt_home_ownership?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The new `Y2Users` classes support creating and editing users. Right now, such classes are only used for (auto)installation and firstboot. That new classes use the shadow tools to probe and commit users. We plan start using them for the YaST users client instead of the `Yast::Users` module. But the users client allows to manipulate more user attributes than the currently supported by `Y2Users`. So, `Y2Users` needs to be extended in order to support all the use cases provided by YaST users client.

Internal links:

* https://trello.com/c/44pVMU58/2656-5-modifying-users-with-y2users
* https://trello.com/c/qfPotJsP/2649-8-missing-attributes-for-interactive-execution
* https://jira.suse.com/browse/SLE-20592

## Solution

`Y2Users` classes were extended to support all the required attributes for creating and editing users. Moreover, now the commit process can be addressed thanks to a new `CommitConfig` class. For example, such a class allows to indicate whether to move the content of the current home directory.

With this PR, a user can be created and edited completely. Deleting users is still missing in `Y2Users`.

NOTE 1: This PR is part of the work accumulated in the *y2users* branch. 

NOTE 2:  The shadow tools does not support some use cases that YaST users client does:
* Create a home directory for an existing user that has no home.
* Create a new home without skel files. 

The shadow tools should be extended to support that use cases. YaST should provide nothing that the shadow tools does not support.

## Testing

* Manually tested
* Added unit tests.
