### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      options: --privileged
 
     steps:
 
@@ -32,7 +34,9 @@ jobs:
 
   Rubocop:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      options: --privileged
 
     steps:
 
@@ -44,7 +48,9 @@ jobs:
 
   Package:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+      options: --privileged
 
     steps:
 
@@ -72,7 +78,9 @@ jobs:
 
   Yardoc:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      options: --privileged
 
     steps:
 
@@ -84,7 +92,9 @@ jobs:
 
   Checks:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      options: --privileged
 
     steps:
 


### PR DESCRIPTION
## Problem

Github actions started failing because the TW docker container uses a new syscall that is not included in the whitelist of the docker version installed in the host system (ubuntu):

~~~
/usr/bin/docker exec  8cf29f62c33867058328ae64e3f50044693a92e1c0d0222dcbade95431f8bb65 sh -c "cat /etc/*release | grep ^ID"
/__e/node12/bin/node[34]: ../src/node_platform.cc:63:std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start(): Assertion `(0) == (uv_thread_create(t.get(), start_thread, this))' failed.
 1: 0x9da7c0 node::Abort() [/__e/node12/bin/node]
 2: 0x9da847  [/__e/node12/bin/node]
 3: 0xa49c8a node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/__e/node12/bin/node]
 4: 0xa49d4b node::NodePlatform::NodePlatform(int, node::tracing::TracingController*) [/__e/node12/bin/node]
 5: 0x94e3da node::InitializeV8Platform(int) [/__e/node12/bin/node]
 6: 0x9ac4c1 node::InitializeOncePerProcess(int, char**) [/__e/node12/bin/node]
 7: 0x9ac6b3 node::Start(int, char**) [/__e/node12/bin/node]
 8: 0x7f32679f4540  [/lib64/libc.so.6]
 9: 0x7f32679f45ec __libc_start_main [/lib64/libc.so.6]
10: 0x94a055  [/__e/node12/bin/node]

~~~

This issue would be automatically fixed if docker is updated in the host, but that is something we cannot control.

## Solution

Run the container with privileged mode. This ensures the syscall is directly passed to the host system.