### PR TITLE
Read useradd config

### DIFF
--- a/src/include/users/helps.rb
+++ b/src/include/users/helps.rb
@@ -112,13 +112,6 @@ module Yast
             "The group name of a new user's primary group.\n" +
             "</p>\n"
         ) +
-        # Help text 1.5/6
-        _(
-          "<p>\n" +
-            "<b>Secondary Groups</b><br>\n" +
-            "Names of additional groups to which to assign new users.\n" +
-            "</p>\n"
-        ) +
         # Help text 2/6
         _(
           "<p><b>Default Login Shell</b><br>\nThe name of the new user's login shell. Select one from the list or enter your own path to the shell.</P>\n"
@@ -129,10 +122,6 @@ module Yast
             "The initial path prefix for a new user's home directory. The username is added\n" +
             "to the end of this value to create the default name of the home directory.\n" +
             "</P>\n"
-        ) +
-        # Help text 4/6
-        _(
-          "<p><b>Skeleton Directory</b><br>\nThe contents of this directory are copied to a user's home directory when a new user is added. </p>\n"
         ) +
         # Help text 4.5/6
         _(

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -1369,14 +1369,16 @@ sub ReadSystemDefaults {
 BEGIN { $TYPEINFO{ReadLoginDefaults} = ["function", "boolean"]; }
 sub ReadLoginDefaults {
 
-    my $self		= shift;
-    foreach my $key (sort keys %useradd_defaults) {
-        my $entry = SCR->Read (".etc.default.useradd.\"\Q$key\E\"");
-        # use the defaults set in this file if $entry not defined
-        next if !defined $entry;
-	$entry =~ s/\"//g;
-        $useradd_defaults{$key} = $entry;
-    }
+    my $self = shift;
+
+    my %defaults = %{Y2UsersLinux->read_useradd_config()};
+
+    $useradd_defaults{"home"} = $defaults{"home"};
+    $useradd_defaults{"group"} = $defaults{"group"};
+    $useradd_defaults{"umask"} = $defaults{"umask"};
+    $useradd_defaults{"expire"} = $defaults{"expiration"};
+    $useradd_defaults{"inactive"} = $defaults{"inactivity_period"};
+    $useradd_defaults{"shell"} = $defaults{"shell"};
 
     UsersLDAP->InitConstants (\%useradd_defaults);
     UsersLDAP->SetDefaultShadow ($self->GetDefaultShadow ("local"));


### PR DESCRIPTION
## Problem

The YaST users client has a tab for editing the useradd settings (i.e., */etc/default/useradd*). The current useradd config is read by the *Users* module, which directly parses */etc/default/useradd*. But such a file could not exist in the system, so *Users* module would propose its own default values instead of relying on the default values proposed by the shadow tools (*useradd -D* command). Moreover, some of the values offered by the "Defaults for New Users" tab are not supported by the shadow tools anymore, for example *skel* and *groups*.    

* https://trello.com/c/hWPBYvVY/2651-3-use-y2usersuseraddconfig-from-to-yastusers
* Part of https://jira.suse.com/browse/SLE-20563

## Solution

Unsupported attributes are removed from the UI (*skel* and *groups*), and the *Y2Users::Linux::UseraddConfigReader* is used for reading values from the system. Entered values in the "Defaults for New Users" tab are persisted into the system by *Y2Users::Linux::Writer*.

![Screenshot from 2021-10-05 08-50-23](https://user-images.githubusercontent.com/1112304/135982362-795a0e7a-ea99-439d-98d2-c17013c75f03.png)

NOTE: This PR is part of the work accumulated in the y2users branch

## Testing

Manually tested.
