### PR TITLE
Document relationship of WriteSecurity and Y2Users writer

### DIFF
--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4412,6 +4412,9 @@ sub Write {
     }
 
     if ($security_modified) {
+	# It does not matter whether this is executed before or after write_from_users_module,
+	# because the encryption is not delegated to the Y2Users writer. Yast::Users encrypts the
+	# passwords right away when initially creating the data structures in memory.
 	WriteSecurity();
     }
 


### PR DESCRIPTION
This is part of the big modification we are doing in the separate `y2users` branch in order to ensure the interactive module of YaST2 uses the `shadow` tools under the hood.

We were not sure whether the UI option "Expert Options -> Password Encryption" would still work after the changes. It does work correctly and this pull request simply adds a comment explaining why.

In short, changing the option takes effect immediately and will affect all the users created after altering the value. Users created in the same YaST execution but before changing the value retain the previous encryption method. The value is finally written to the `login.defs` configuration just to make it persistent, but not to affect the current execution.