### PR TITLE
Fix groups

### DIFF
--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -41,6 +41,7 @@ use MIME::Base64 qw(encode_base64);
 use Digest::MD5;
 use Digest::SHA1 qw(sha1);
 use Data::Dumper;
+use Storable qw(dclone);
 
 $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Terse = 1;
@@ -2405,8 +2406,7 @@ sub CreateGroupOrg {
 	}
 
 	# save first map for later checks of modification (in Commit)
-	my %org_group			= %group_in_work;
-	$group_in_work{"org_group"}	= \%org_group;
+	$group_in_work{"org_group"}	= dclone(\%group_in_work);
     }
 }
 

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -1728,6 +1728,7 @@ sub RemoveUserFromGroup {
     my $ret		= 0;
     my $group_type	= $group_in_work{"type"};
 
+    CreateGroupOrg();
     if ($group_type eq "ldap") {
         $user           = $user_in_work{"dn"};
 	if (defined $user_in_work{"org_dn"}) {


### PR DESCRIPTION
Issue: difference between old and new users in group is not detectable.

Fix: ensure it creates original group even when just syncing from edit user. And also ensure it do deep clone.