### PR TITLE
Edit and delete groups

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,24 +119,28 @@ ylib_y2users_clients_DATA = \
 
 ylib_y2users_linuxdir = @ylibdir@/y2users/linux
 ylib_y2users_linux_DATA = \
-  lib/y2users/linux/action_result.rb \
   lib/y2users/linux/base_reader.rb \
+  lib/y2users/linux/local_reader.rb \
+  lib/y2users/linux/useradd_config_reader.rb \
+  lib/y2users/linux/reader.rb \
   lib/y2users/linux/create_user_action.rb \
   lib/y2users/linux/delete_user_action.rb \
   lib/y2users/linux/delete_user_password_action.rb \
   lib/y2users/linux/edit_user_action.rb \
-  lib/y2users/linux/groups_writer.rb \
-  lib/y2users/linux/local_reader.rb \
-  lib/y2users/linux/login_config_writer.rb \
-  lib/y2users/linux/reader.rb \
   lib/y2users/linux/remove_home_content_action.rb \
   lib/y2users/linux/set_auth_keys_action.rb \
   lib/y2users/linux/set_home_ownership_action.rb \
   lib/y2users/linux/set_user_password_action.rb \
-  lib/y2users/linux/user_action.rb \
-  lib/y2users/linux/useradd_config_reader.rb \
+  lib/y2users/linux/delete_group_action.rb \
+  lib/y2users/linux/edit_group_action.rb \
+  lib/y2users/linux/create_group_action.rb \
+  lib/y2users/linux/action.rb \
+  lib/y2users/linux/action_result.rb \
   lib/y2users/linux/useradd_config_writer.rb \
+  lib/y2users/linux/login_config_writer.rb \
+  lib/y2users/linux/action_writer.rb \
   lib/y2users/linux/users_writer.rb \
+  lib/y2users/linux/groups_writer.rb \
   lib/y2users/linux/writer.rb
 
 ylib_y2users_users_moduledir = @ylibdir@/y2users/users_module

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1963,7 +1963,6 @@ module Yast
       # create a local copy of current group
       group = Users.GetCurrentGroup
       groupname = Ops.get_string(group, "cn", "")
-      password = Ops.get_string(group, "userPassword")
       gid = GetInt(Ops.get(group, "gidNumber"), -1)
       # these are the users with this group as a default:
       more_users = Ops.get_map(group, "more_users", {})
@@ -2007,7 +2006,6 @@ module Yast
       # initialize local variables with current state of group
       reinit_groupdata = lambda do
         groupname = Ops.get_string(group, "cn", groupname)
-        password = Ops.get_string(group, "userPassword", password)
         gid = GetInt(Ops.get(group, "gidNumber"), gid)
         more_users = Convert.convert(
           Ops.get(group, "more_users", more_users),
@@ -2069,11 +2067,6 @@ module Yast
                   _("Group &ID (gid)"),
                   Builtins.sformat("%1", gid)
                 )
-              ),
-              VSpacing(1),
-              Bottom(Password(Id(:pw1), Opt(:hstretch), Label.Password, "")),
-              Bottom(
-                Password(Id(:pw2), Opt(:hstretch), Label.ConfirmPassword, "")
               ),
               VSpacing(1)
             )
@@ -2257,8 +2250,6 @@ module Yast
 
         # 1. click inside Group Data dialog or moving outside of it
         if current == :edit && (ret == :next || tab)
-          pw1 = Convert.to_string(UI.QueryWidget(Id(:pw1), :Value))
-          pw2 = Convert.to_string(UI.QueryWidget(Id(:pw2), :Value))
           new_gid = Convert.to_string(UI.QueryWidget(Id(:gid), :Value))
           new_i_gid = Builtins.tointeger(new_gid)
           new_groupname = Convert.to_string(
@@ -2271,50 +2262,6 @@ module Yast
             Report.Error(error2)
             focus_tab.call(current, :groupname)
             next
-          end
-          # --------------------------------- password checks
-          if pw1 != pw2
-            # The two group password information do not match
-            # error popup
-            Report.Error(_("The passwords do not match.\nTry again."))
-
-            focus_tab.call(current, :pw1)
-            next
-          end
-          if pw1 != "" && pw1 != @default_pw
-            error2 = UsersSimple.CheckPassword(pw1, group_type)
-            if error2 != ""
-              Report.Error(error2)
-              focus_tab.call(current, :pw1)
-              next
-            end
-
-            errors = UsersSimple.CheckPasswordUI(
-              {
-                "cn"           => new_groupname,
-                "userPassword" => pw1,
-                "type"         => group_type
-              }
-            )
-            if errors != []
-              message = Ops.add(
-                Ops.add(
-                  Builtins.mergestring(errors, "\n\n"),
-                  # last part of message popup
-                  "\n\n"
-                ),
-                _("Really use this password?")
-              )
-              if !Popup.YesNo(message)
-                focus_tab.call(current, :pw1)
-                next
-              end
-            end
-
-            password = pw1
-            if Ops.get_boolean(group, "encrypted", false)
-              Ops.set(group, "encrypted", false)
-            end
           end
 
           # --------------------------------- gid checks
@@ -2364,7 +2311,6 @@ module Yast
 
           # --------------------------------- now everything should be OK
           Ops.set(group, "cn", new_groupname)
-          Ops.set(group, "userPassword", password)
           Ops.set(group, "more_users", more_users)
           Ops.set(group, "gidNumber", new_i_gid)
           Ops.set(group, "type", new_type)
@@ -2485,12 +2431,6 @@ module Yast
           end
 
           UI.SetFocus(Id(:groupname)) if what == "add_group"
-          if what == "edit_group"
-            if password != nil
-              UI.ChangeWidget(Id(:pw1), :Value, @default_pw)
-              UI.ChangeWidget(Id(:pw2), :Value, @default_pw)
-            end
-          end
 
           if more
             # set of users having this group as default - cannot be edited!

--- a/src/include/users/helps.rb
+++ b/src/include/users/helps.rb
@@ -300,50 +300,29 @@ module Yast
       # help text 1/6
       helptext = Ops.add(
         Ops.add(
-          Ops.add(
-            Ops.add(
-              _("<p>\nEnter the group data here.   \n</p>\n") +
-                # help text 2/6
-                _(
-                  "<p>\n" +
-                    "<b>Group Name:</b>\n" +
-                    "Avoid long names for groups. Normal lengths are between \n" +
-                    "two and eight characters.  \n" +
-                    "You can redefine the list of characters allowed for group names in\n" +
-                    "the /etc/login.defs file. Read its man page for information.\n" +
-                    "</p>\n"
-                ),
-              # help text 3/6, %1 is number
-              Builtins.sformat(
-                _(
-                  "<p>\n" +
-                    "<b>Group ID (gid):</b>\n" +
-                    "In addition to its name, a group must be assigned a numerical ID for its\n" +
-                    "internal representation. These values are between 0 and\n" +
-                    "%1. Some of the IDs are already assigned during installation. You will be\n" +
-                    "warned if you try to use an already set one.\n" +
-                    "</p>\n"
-                ),
-                UsersCache.GetMaxGID("local")
-              )
-            ),
-            # help text 4/6
+          _("<p>\nEnter the group data here.   \n</p>\n") +
+            # help text 2/6
             _(
               "<p>\n" +
-                "<b>Password:</b>\n" +
-                "To require users who are not members of the group to identify themselves when\n" +
-                "switching to this group (see the man page of <tt>newgrp</tt>), assign a\n" +
-                "password to this group. For security reasons, this password is not shown\n" +
-                "here. This entry is not required.\n" +
+                "<b>Group Name:</b>\n" +
+                "Avoid long names for groups. Normal lengths are between \n" +
+                "two and eight characters.  \n" +
+                "You can redefine the list of characters allowed for group names in\n" +
+                "the /etc/login.defs file. Read its man page for information.\n" +
                 "</p>\n"
-            )
-          ),
-          # help text 5/6
-          _(
-            "<p>\n" +
-              "<b>Confirm Password:</b>\n" +
-              "Enter the password a second time to avoid typing errors.\n" +
-              "</p>\n"
+            ),
+          # help text 3/6, %1 is number
+          Builtins.sformat(
+            _(
+              "<p>\n" +
+                "<b>Group ID (gid):</b>\n" +
+                "In addition to its name, a group must be assigned a numerical ID for its\n" +
+                "internal representation. These values are between 0 and\n" +
+                "%1. Some of the IDs are already assigned during installation. You will be\n" +
+                "warned if you try to use an already set one.\n" +
+                "</p>\n"
+            ),
+            UsersCache.GetMaxGID("local")
           )
         ),
         # help text 6/6

--- a/src/lib/y2users/group.rb
+++ b/src/lib/y2users/group.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "y2users/config_element"
 require "yast2/equatable"
 
@@ -35,6 +36,8 @@ module Y2Users
   #   group.config #=> config
   #   group.attached? #=> true
   class Group < ConfigElement
+    Yast.import "ShadowConfig"
+
     include Yast2::Equatable
 
     # Group name
@@ -72,6 +75,9 @@ module Y2Users
       @name = name
       @users_name = []
       @source = :unknown
+
+      # See #system?
+      @system = false
     end
 
     # Users that become to this group, including users which have this group as primary group
@@ -85,6 +91,45 @@ module Y2Users
       config.users.select { |u| same_gid?(u) || users_name.include?(u.name) }
     end
 
+    # Whether the group has an gid
+    #
+    # @return [Boolean]
+    def gid?
+      !(gid.nil? || gid == "")
+    end
+
+    # Whether this is a system group
+    #
+    # A group is considered a system group if its gid is smaller than SYS_GID_MAX (defined in
+    # /etc/login.defs).
+    #
+    # Note the value of SYS_GID_MIN (also defined in /etc/login.defs) is irrelevant for this check.
+    #
+    # For groups that still don't have an gid, it is possible to enforce whether they should be
+    # considered as a system group (and created as such in the system) via {#system=}.
+    #
+    # This is important when creating an group because its gid is chosen in the
+    # SYS_UID_MIN-SYS_UID_MAX range.
+    #
+    # @return [Boolean]
+    def system?
+      gid? ? system_gid? : @system
+    end
+
+    # Sets whether the group should be considered as a system one
+    #
+    # @raise [RuntimeError] if the group already has an gid, because forcing the value only makes
+    #   sense for a group which gid is still not known.
+    #
+    # @see #system?
+    #
+    # @param value [Boolean]
+    def system=(value)
+      raise "The gid (#{gid}) is already defined" if gid
+
+      @system = value
+    end
+
   private
 
     # @see #users
@@ -92,6 +137,20 @@ module Y2Users
       return false unless gid
 
       user.gid == gid
+    end
+
+    # Whether the user gid corresponds to a system group gid
+    #
+    # @return [Boolean]
+    def system_gid?
+      return false unless gid? && sys_gid_max
+
+      gid.to_i <= sys_gid_max
+    end
+
+    # @return [Integer, nil]
+    def sys_gid_max
+      Yast::ShadowConfig.fetch(:sys_gid_max)&.to_i
     end
   end
 end

--- a/src/lib/y2users/linux/action.rb
+++ b/src/lib/y2users/linux/action.rb
@@ -23,12 +23,12 @@ require "abstract_method"
 
 module Y2Users
   module Linux
-    # Abstract base class for actions to perform over a user
+    # Abstract base class for actions over the system (e.g., create a user, delete a group, etc)
     #
     # Derived classes must implement #run_action method.
     #
     # @example
-    #   class ActionTest < UserAction
+    #   class ActionTest < Action
     #     def run_action
     #       print("test")
     #       true
@@ -39,13 +39,13 @@ module Y2Users
     #   result = action.perform
     #   result.success?       #=> true
     #   result.issues.empty?  #=> true
-    class UserAction
+    class Action
       # Constructor
       #
-      # @param user [User]
+      # @param action_element [Object] object to perform the action (e.g., a user)
       # @param commit_config [CommitConfig, nil] optional configuration for the commit
-      def initialize(user, commit_config = nil)
-        @user = user
+      def initialize(action_element, commit_config = nil)
+        @action_element = action_element
         @commit_config = commit_config
       end
 
@@ -60,8 +60,8 @@ module Y2Users
 
     private
 
-      # @return [User]
-      attr_reader :user
+      # @return [Object]
+      attr_reader :action_element
 
       # @return [CommitConfig]
       attr_reader :commit_config

--- a/src/lib/y2users/linux/action_writer.rb
+++ b/src/lib/y2users/linux/action_writer.rb
@@ -1,0 +1,66 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2issues/list"
+require "abstract_method"
+
+module Y2Users
+  module Linux
+    # Abstract base class for writers that performs actions.
+    #
+    # @see UsersWriter
+    class ActionWriter
+      # Writes changes into the system
+      #
+      # @return [Y2Issues::List] the list of issues generated while writing changes; empty when none
+      def write
+        @issues = Y2Issues::List.new
+
+        actions
+
+        issues
+      end
+
+    private
+
+      # Performs actions
+      #
+      # Derived classes must define this method.
+      abstract_method :actions
+
+      # Issues generated during the process
+      #
+      # @return [Y2Issues::List]
+      attr_reader :issues
+
+      # Performs the given action
+      #
+      # Issues can be generated while performing the action, see {#issues}.
+      #
+      # @param action [Action]
+      # @return [Boolean] true on success
+      def perform_action(action)
+        result = action.perform
+        issues.concat(result.issues)
+
+        result.success?
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/create_group_action.rb
+++ b/src/lib/y2users/linux/create_group_action.rb
@@ -68,6 +68,7 @@ module Y2Users
       def groupadd_options
         opts = []
         opts += ["--non-unique", "--gid", group.gid] if group.gid
+        opts << "--system" if group.system?
         opts << group.name
 
         opts

--- a/src/lib/y2users/linux/create_group_action.rb
+++ b/src/lib/y2users/linux/create_group_action.rb
@@ -1,0 +1,77 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/execute"
+require "y2issues/issue"
+require "y2users/linux/action"
+
+module Y2Users
+  module Linux
+    # Action for creating a new group
+    class CreateGroupAction < Action
+      include Yast::I18n
+      include Yast::Logger
+
+      # Constructor
+      #
+      # @see Action
+      def initialize(group, commit_config = nil)
+        textdomain "users"
+
+        super
+      end
+
+    private
+
+      alias_method :group, :action_element
+
+      # Command for creating new groups
+      GROUPADD = "/usr/sbin/groupadd".freeze
+      private_constant :GROUPADD
+
+      # @see Action#run_action
+      #
+      # Issues are generated when the group cannot be created.
+      def run_action
+        Yast::Execute.on_target!(GROUPADD, *groupadd_options)
+        true
+      rescue Cheetah::ExecutionFailed => e
+        issues << Y2Issues::Issue.new(
+          # TRANSLATORS: %{group} is replaced by a group name.
+          format(_("The group %{group} could not be created"), group: group.name)
+        )
+        log.error("Error creating group #{group.name}: #{e.stderr}")
+        false
+      end
+
+      # Generates options for `groupadd` according to the group attributes
+      #
+      # @return [Array<String>]
+      def groupadd_options
+        opts = []
+        opts += ["--non-unique", "--gid", group.gid] if group.gid
+        opts << group.name
+
+        opts
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for creating a new user
-    class CreateUserAction < UserAction
+    class CreateUserAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -40,6 +40,8 @@ module Y2Users
       end
 
     private
+
+      alias_method :user, :action_element
 
       # Command for creating new users
       USERADD = "/usr/sbin/useradd".freeze
@@ -50,7 +52,7 @@ module Y2Users
       USERADD_E_HOMEDIR = 12
       private_constant :USERADD_E_HOMEDIR
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Issues are generated when the user cannot be created.
       def run_action

--- a/src/lib/y2users/linux/delete_group_action.rb
+++ b/src/lib/y2users/linux/delete_group_action.rb
@@ -1,0 +1,66 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/execute"
+require "y2issues/issue"
+require "y2users/linux/action"
+
+module Y2Users
+  module Linux
+    # Action for deleting a group
+    class DeleteGroupAction < Action
+      include Yast::I18n
+      include Yast::Logger
+
+      # Constructor
+      #
+      # @see Action
+      def initialize(group, commit_config = nil)
+        textdomain "users"
+
+        super
+      end
+
+    private
+
+      alias_method :group, :action_element
+
+      # Command for deleting groups
+      GROUPDEL = "/usr/sbin/groupdel".freeze
+      private_constant :GROUPDEL
+
+      # @see Action#run_action
+      #
+      # Issues are generated when the group cannot be deleted.
+      def run_action
+        Yast::Execute.on_target!(GROUPDEL, group.name)
+        true
+      rescue Cheetah::ExecutionFailed => e
+        issues << Y2Issues::Issue.new(
+          # TRANSLATORS: %{group} is replaced by a group name.
+          format(_("The group %{group} could not be deleted"), group: group.name)
+        )
+        log.error("Error deleting group #{group.name}: #{e.stderr}")
+        false
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/delete_user_action.rb
+++ b/src/lib/y2users/linux/delete_user_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for deleting an existing user
-    class DeleteUserAction < UserAction
+    class DeleteUserAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -41,11 +41,13 @@ module Y2Users
 
     private
 
+      alias_method :user, :action_element
+
       # Command for deleting a user
       USERDEL = "/usr/sbin/userdel".freeze
       private_constant :USERDEL
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Issues are generated when the user cannot be deleted.
       def run_action

--- a/src/lib/y2users/linux/delete_user_password_action.rb
+++ b/src/lib/y2users/linux/delete_user_password_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for deleting the user password
-    class DeleteUserPasswordAction < UserAction
+    class DeleteUserPasswordAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -41,11 +41,13 @@ module Y2Users
 
     private
 
+      alias_method :user, :action_element
+
       # Command for editing a password (i.e., used for deleting the password)
       PASSWD = "/usr/bin/passwd".freeze
       private_constant :PASSWD
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Issues are generated when the password cannot be deleted
       def run_action

--- a/src/lib/y2users/linux/edit_group_action.rb
+++ b/src/lib/y2users/linux/edit_group_action.rb
@@ -49,7 +49,7 @@ module Y2Users
       #
       # It is used to calculate the changes to apply over the group.
       #
-      # @return [User]
+      # @return [Group]
       attr_reader :initial_group
 
       # Command for modifying groups
@@ -60,7 +60,7 @@ module Y2Users
       #
       # Issues are generated when the group cannot be edited.
       def run_action
-        options = usermod_options
+        options = groupmod_options
         Yast::Execute.on_target!(GROUPMOD, *options, initial_group.name) if options.any?
         true
       rescue Cheetah::ExecutionFailed => e
@@ -75,7 +75,7 @@ module Y2Users
       # Generates options for `groupmod` according to the changes in the group
       #
       # @return [Array<String>]
-      def usermod_options
+      def groupmod_options
         opts = []
         opts += ["--new-name", group.name] if group.name && group.name != initial_group.name
         opts += ["--gid", group.gid] if group.gid && group.gid != initial_group.gid

--- a/src/lib/y2users/linux/edit_group_action.rb
+++ b/src/lib/y2users/linux/edit_group_action.rb
@@ -1,0 +1,87 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/execute"
+require "y2issues/issue"
+require "y2users/linux/action"
+
+module Y2Users
+  module Linux
+    # Action for editing an existing group
+    class EditGroupAction < Action
+      include Yast::I18n
+      include Yast::Logger
+
+      # Constructor
+      #
+      # @see Action
+      def initialize(initial_group, target_group, commit_config = nil)
+        textdomain "users"
+
+        super(target_group, commit_config)
+
+        @initial_group = initial_group
+      end
+
+    private
+
+      alias_method :group, :action_element
+
+      # Initial state of the group
+      #
+      # It is used to calculate the changes to apply over the group.
+      #
+      # @return [User]
+      attr_reader :initial_group
+
+      # Command for modifying groups
+      GROUPMOD = "/usr/sbin/groupmod".freeze
+      private_constant :GROUPMOD
+
+      # @see Action#run_action
+      #
+      # Issues are generated when the group cannot be edited.
+      def run_action
+        options = usermod_options
+        Yast::Execute.on_target!(GROUPMOD, *options, initial_group.name) if options.any?
+        true
+      rescue Cheetah::ExecutionFailed => e
+        issues << Y2Issues::Issue.new(
+          # TRANSLATORS: %{group} is replaced by a group name
+          format(_("The group %{group} could not be modified"), group: initial_group.name)
+        )
+        log.error("Error modifying group #{initial_group.name}: #{e.stderr}")
+        false
+      end
+
+      # Generates options for `groupmod` according to the changes in the group
+      #
+      # @return [Array<String>]
+      def usermod_options
+        opts = []
+        opts += ["--new-name", group.name] if group.name && group.name != initial_group.name
+        opts += ["--gid", group.gid] if group.gid && group.gid != initial_group.gid
+
+        opts
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/edit_user_action.rb
+++ b/src/lib/y2users/linux/edit_user_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for editing an existing user
-    class EditUserAction < UserAction
+    class EditUserAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(initial_user, target_user, commit_config = nil)
         textdomain "users"
 
@@ -42,6 +42,8 @@ module Y2Users
       end
 
     private
+
+      alias_method :user, :action_element
 
       # Initial state of the user
       #
@@ -54,7 +56,7 @@ module Y2Users
       USERMOD = "/usr/sbin/usermod".freeze
       private_constant :USERMOD
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Issues are generated when the user cannot be edited.
       def run_action

--- a/src/lib/y2users/linux/groups_writer.rb
+++ b/src/lib/y2users/linux/groups_writer.rb
@@ -18,88 +18,127 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2issues/with_issues"
 require "yast/i18n"
 require "yast2/execute"
+require "y2users/linux/action_writer"
+require "y2users/linux/delete_group_action"
+require "y2users/linux/create_group_action"
+require "y2users/linux/edit_group_action"
 
 module Y2Users
   module Linux
-    # Writes groups to the system using Yast2::Execute and standard linux tools.
+    # Writes groups to the system using standard Linux tools.
     #
     # @note: this is not meant to be used directly, but to be used by the general {Linux::Writer}
-    class GroupsWriter
+    class GroupsWriter < ActionWriter
       include Yast::I18n
       include Yast::Logger
-      include Y2Issues::WithIssues
 
       # Constructor
       #
-      # @param config [Config] see #config
+      # @param target_config [Config] see #target_config
       # @param initial_config [Config] see #initial_config
-      def initialize(config, initial_config)
+      def initialize(target_config, initial_config)
         textdomain "users"
 
-        @config = config
         @initial_config = initial_config
-      end
-
-      # Performs the changes in the system in order to create, edit or delete groups according to
-      # the configs.
-      #
-      # TODO: edit and delete groups
-      #
-      # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
-      def write
-        with_issues do |issues|
-          issues.concat(add_groups)
-        end
-      end
-
-      # Creates the new groups
-      #
-      # @return [Y2Issues::List] the list of issues found while creating groups; empty when none
-      def add_groups
-        with_issues do |issues|
-          new_groups = (config.groups.map(&:id) - initial_config.groups.map(&:id))
-          new_groups.map! { |id| config.groups.find { |g| g.id == id } }
-          # empty string to process groups without gid the last
-          new_groups.sort_by! { |g| g.gid || "" }.reverse!
-          new_groups.each { |g| add_group(g, issues) }
-        end
+        @target_config = target_config
       end
 
     private
 
-      # Configuration containing the users and groups that should exist in the system after writing
-      #
-      # @return [Config]
-      attr_reader :config
-
       # Initial state of the system (usually a Y2Users::Config.system in a running system) that will
-      # be compared with {#config} to know what changes need to be performed.
+      # be compared with {#target_config} to know what changes need to be performed.
       #
       # @return [Config]
       attr_reader :initial_config
 
-      # Command for creating new users
-      GROUPADD = "/usr/sbin/groupadd".freeze
-      private_constant :GROUPADD
-
-      # Executes the command for creating the group
+      # Configuration containing the users and groups that should exist in the system after writing
       #
-      # @param group [Group] the group to be created on the system
-      # @param issues [Y2Issues::List] a collection for adding an issue if something goes wrong
-      def add_group(group, issues)
-        args = []
-        args << "--non-unique" << "--gid" << group.gid if group.gid
-        args << group.name
-        # TODO: system groups?
-        Yast::Execute.on_target!(GROUPADD, *args)
-      rescue Cheetah::ExecutionFailed => e
-        issues << Y2Issues::Issue.new(
-          format(_("The group '%{groupname}' could not be created"), groupname: group.name)
-        )
-        log.error("Error creating group '#{group.name}' - #{e.message}")
+      # @return [Config]
+      attr_reader :target_config
+
+      # Performs the changes in the system in order to create, edit or delete groups according to
+      # the configs.
+      #
+      # @see ActionWriter
+      def actions
+        delete_groups
+        edit_groups
+        add_groups
+      end
+
+      # Deletes groups
+      def delete_groups
+        deleted_groups.each { |g| delete_group(g) }
+      end
+
+      # Performs the action for deleting a group
+      #
+      # @param group [Group]
+      # @return [Boolean] true on success
+      def delete_group(group)
+        action = DeleteGroupAction.new(group)
+
+        perform_action(action)
+      end
+
+      # Creates the new groups
+      def add_groups
+        new_groups.each { |g| add_group(g) }
+      end
+
+      # Performs the action for creating a new group
+      #
+      # @param group [Group]
+      # @return [Boolean] true on success
+      def add_group(group)
+        action = CreateGroupAction.new(group)
+
+        perform_action(action)
+      end
+
+      # Edits the groups
+      def edit_groups
+        edited_groups.each do |group|
+          initial_group = initial_config.groups.by_id(group.id)
+          edit_group(initial_group, group)
+        end
+      end
+
+      # Performs the action for editing a group
+      #
+      # @param initial_group [Group]
+      # @param target_group [Group]
+      #
+      # @return [Boolean] true on success
+      def edit_group(initial_group, target_group)
+        action = EditGroupAction.new(initial_group, target_group)
+
+        perform_action(action)
+      end
+
+      # Groups that should be deleted
+      #
+      # @return [Array<Group>]
+      def deleted_groups
+        initial_config.groups.without(target_config.groups.ids).all
+      end
+
+      # Groups that should be created
+      #
+      # @return [Array<Group>]
+      def new_groups
+        groups = target_config.groups.without(initial_config.groups.map(&:id))
+        # empty string to process groups without gid the last
+        groups.all.sort_by! { |g| g.gid || "" }.reverse
+      end
+
+      # Groups that should be edited
+      #
+      # @return [Array<Group>]
+      def edited_groups
+        target_config.groups.changed_from(initial_config.groups).all
       end
     end
   end

--- a/src/lib/y2users/linux/remove_home_content_action.rb
+++ b/src/lib/y2users/linux/remove_home_content_action.rb
@@ -21,7 +21,7 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
@@ -30,13 +30,13 @@ module Y2Users
     # Note that this action is not intended to remove the home itself, but only its content.
     # Basically, this action exists to supply the use case of creating a home without skel files,
     # which is not currently supported by the shadow tools.
-    class RemoveHomeContentAction < UserAction
+    class RemoveHomeContentAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -45,11 +45,13 @@ module Y2Users
 
     private
 
+      alias_method :user, :action_element
+
       # Command for finding files
       FIND = "/usr/bin/find".freeze
       private_constant :FIND
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Removes the content of the user home, even the hidden files.
       #

--- a/src/lib/y2users/linux/set_auth_keys_action.rb
+++ b/src/lib/y2users/linux/set_auth_keys_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "y2issues/issue"
 require "users/ssh_authorized_keyring"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for setting the authorized keys of a user
-    class SetAuthKeysAction < UserAction
+    class SetAuthKeysAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -41,7 +41,9 @@ module Y2Users
 
     private
 
-      # @see UserAction#run_action
+      alias_method :user, :action_element
+
+      # @see Action#run_action
       #
       # Issues are generated when the authorized keys cannot be set.
       def run_action

--- a/src/lib/y2users/linux/set_home_ownership_action.rb
+++ b/src/lib/y2users/linux/set_home_ownership_action.rb
@@ -21,7 +21,7 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
@@ -29,13 +29,13 @@ module Y2Users
     #
     # This action is needed when reusing an existing home in order to adapt home ownership to the
     # user.
-    class SetHomeOwnershipAction < UserAction
+    class SetHomeOwnershipAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -44,11 +44,13 @@ module Y2Users
 
     private
 
+      alias_method :user, :action_element
+
       # Command for changing ownership
       CHOWN = "/usr/bin/chown".freeze
       private_constant :CHOWN
 
-      # @see UserAction#run_action
+      # @see Action#run_action
       #
       # Issues are generated when ownership cannot be changed.
       def run_action

--- a/src/lib/y2users/linux/set_user_password_action.rb
+++ b/src/lib/y2users/linux/set_user_password_action.rb
@@ -21,18 +21,18 @@ require "yast"
 require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
-require "y2users/linux/user_action"
+require "y2users/linux/action"
 
 module Y2Users
   module Linux
     # Action for setting the user password
-    class SetUserPasswordAction < UserAction
+    class SetUserPasswordAction < Action
       include Yast::I18n
       include Yast::Logger
 
       # Constructor
       #
-      # @see UserAction
+      # @see Action
       def initialize(user, commit_config = nil)
         textdomain "users"
 
@@ -41,7 +41,9 @@ module Y2Users
 
     private
 
-      # @see UserAction#run_action
+      alias_method :user, :action_element
+
+      # @see Action#run_action
       def run_action
         set_password_value && set_password_attributes
       end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -86,8 +86,8 @@ module Y2Users
       # @see ActionWriter
       def actions
         delete_users
-        add_users
         edit_users
+        add_users
         write_root_aliases
       end
 

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "y2users/config_element"
 require "y2users/user_validator"
 require "y2users/password_validator"

--- a/src/lib/y2users/users_module/reader.rb
+++ b/src/lib/y2users/users_module/reader.rb
@@ -205,15 +205,7 @@ module Y2Users
 
         group.gid = attr_value(:gidNumber, group_attrs)&.to_s
         group.users_name = group_attrs["userlist"].keys
-
-        # TODO: no system support for groups
-        # if !group.gid && group_attrs["type"] == "system"
-        #  group.system = true
-        # end
-
-        # set password only if specified, nil means not touch it
-        # TODO: group passwords not supported
-        # group.password = create_password(group_attrs) if group_attrs["userPassword"]
+        group.system = true if !group.gid && group_attrs["type"] == "system"
 
         group
       end

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -2544,16 +2544,6 @@ sub EditGroup {
 		$group_in_work{"removed_userlist"} = \%removed;
 	    }
 	}
-	if ($key eq "userPassword" && (defined $data{$key}) &&
-	    # crypt password only once (when changed)
-	    !bool ($data{"encrypted"}))
-	{
-		$group_in_work{$key}		=
-		    $self->CryptPassword ($data{$key}, $type, "group");
-		$group_in_work{"encrypted"}	= YaST::YCP::Boolean (1);
-		$data{"encrypted"}		= YaST::YCP::Boolean (1);
-		next;
-	}
 	$group_in_work{$key}	= $data{$key};
     }
     $group_in_work{"what"}	= "edit_group";
@@ -3295,16 +3285,7 @@ sub AddGroup {
     # ----------------------------------------------------------------
 
     foreach my $key (keys %data) {
-	if ($key eq "userPassword" && (defined $data{$key}) &&
-	    !bool ($data{"encrypted"}))
-	{
-	    $group_in_work{$key}	=
-		$self->CryptPassword ($data{$key}, $type, "group");
-	    $group_in_work{"encrypted"}	= YaST::YCP::Boolean (1);
-	}
-	else {
-	    $group_in_work{$key}	= $data{$key};
-	}
+	$group_in_work{$key}	= $data{$key};
     }
 
     $group_in_work{"type"}		= $type;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -36,6 +36,9 @@ TESTS = \
   lib/y2users/linux/set_auth_keys_action_test.rb \
   lib/y2users/linux/set_home_ownership_action_test.rb \
   lib/y2users/linux/set_user_password_action_test.rb \
+  lib/y2users/linux/delete_group_action_test.rb \
+  lib/y2users/linux/edit_group_action_test.rb \
+  lib/y2users/linux/create_group_action_test.rb \
   lib/y2users/linux/useradd_config_writer_test.rb \
   lib/y2users/linux/users_writer_test.rb \
   lib/y2users/linux/writer_test.rb \

--- a/test/lib/y2users/group_test.rb
+++ b/test/lib/y2users/group_test.rb
@@ -185,4 +185,88 @@ describe Y2Users::Group do
       end
     end
   end
+
+  describe "#system?" do
+    before do
+      allow(Yast::ShadowConfig).to receive(:fetch).with(:sys_gid_max).and_return("499")
+    end
+
+    context "when the group has gid" do
+      before do
+        subject.gid = gid
+      end
+
+      context "and the gid is smaller than the max system gid" do
+        let(:gid) { 300 }
+
+        it "returns true" do
+          expect(subject.system?).to eq(true)
+        end
+      end
+
+      context "and the gid is bigger than the max system gid" do
+        let(:gid) { 500 }
+
+        it "returns false" do
+          expect(subject.system?).to eq(false)
+        end
+      end
+    end
+
+    context "when the group has no gid" do
+      before do
+        subject.system = is_system
+      end
+
+      context "and the group was configured as a system group" do
+        let(:is_system) { true }
+
+        it "returns true" do
+          expect(subject.system?).to eq(true)
+        end
+      end
+
+      context "and the user was not configured as a system user" do
+        let(:is_system) { false }
+
+        it "returns false" do
+          expect(subject.system?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#system=" do
+    before do
+      subject.gid = gid
+    end
+
+    context "if the group has already a gid" do
+      let(:gid) { 1000 }
+
+      it "raises an error" do
+        expect { subject.system = true }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "if the group has no gid yet" do
+      let(:gid) { nil }
+
+      context "and true is given" do
+        it "marks the group as a system group" do
+          subject.system = true
+
+          expect(subject.system?).to eq(true)
+        end
+      end
+
+      context "and false is given" do
+        it "marks the group as a local group" do
+          subject.system = false
+
+          expect(subject.system?).to eq(false)
+        end
+      end
+    end
+  end
 end

--- a/test/lib/y2users/group_test.rb
+++ b/test/lib/y2users/group_test.rb
@@ -226,7 +226,7 @@ describe Y2Users::Group do
         end
       end
 
-      context "and the user was not configured as a system user" do
+      context "and the group was not configured as a system group" do
         let(:is_system) { false }
 
         it "returns false" do

--- a/test/lib/y2users/linux/create_group_action_test.rb
+++ b/test/lib/y2users/linux/create_group_action_test.rb
@@ -80,6 +80,34 @@ describe Y2Users::Linux::CreateGroupAction do
       end
     end
 
+    context "when the group is a local group" do
+      before do
+        group.system = false
+      end
+
+      it "calls groupadd without --system option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args).to_not include("--system")
+        end
+
+        subject.perform
+      end
+    end
+
+    context "when the group is a system group" do
+      before do
+        group.system = true
+      end
+
+      it "calls groupadd with --system option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args).to include("--system")
+        end
+
+        subject.perform
+      end
+    end
+
     context "when the command for creating the group successes" do
       it "returns a successful result" do
         result = subject.perform

--- a/test/lib/y2users/linux/create_group_action_test.rb
+++ b/test/lib/y2users/linux/create_group_action_test.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/linux/create_group_action"
+require "y2users/group"
+
+describe Y2Users::Linux::CreateGroupAction do
+  subject { described_class.new(group) }
+
+  let(:group) { Y2Users::Group.new("test") }
+
+  describe "#write" do
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    it "calls groupadd to create the group" do
+      expect(Yast::Execute).to receive(:on_target!).with("/usr/sbin/groupadd", "test")
+
+      subject.perform
+    end
+
+    context "when the group has gid" do
+      before do
+        group.gid = "1000"
+      end
+
+      it "calls groupadd with --non-unique option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args).to include("--non-unique")
+        end
+
+        subject.perform
+      end
+
+      it "calls groupadd with --gid option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args.join(" ")).to match(/--gid 1000/)
+        end
+
+        subject.perform
+      end
+    end
+
+    context "when the group has no gid" do
+      it "calls groupadd without --non-unique option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args).to_not include("--non-unique")
+        end
+
+        subject.perform
+      end
+
+      it "calls groupadd without --gid option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args).to_not include("--gid")
+        end
+
+        subject.perform
+      end
+    end
+
+    context "when the command for creating the group successes" do
+      it "returns a successful result" do
+        result = subject.perform
+
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context "when the command for creating the group fails" do
+      before do
+        allow(Yast::Execute).to receive(:on_target!)
+          .and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+      end
+
+      it "returns a failed result with an issue" do
+        result = subject.perform
+
+        expect(result.success?).to eq(false)
+        expect(result.issues.first.message).to match(/could not be created/)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/create_group_action_test.rb
+++ b/test/lib/y2users/linux/create_group_action_test.rb
@@ -29,7 +29,7 @@ describe Y2Users::Linux::CreateGroupAction do
 
   let(:group) { Y2Users::Group.new("test") }
 
-  describe "#write" do
+  describe "#perform" do
     before do
       allow(Yast::Execute).to receive(:on_target!)
     end

--- a/test/lib/y2users/linux/delete_group_action_test.rb
+++ b/test/lib/y2users/linux/delete_group_action_test.rb
@@ -29,7 +29,7 @@ describe Y2Users::Linux::DeleteGroupAction do
 
   let(:group) { Y2Users::Group.new("test") }
 
-  describe "#write" do
+  describe "#perform" do
     before do
       allow(Yast::Execute).to receive(:on_target!)
     end

--- a/test/lib/y2users/linux/delete_group_action_test.rb
+++ b/test/lib/y2users/linux/delete_group_action_test.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/linux/delete_group_action"
+require "y2users/group"
+
+describe Y2Users::Linux::DeleteGroupAction do
+  subject { described_class.new(group) }
+
+  let(:group) { Y2Users::Group.new("test") }
+
+  describe "#write" do
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    it "calls groupdel to delete the group" do
+      expect(Yast::Execute).to receive(:on_target!).with("/usr/sbin/groupdel", "test")
+
+      subject.perform
+    end
+
+    context "when the command for deleting the group successes" do
+      it "returns a successful result" do
+        result = subject.perform
+
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context "when the command for deleting the group fails" do
+      before do
+        allow(Yast::Execute).to receive(:on_target!)
+          .and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+      end
+
+      it "returns a failed result with an issue" do
+        allow(Yast::Execute).to receive(:on_target!)
+          .and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+
+        result = subject.perform
+
+        expect(result.success?).to eq(false)
+        expect(result.issues.first.message).to match(/could not be deleted/)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/edit_group_action_test.rb
+++ b/test/lib/y2users/linux/edit_group_action_test.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2users/linux/edit_group_action"
+require "y2users/group"
+
+describe Y2Users::Linux::EditGroupAction do
+  subject { described_class.new(initial_group, target_group) }
+
+  let(:initial_group) { Y2Users::Group.new("test") }
+
+  let(:target_group) { initial_group.copy }
+
+  describe "#write" do
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    context "when the group name has changed" do
+      before do
+        target_group.name = "other"
+      end
+
+      it "calls groupmod with --new-name option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupmod/, any_args, "test") do |*args|
+          expect(args.join(" ")).to match(/--new-name other/)
+        end
+
+        subject.perform
+      end
+    end
+
+    context "when the gid has changed" do
+      before do
+        target_group.gid = "1000"
+      end
+
+      it "calls groupmod with --gid option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupmod/, any_args, "test") do |*args|
+          expect(args.join(" ")).to match(/--gid 1000/)
+        end
+
+        subject.perform
+      end
+    end
+
+    context "when the group has not been modified" do
+      it "does not call groupmod" do
+        expect(Yast::Execute).to_not receive(:on_target!).with(/groupmod/)
+
+        subject.perform
+      end
+    end
+
+    context "when the command for editing the group successes" do
+      before do
+        # Some change to ensure the command is called
+        target_group.name = "other"
+      end
+
+      it "returns a successful result" do
+        result = subject.perform
+
+        expect(result.success?).to eq(true)
+      end
+    end
+
+    context "when the command for creating the group fails" do
+      before do
+        # Some change to ensure the command is called
+        target_group.name = "other"
+
+        allow(Yast::Execute).to receive(:on_target!)
+          .and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+      end
+
+      it "returns a failed result with an issue" do
+        result = subject.perform
+
+        expect(result.success?).to eq(false)
+        expect(result.issues.first.message).to match(/could not be modified/)
+      end
+    end
+  end
+end

--- a/test/lib/y2users/linux/edit_group_action_test.rb
+++ b/test/lib/y2users/linux/edit_group_action_test.rb
@@ -31,7 +31,7 @@ describe Y2Users::Linux::EditGroupAction do
 
   let(:target_group) { initial_group.copy }
 
-  describe "#write" do
+  describe "#perform" do
     before do
       allow(Yast::Execute).to receive(:on_target!)
     end

--- a/test/lib/y2users/linux/set_user_password_action_test.rb
+++ b/test/lib/y2users/linux/set_user_password_action_test.rb
@@ -59,7 +59,7 @@ describe Y2Users::Linux::SetUserPasswordAction do
 
   let(:account_expiration) { nil }
 
-  describe "#write" do
+  describe "#perform" do
     before do
       allow(Yast::Execute).to receive(:on_target!)
     end

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -94,7 +94,7 @@ describe Y2Users::Linux::UsersWriter do
 
     before do
       # Prevent to perform real actions into the system
-      allow_any_instance_of(Y2Users::Linux::UserAction).to receive(:perform).and_return(success)
+      allow_any_instance_of(Y2Users::Linux::Action).to receive(:perform).and_return(success)
       allow(Yast::MailAliases).to receive(:SetRootAlias)
     end
 
@@ -343,7 +343,7 @@ describe Y2Users::Linux::UsersWriter do
         end
 
         it "does not perform more actions" do
-          expect_any_instance_of(Y2Users::Linux::UserAction).to_not receive(:perform)
+          expect_any_instance_of(Y2Users::Linux::Action).to_not receive(:perform)
 
           subject.write
         end
@@ -560,7 +560,7 @@ describe Y2Users::Linux::UsersWriter do
         end
 
         it "does not perform more actions" do
-          expect_any_instance_of(Y2Users::Linux::UserAction).to_not receive(:perform)
+          expect_any_instance_of(Y2Users::Linux::Action).to_not receive(:perform)
 
           subject.write
         end

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -521,7 +521,7 @@ describe Y2Users::Linux::UsersWriter do
             end
           end
 
-          context "and the home did no exist on disk yet" do
+          context "and the home did not exist on disk yet" do
             let(:exist_home) { false }
 
             context "and the home was created" do

--- a/test/lib/y2users/users_module/reader_test.rb
+++ b/test/lib/y2users/users_module/reader_test.rb
@@ -145,12 +145,11 @@ describe Y2Users::UsersModule::Reader do
       # real data with data dumper from perl after modifications in UI
       {
         "cn"            => "users",
-        "gidNumber"     => 100,
+        "gidNumber"     => "100",
         "more_users"    => {},
         "org_cn"        => "users",
         "org_gidNumber" => 100,
         "type"          => "local",
-        "userPassword"  => "x",
         "userlist"      => {}
       },
       {
@@ -161,11 +160,17 @@ describe Y2Users::UsersModule::Reader do
         "org_cn"        => "wheel",
         "org_gidNumber" => 497,
         "type"          => "system",
-        "userPassword"  => "x",
         "userlist"      => {
           "test5" => 1
         },
         "what"          => "user_change"
+      },
+      {
+        "cn"         => "test",
+        "gidNumber"  => "",
+        "more_users" => {},
+        "type"       => "system",
+        "userlist"   => {}
       }
     ]
   end
@@ -181,7 +186,6 @@ describe Y2Users::UsersModule::Reader do
         "org_gidNumber" => 1000,
         "plugins"       => [],
         "type"          => "local",
-        "userPassword"  => nil,
         "userlist"      => {
           "test2" => 1
         },
@@ -299,7 +303,7 @@ describe Y2Users::UsersModule::Reader do
       expect(target_config).to be_a(Y2Users::Config)
 
       expect(target_config.users.size).to eq 2
-      expect(target_config.groups.size).to eq 3
+      expect(target_config.groups.size).to eq 4
 
       test_user = target_config.users.by_name("test5")
       expect(test_user.uid).to eq "1002"
@@ -319,6 +323,9 @@ describe Y2Users::UsersModule::Reader do
       expect(test_group.gid).to eq "497"
       expect(test_group.users.map(&:name)).to eq(["test5"])
 
+      test_group = target_config.groups.by_name("test")
+      expect(test_group.system?).to eq(true)
+
       useradd = target_config.useradd
       expect(useradd.group).to eq "100"
       expect(useradd.expiration).to eq ""
@@ -328,7 +335,7 @@ describe Y2Users::UsersModule::Reader do
       expect(system_config).to be_a(Y2Users::Config)
 
       expect(system_config.users.size).to eq 3
-      expect(system_config.groups.size).to eq 3
+      expect(system_config.groups.size).to eq 4
 
       added_user = system_config.users.by_name("test5")
       expect(added_user).to eq nil


### PR DESCRIPTION
## Problem

Editing and deleting groups is not supported by *Y2Users* yet.

* https://trello.com/c/Gi94AHix/2697-2-y2users-modification-and-deletion-of-groups

## Solution

Add support for editing and deleting groups in *Linux::GroupsWriter*. Moreover, group password is dropped.

## Testing

* Unit tests
* Manually tested