### PR TITLE
Read home permissions and root aliases

### DIFF
--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -20,14 +20,9 @@
 require "yast"
 require "abstract_method"
 require "y2users/config"
-require "y2users/login_config"
 require "y2users/parsers/group"
 require "y2users/parsers/passwd"
 require "y2users/parsers/shadow"
-require "y2users/linux/useradd_config_reader"
-require "users/ssh_authorized_keyring"
-
-Yast.import "Autologin"
 
 module Y2Users
   module Linux

--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -28,6 +28,7 @@ require "y2users/linux/useradd_config_reader"
 require "users/ssh_authorized_keyring"
 
 Yast.import "Autologin"
+Yast.import "MailAliases"
 
 module Y2Users
   module Linux
@@ -41,6 +42,7 @@ module Y2Users
       def read
         Config.new.tap do |config|
           read_elements(config)
+          read_root_aliases(config)
           read_passwords(config)
           read_authorized_keys(config)
           read_useradd_config(config)
@@ -84,6 +86,18 @@ module Y2Users
       # @!method load_groups
       #   @return [String] loaded groups from the system
       abstract_method :load_groups
+
+      # Set root aliases (i.e., users receiving system mails)
+      #
+      # @see Yast::MailAliases#GetRootAlias
+      #
+      # @param config [Config]
+      def read_root_aliases(config)
+        Yast::MailAliases.GetRootAlias.split(", ").each do |name|
+          user = config.users.by_name(name)
+          user.receive_system_mail = true if user
+        end
+      end
 
       # Parses the content retrieved by {#load_passwords} and sets user passwords
       #

--- a/src/lib/y2users/linux/base_reader.rb
+++ b/src/lib/y2users/linux/base_reader.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "yast2/execute"
 require "abstract_method"
 require "y2users/config"
 require "y2users/login_config"
@@ -29,7 +28,6 @@ require "y2users/linux/useradd_config_reader"
 require "users/ssh_authorized_keyring"
 
 Yast.import "Autologin"
-Yast.import "MailAliases"
 
 module Y2Users
   module Linux
@@ -43,12 +41,7 @@ module Y2Users
       def read
         Config.new.tap do |config|
           read_elements(config)
-          read_root_aliases(config)
           read_passwords(config)
-          read_home_permissions(config)
-          read_authorized_keys(config)
-          read_useradd_config(config)
-          read_login(config)
         end
       end
 
@@ -89,18 +82,6 @@ module Y2Users
       #   @return [String] loaded groups from the system
       abstract_method :load_groups
 
-      # Set root aliases (i.e., users receiving system mails)
-      #
-      # @see Yast::MailAliases#GetRootAlias
-      #
-      # @param config [Config]
-      def read_root_aliases(config)
-        Yast::MailAliases.GetRootAlias.split(", ").each do |name|
-          user = config.users.by_name(name)
-          user.receive_system_mail = true if user
-        end
-      end
-
       # Parses the content retrieved by {#load_passwords} and sets user passwords
       #
       # @see Parsers::Shadow#parse
@@ -123,58 +104,6 @@ module Y2Users
       # @!method load_passwords
       #   @return [String] loaded passwords from the system
       abstract_method :load_passwords
-
-      # Command for reading home directory permissions
-      STAT = "/usr/bin/stat".freeze
-      private_constant :STAT
-
-      # Reads home permissions
-      #
-      # @return [Array<Y2Users::User>]
-      def read_home_permissions(config)
-        config.users.reject(&:system?).each do |user|
-          next unless user.home && Dir.exist?(user.home.path)
-
-          user.home.permissions = Yast::Execute.locally!(
-            STAT, "--printf", "%a", user.home.path,
-            stdout: :capture
-          )
-        end
-      end
-
-      # Reads users authorized keys
-      #
-      # @see Yast::Users::SSHAuthorizedKeyring#read_keys
-      # @return [Array<Y2Users::User>]
-      def read_authorized_keys(config)
-        config.users.each do |user|
-          next unless user.home
-
-          user.authorized_keys = Yast::Users::SSHAuthorizedKeyring.new(user.home.path).read_keys
-        end
-      end
-
-      # Reads the configuration for useradd
-      #
-      # @param config [Config]
-      def read_useradd_config(config)
-        config.useradd = UseraddConfigReader.new.read
-      end
-
-      # Reads the login information
-      #
-      # @param config [Config]
-      def read_login(config)
-        Yast::Autologin.Read
-
-        return unless Yast::Autologin.used
-
-        login = LoginConfig.new
-        login.autologin_user = config.users.by_name(Yast::Autologin.user)
-        login.passwordless = Yast::Autologin.pw_less
-
-        config.login = login
-      end
     end
   end
 end

--- a/src/lib/y2users/linux/reader.rb
+++ b/src/lib/y2users/linux/reader.rb
@@ -71,10 +71,13 @@ module Y2Users
         config.users.reject(&:system?).each do |user|
           next unless user.home && Dir.exist?(user.home.path)
 
+          # NOTE: '#' printf flag is needed to make sure permissions bits
+          # returned by the %a stat format sequence are in octal notation
+          # starting by 0, which is needed for some commands like useradd.
           user.home.permissions = Yast::Execute.on_target!(
-            STAT, "--printf", "%a", user.home.path,
+            STAT, "--printf", "%#a", user.home.path,
             stdout: :capture
-          ).prepend("0")
+          )
         end
       end
 

--- a/src/lib/y2users/linux/reader.rb
+++ b/src/lib/y2users/linux/reader.rb
@@ -71,9 +71,8 @@ module Y2Users
         config.users.reject(&:system?).each do |user|
           next unless user.home && Dir.exist?(user.home.path)
 
-          # NOTE: '#' printf flag is needed to make sure permissions bits
-          # returned by the %a stat format sequence are in octal notation
-          # starting by 0, which is needed for some commands like useradd.
+          # "stat --printf %#a" returns the permissions in octal format
+          # (e.g., 0755), as expected by {Home#permissions}.
           user.home.permissions = Yast::Execute.on_target!(
             STAT, "--printf", "%#a", user.home.path,
             stdout: :capture

--- a/src/lib/y2users/linux/reader.rb
+++ b/src/lib/y2users/linux/reader.rb
@@ -20,11 +20,93 @@
 require "yast2/execute"
 require "y2users/linux/base_reader"
 
+Yast.import "MailAliases"
+
 module Y2Users
   module Linux
     # Reads users configuration from the system using `getent` command.
     class Reader < BaseReader
-    private # rubocop:disable Layout/IndentationWidth
+      # @see BaseReader#read
+      # @note some of these #read_* methods could be moved to the
+      #   {BaseReader#read} once they allow reading from a specific location
+      #   (i.e., compatible with {LocalReader} too)
+      def read
+        config = super
+
+        read_root_aliases(config)
+        read_home_permissions(config)
+        read_authorized_keys(config)
+        read_useradd_config(config)
+        read_login(config)
+
+        config
+      end
+
+    private
+
+      # Set root aliases (i.e., users receiving system mails)
+      #
+      # @see Yast::MailAliases#GetRootAlias
+      #
+      # @param config [Config]
+      def read_root_aliases(config)
+        Yast::MailAliases.GetRootAlias.split(", ").each do |name|
+          user = config.users.by_name(name)
+          user.receive_system_mail = true if user
+        end
+      end
+
+      # Command for reading home directory permissions
+      STAT = "/usr/bin/stat".freeze
+      private_constant :STAT
+
+      # Reads home permissions
+      #
+      # @return [Array<Y2Users::User>]
+      def read_home_permissions(config)
+        config.users.reject(&:system?).each do |user|
+          next unless user.home && Dir.exist?(user.home.path)
+
+          user.home.permissions = Yast::Execute.locally!(
+            STAT, "--printf", "%a", user.home.path,
+            stdout: :capture
+          )
+        end
+      end
+
+      # Reads users authorized keys
+      #
+      # @see Yast::Users::SSHAuthorizedKeyring#read_keys
+      # @return [Array<Y2Users::User>]
+      def read_authorized_keys(config)
+        config.users.each do |user|
+          next unless user.home
+
+          user.authorized_keys = Yast::Users::SSHAuthorizedKeyring.new(user.home.path).read_keys
+        end
+      end
+
+      # Reads the configuration for useradd
+      #
+      # @param config [Config]
+      def read_useradd_config(config)
+        config.useradd = UseraddConfigReader.new.read
+      end
+
+      # Reads the login information
+      #
+      # @param config [Config]
+      def read_login(config)
+        Yast::Autologin.Read
+
+        return unless Yast::Autologin.used
+
+        login = LoginConfig.new
+        login.autologin_user = config.users.by_name(Yast::Autologin.user)
+        login.passwordless = Yast::Autologin.pw_less
+
+        config.login = login
+      end
 
       # Loads entries from `passwd` database
       #

--- a/src/lib/y2users/linux/reader.rb
+++ b/src/lib/y2users/linux/reader.rb
@@ -67,10 +67,10 @@ module Y2Users
         config.users.reject(&:system?).each do |user|
           next unless user.home && Dir.exist?(user.home.path)
 
-          user.home.permissions = Yast::Execute.locally!(
+          user.home.permissions = Yast::Execute.on_target!(
             STAT, "--printf", "%a", user.home.path,
             stdout: :capture
-          )
+          ).prepend("0")
         end
       end
 

--- a/src/lib/y2users/linux/reader.rb
+++ b/src/lib/y2users/linux/reader.rb
@@ -19,7 +19,11 @@
 
 require "yast2/execute"
 require "y2users/linux/base_reader"
+require "y2users/login_config"
+require "y2users/linux/useradd_config_reader"
+require "users/ssh_authorized_keyring"
 
+Yast.import "Autologin"
 Yast.import "MailAliases"
 
 module Y2Users

--- a/test/lib/y2users/linux/base_reader_test.rb
+++ b/test/lib/y2users/linux/base_reader_test.rb
@@ -44,6 +44,7 @@ describe Y2Users::Linux::BaseReader do
       allow(subject).to receive(:load_passwords).and_return(shadow_content)
 
       allow(subject.log).to receive(:warn)
+      allow(Yast::MailAliases).to receive(:GetRootAlias).and_return("games, unknown, news")
     end
 
     it "generates a config with read data" do
@@ -70,6 +71,15 @@ describe Y2Users::Linux::BaseReader do
       expect(subject.log).to receive(:warn).with(/Found password for.*fakeuser./)
 
       subject.read
+    end
+
+    it "sets root aliases" do
+      config = subject.read
+
+      root_aliases = config.users.select(&:receive_system_mail?)
+
+      expect(root_aliases.size).to eq 2
+      expect(root_aliases.map(&:name)).to contain_exactly("games", "news")
     end
   end
 end

--- a/test/lib/y2users/linux/base_reader_test.rb
+++ b/test/lib/y2users/linux/base_reader_test.rb
@@ -25,34 +25,20 @@ require "y2users/config"
 require "y2users/linux/base_reader"
 
 describe Y2Users::Linux::BaseReader do
-  around do |example|
-    # Let's use test/fixtures/home as src root for reading authorized keys from there
-    change_scr_root(FIXTURES_PATH.join("home")) { example.run }
-  end
-
   describe "#read" do
-    let(:passwd_content) { File.read(File.join(FIXTURES_PATH, "/root2/etc/passwd")) }
-    let(:group_content)  { File.read(File.join(FIXTURES_PATH, "/root2/etc/group")) }
-    let(:shadow_content) { File.read(File.join(FIXTURES_PATH, "/root2/etc/shadow")) }
+    let(:passwd_content) { File.read(File.join(FIXTURES_PATH, "/root/etc/passwd")) }
+    let(:group_content)  { File.read(File.join(FIXTURES_PATH, "/root/etc/group")) }
+    let(:shadow_content) { File.read(File.join(FIXTURES_PATH, "/root/etc/shadow")) }
     let(:root_home) { FIXTURES_PATH.join("home", "root").to_s }
     let(:expected_root_auth_keys) { authorized_keys_from(root_home) }
 
     before do
+      allow(subject.log).to receive(:warn)
+
       # mock Yast::Execute calls and provide file content from fixture
       allow(subject).to receive(:load_users).and_return(passwd_content)
       allow(subject).to receive(:load_groups).and_return(group_content)
       allow(subject).to receive(:load_passwords).and_return(shadow_content)
-
-      allow(subject.log).to receive(:warn)
-      allow(Yast::MailAliases).to receive(:GetRootAlias).and_return("games, unknown, news")
-
-      # mocks to check reading of home permissions
-      allow(Dir).to receive(:exist?)
-      allow(Dir).to receive(:exist?).with("/home/a_user").and_return(true)
-      allow(Yast::Execute).to receive(:locally!)
-      allow(Yast::Execute).to receive(:locally!)
-        .with("/usr/bin/stat", any_args, "/home/a_user", stdout: :capture)
-        .and_return("700")
     end
 
     it "generates a config with read data" do
@@ -60,8 +46,8 @@ describe Y2Users::Linux::BaseReader do
 
       expect(config).to be_a(Y2Users::Config)
 
-      expect(config.users.size).to eq 19
-      expect(config.groups.size).to eq 7
+      expect(config.users.size).to eq 18
+      expect(config.groups.size).to eq 37
 
       root_user = config.users.root
       expect(root_user.uid).to eq "0"
@@ -70,7 +56,6 @@ describe Y2Users::Linux::BaseReader do
       expect(root_user.primary_group.name).to eq "root"
       expect(root_user.password.value.encrypted?).to eq true
       expect(root_user.password.value.content).to match(/^\$6\$pL/)
-      expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
     end
 
     it "logs warning if password found for not existing user" do
@@ -79,22 +64,6 @@ describe Y2Users::Linux::BaseReader do
       expect(subject.log).to receive(:warn).with(/Found password for.*fakeuser./)
 
       subject.read
-    end
-
-    it "sets root aliases" do
-      config = subject.read
-
-      root_aliases = config.users.select(&:receive_system_mail?)
-
-      expect(root_aliases.size).to eq 2
-      expect(root_aliases.map(&:name)).to contain_exactly("games", "news")
-    end
-
-    it "sets home permissions" do
-      config = subject.read
-
-      user = config.users.by_name("a_user")
-      expect(user.home.permissions).to eq("700")
     end
   end
 end

--- a/test/lib/y2users/linux/base_reader_test.rb
+++ b/test/lib/y2users/linux/base_reader_test.rb
@@ -45,6 +45,10 @@ describe Y2Users::Linux::BaseReader do
 
       allow(subject.log).to receive(:warn)
       allow(Yast::MailAliases).to receive(:GetRootAlias).and_return("games, unknown, news")
+      allow(Yast::Execute).to receive(:locally!)
+      allow(Yast::Execute).to receive(:locally!)
+        .with("/usr/bin/stat", any_args, "/root", stdout: :capture)
+        .and_return("700")
     end
 
     it "generates a config with read data" do
@@ -80,6 +84,13 @@ describe Y2Users::Linux::BaseReader do
 
       expect(root_aliases.size).to eq 2
       expect(root_aliases.map(&:name)).to contain_exactly("games", "news")
+    end
+
+    it "sets home permissions" do
+      config = subject.read
+
+      root = config.users.root
+      expect(root.home.permissions).to eq("700")
     end
   end
 end

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -37,6 +37,7 @@ describe Y2Users::Linux::LocalReader do
     allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", anything)
       .and_return(useradd_default_values)
 
+    allow(Yast::ShadowConfig).to receive(:fetch)
     allow(Yast::ShadowConfig).to receive(:fetch).with(:umask).and_return("044")
   end
 

--- a/test/lib/y2users/linux/local_reader_test.rb
+++ b/test/lib/y2users/linux/local_reader_test.rb
@@ -36,16 +36,10 @@ describe Y2Users::Linux::LocalReader do
   before do
     allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", anything)
       .and_return(useradd_default_values)
-
-    allow(Yast::ShadowConfig).to receive(:fetch)
-    allow(Yast::ShadowConfig).to receive(:fetch).with(:umask).and_return("044")
   end
 
   describe "#read" do
     context "when all expected files are present" do
-      let(:root_home) { FIXTURES_PATH.join("home", "root").to_s }
-      let(:expected_root_auth_keys) { authorized_keys_from(root_home) }
-
       it "generates a config with read data" do
         config = subject.read
 
@@ -61,14 +55,6 @@ describe Y2Users::Linux::LocalReader do
         expect(root_user.primary_group.name).to eq "root"
         expect(root_user.password.value.encrypted?).to eq true
         expect(root_user.password.value.content).to match(/^\$6\$pL/)
-        expect(root_user.authorized_keys).to eq(expected_root_auth_keys)
-
-        useradd = config.useradd
-        expect(useradd.group).to eq "100"
-        expect(useradd.expiration).to eq ""
-        expect(useradd.inactivity_period).to eq(-1)
-        expect(useradd.create_mail_spool).to eq true
-        expect(useradd.umask).to eq "044"
 
         expect(config.login?).to eq(false)
       end
@@ -96,13 +82,6 @@ describe Y2Users::Linux::LocalReader do
 
         expect(config.users.size).to eq 0
         expect(config.groups.size).to eq 0
-
-        useradd = config.useradd
-        expect(useradd.group).to eq "100"
-        expect(useradd.expiration).to eq ""
-        expect(useradd.inactivity_period).to eq(-1)
-        expect(useradd.create_mail_spool).to eq true
-        expect(useradd.umask).to eq "044"
 
         expect(config.login?).to eq(false)
       end

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -47,6 +47,7 @@ describe Y2Users::Linux::Reader do
     allow(Yast::Execute).to receive(:on_target!).with(/useradd/, "-D", anything)
       .and_return(useradd_default_values)
 
+    allow(Yast::ShadowConfig).to receive(:fetch)
     allow(Yast::ShadowConfig).to receive(:fetch).with(:umask).and_return("024")
   end
 

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -57,8 +57,7 @@ describe Y2Users::Linux::Reader do
       # mocks to check reading of home permissions
       allow(Dir).to receive(:exist?)
       allow(Dir).to receive(:exist?).with("/home/a_user").and_return(true)
-      allow(Yast::Execute).to receive(:locally!)
-      allow(Yast::Execute).to receive(:locally!)
+      allow(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/stat", any_args, "/home/a_user", stdout: :capture)
         .and_return("700")
     end
@@ -101,11 +100,11 @@ describe Y2Users::Linux::Reader do
       expect(root_aliases.map(&:name)).to contain_exactly("games", "news")
     end
 
-    it "sets home permissions" do
+    it "sets home permissions (octal number starting by 0)" do
       config = subject.read
 
       user = config.users.by_name("a_user")
-      expect(user.home.permissions).to eq("700")
+      expect(user.home.permissions).to eq("0700")
     end
 
     context "when there are login settings" do

--- a/test/lib/y2users/linux/reader_test.rb
+++ b/test/lib/y2users/linux/reader_test.rb
@@ -59,7 +59,7 @@ describe Y2Users::Linux::Reader do
       allow(Dir).to receive(:exist?).with("/home/a_user").and_return(true)
       allow(Yast::Execute).to receive(:on_target!)
         .with("/usr/bin/stat", any_args, "/home/a_user", stdout: :capture)
-        .and_return("700")
+        .and_return("0700")
     end
 
     it "generates a config with read data" do


### PR DESCRIPTION
Adapt Linux readers to read home permissions and root aliases too.

* https://trello.com/c/UIMO6uJg/2655-1-missing-atributes-on-linuxreader
