### PR TITLE
Make SetAuthKeys action aware of previous keys 

### DIFF
--- a/src/lib/y2users/linux/set_auth_keys_action.rb
+++ b/src/lib/y2users/linux/set_auth_keys_action.rb
@@ -33,13 +33,19 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      # @param user [User] user to perform the action
+      # @param commit_config [CommitConfig, nil] optional configuration for the commit
+      # @param previous_keys [Array<String>, nil] optional collection holding previous keys, if any
+      def initialize(user, commit_config = nil, previous_keys = nil)
         textdomain "users"
 
-        super
+        super(user, commit_config)
+        @previous_keys = previous_keys || []
       end
 
     private
+
+      attr_accessor :previous_keys
 
       alias_method :user, :action_element
 
@@ -47,7 +53,9 @@ module Y2Users
       #
       # Issues are generated when the authorized keys cannot be set.
       def run_action
-        Yast::Users::SSHAuthorizedKeyring.new(user.home, user.authorized_keys).write_keys
+        keyring = Yast::Users::SSHAuthorizedKeyring.new(user.home.path, previous_keys)
+        keyring.add_keys(user.authorized_keys)
+        keyring.write_keys
         true
       rescue Yast::Users::SSHAuthorizedKeyring::PathError => e
         issues << Y2Issues::Issue.new(

--- a/src/lib/y2users/linux/set_auth_keys_action.rb
+++ b/src/lib/y2users/linux/set_auth_keys_action.rb
@@ -35,8 +35,8 @@ module Y2Users
       # @see Action
       # @param user [User] user to perform the action
       # @param commit_config [CommitConfig, nil] optional configuration for the commit
-      # @param previous_keys [Array<String>, nil] optional collection holding previous keys, if any
-      def initialize(user, commit_config = nil, previous_keys = nil)
+      # @param previous_keys [Array<String>] optional collection holding previous SSH keys, if any
+      def initialize(user, commit_config = nil, previous_keys = [])
         textdomain "users"
 
         super(user, commit_config)
@@ -45,7 +45,8 @@ module Y2Users
 
     private
 
-      attr_accessor :previous_keys
+      # @return [Array<String>] collection holding previous SSH public keys for given user
+      attr_reader :previous_keys
 
       alias_method :user, :action_element
 

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -146,9 +146,8 @@ module Y2Users
         adapt_home_ownership(target_user) if commit_config.adapt_home_ownership?
         edit_password(target_user) if initial_user.password != target_user.password
 
-        if initial_user.authorized_keys != target_user.authorized_keys
-          write_auth_keys(target_user, initial_user.authorized_keys)
-        end
+        previous_keys = initial_user.authorized_keys
+        write_auth_keys(target_user, previous_keys) if previous_keys != target_user.authorized_keys
       end
 
       # Updates root aliases

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -146,7 +146,7 @@ module Y2Users
         adapt_home_ownership(target_user) if commit_config.adapt_home_ownership?
         edit_password(target_user) if initial_user.password != target_user.password
 
-        previous_keys = initial_user.authorized_keys
+        previous_keys = initial_user.authorized_keys || []
         write_auth_keys(target_user, previous_keys) if previous_keys != target_user.authorized_keys
       end
 
@@ -291,9 +291,9 @@ module Y2Users
       # Performs the action for setting the authorized keys for the given user
       #
       # @param user [User]
-      # @param previous_keys [Array<String>, nil] previous auth keys for given user, if any
+      # @param previous_keys [Array<String>] previous auth keys for given user, if any
       # @return [Boolean] true on success
-      def write_auth_keys(user, previous_keys = nil)
+      def write_auth_keys(user, previous_keys = [])
         return true unless exist_user_home?(user)
 
         action = SetAuthKeysAction.new(user, commit_config(user), previous_keys)

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -145,7 +145,10 @@ module Y2Users
         commit_config = commit_config(target_user)
         adapt_home_ownership(target_user) if commit_config.adapt_home_ownership?
         edit_password(target_user) if initial_user.password != target_user.password
-        write_auth_keys(target_user) if initial_user.authorized_keys != target_user.authorized_keys
+
+        if initial_user.authorized_keys != target_user.authorized_keys
+          write_auth_keys(target_user, initial_user.authorized_keys)
+        end
       end
 
       # Updates root aliases
@@ -289,11 +292,12 @@ module Y2Users
       # Performs the action for setting the authorized keys for the given user
       #
       # @param user [User]
+      # @param previous_keys [Array<String>, nil] previous auth keys for given user, if any
       # @return [Boolean] true on success
-      def write_auth_keys(user)
+      def write_auth_keys(user, previous_keys = nil)
         return true unless exist_user_home?(user)
 
-        action = SetAuthKeysAction.new(user, commit_config(user))
+        action = SetAuthKeysAction.new(user, commit_config(user), previous_keys)
 
         perform_action(action)
       end

--- a/test/lib/y2users/linux/set_auth_keys_action_test.rb
+++ b/test/lib/y2users/linux/set_auth_keys_action_test.rb
@@ -32,7 +32,7 @@ describe Y2Users::Linux::SetAuthKeysAction do
 
   describe "#perform" do
     it "calls SSHAuthorizedKeyring#write_keys" do
-      obj = double
+      obj = double(Yast::Users::SSHAuthorizedKeyring)
       expect(obj).to receive(:write_keys)
       expect(obj).to receive(:add_keys).with(["test"])
       expect(Yast::Users::SSHAuthorizedKeyring).to receive(:new).with("/home/test", [])
@@ -42,7 +42,7 @@ describe Y2Users::Linux::SetAuthKeysAction do
     end
 
     it "returns result without success and with issues if cmd failed" do
-      obj = double
+      obj = double(Yast::Users::SSHAuthorizedKeyring)
       expect(obj).to receive(:add_keys).with(["test"])
       expect(obj).to receive(:write_keys)
         .and_raise(Yast::Users::SSHAuthorizedKeyring::PathError, "/home/test")

--- a/test/lib/y2users/linux/set_auth_keys_action_test.rb
+++ b/test/lib/y2users/linux/set_auth_keys_action_test.rb
@@ -34,7 +34,8 @@ describe Y2Users::Linux::SetAuthKeysAction do
     it "calls SSHAuthorizedKeyring#write_keys" do
       obj = double
       expect(obj).to receive(:write_keys)
-      expect(Yast::Users::SSHAuthorizedKeyring).to receive(:new).with(user.home, ["test"])
+      expect(obj).to receive(:add_keys).with(["test"])
+      expect(Yast::Users::SSHAuthorizedKeyring).to receive(:new).with("/home/test", [])
         .and_return(obj)
 
       subject.perform
@@ -42,9 +43,10 @@ describe Y2Users::Linux::SetAuthKeysAction do
 
     it "returns result without success and with issues if cmd failed" do
       obj = double
+      expect(obj).to receive(:add_keys).with(["test"])
       expect(obj).to receive(:write_keys)
-        .and_raise(Yast::Users::SSHAuthorizedKeyring::PathError, user.home)
-      expect(Yast::Users::SSHAuthorizedKeyring).to receive(:new).with(user.home, ["test"])
+        .and_raise(Yast::Users::SSHAuthorizedKeyring::PathError, "/home/test")
+      expect(Yast::Users::SSHAuthorizedKeyring).to receive(:new).with("/home/test", [])
         .and_return(obj)
 
       result = action.perform

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -73,7 +73,7 @@ describe Y2Users::Linux::UsersWriter do
     def mock_action(action, result, *users)
       action_instance = instance_double(action, perform: result)
 
-      allow(action).to receive(:new).with(*users, anything).and_return(action_instance)
+      allow(action).to receive(:new).with(*users, any_args).and_return(action_instance)
 
       action_instance
     end
@@ -342,6 +342,18 @@ describe Y2Users::Linux::UsersWriter do
               action = mock_action(set_auth_keys_action, success, target_user)
 
               expect(action).to receive(:perform)
+
+              subject.write
+            end
+
+            it "provides previous keys to the action for setting authorized keys" do
+              action = instance_double(set_auth_keys_action, perform: success)
+
+              expect(set_auth_keys_action)
+                .to receive(:new).with(target_user, any_args) do |*args|
+                  previous_keys = args.last
+                  expect(previous_keys).to eq(initial_user.authorized_keys)
+                end.and_return(action)
 
               subject.write
             end


### PR DESCRIPTION
## Problem

Manual testing revealed that after changes introduced in #349 SSH Public Keys are not being added or modified anymore. That issue happens because `Yast::Users::SSHAuthorizedKeyring` needs both, news and previous SSH public keys to know if it must proceed when its public  `#write_keys` method is called (see #320). However, the new `Y2Users::Linux::SetAuthKeysAction` is providing only the new/updated keys, which is only half of the information needed.

## Solution

Adapt the action to set both, previous and new SSH public keys before calling `#write_keys`.

## Tests

* Adapted unit tests
* Tested manually in a running system
