### PR TITLE
Fix check for user home existence

### DIFF
--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -328,7 +328,10 @@ module Y2Users
       def exist_user_home?(user)
         return false unless user.home&.path
 
-        File.exist?(user.home.path)
+        Yast::Execute.on_target!("/usr/bin/stat", user.home.path)
+        true
+      rescue Cheetah::ExecutionFailed
+        false
       end
     end
   end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -328,10 +328,7 @@ module Y2Users
       def exist_user_home?(user)
         return false unless user.home&.path
 
-        Yast::Execute.on_target!("/usr/bin/stat", user.home.path)
-        true
-      rescue Cheetah::ExecutionFailed
-        false
+        Yast::FileUtils.IsDirectory(user.home.path)
       end
     end
   end

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -173,7 +173,8 @@ describe Y2Users::Linux::UsersWriter do
         before do
           target_user.home.path = "/home/new_home"
 
-          allow(subject).to receive(:exist_user_home?).with(target_user).and_return(true)
+          allow(Yast::FileUtils).to receive(:IsDirectory).with(target_user.home.path)
+            .and_return(true)
         end
 
         let(:commit_config) do
@@ -202,7 +203,7 @@ describe Y2Users::Linux::UsersWriter do
         before do
           mock_action(edit_user_action, success, initial_user, target_user)
 
-          allow(subject).to receive(:exist_user_home?).and_call_original
+          allow(Yast::FileUtils).to receive(:IsDirectory).and_call_original
         end
 
         let(:commit_config) do
@@ -218,7 +219,8 @@ describe Y2Users::Linux::UsersWriter do
           let(:adapt_home_ownership) { true }
 
           before do
-            allow(subject).to receive(:exist_user_home?).with(target_user).and_return(exist_home)
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(target_user.home.path)
+              .and_return(exist_home)
           end
 
           context "and the user home exists" do
@@ -335,7 +337,8 @@ describe Y2Users::Linux::UsersWriter do
 
           context "and the user home exists" do
             before do
-              allow(subject).to receive(:exist_user_home?).with(target_user).and_return(true)
+              allow(Yast::FileUtils).to receive(:IsDirectory).with(target_user.home.path)
+                .and_return(true)
             end
 
             it "performs the action for setting the authorized keys" do
@@ -369,7 +372,8 @@ describe Y2Users::Linux::UsersWriter do
 
           context "and the user home does not exist" do
             before do
-              allow(subject).to receive(:exist_user_home?).with(target_user).and_return(false)
+              allow(Yast::FileUtils).to receive(:IsDirectory).with(target_user.home.path)
+                .and_return(false)
             end
 
             it "does not perform the action for setting the authorized keys" do
@@ -543,14 +547,15 @@ describe Y2Users::Linux::UsersWriter do
         let(:adapt_home_ownership) { nil }
 
         before do
-          allow(subject).to receive(:exist_user_home?).and_call_original
+          allow(Yast::FileUtils).to receive(:IsDirectory).and_call_original
         end
 
         context "and the user home should be created without skel" do
           let(:home_without_skel) { true }
 
           before do
-            allow(subject).to receive(:exist_user_home?).with(test3).and_return(exist_home)
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path)
+              .and_return(exist_home)
           end
 
           context "and the home already existed on disk" do
@@ -568,7 +573,7 @@ describe Y2Users::Linux::UsersWriter do
 
             context "and the home was created" do
               before do
-                allow(subject).to receive(:exist_user_home?).with(test3)
+                allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path)
                   .and_return(exist_home, true)
               end
 
@@ -605,7 +610,8 @@ describe Y2Users::Linux::UsersWriter do
           let(:adapt_home_ownership) { true }
 
           before do
-            allow(subject).to receive(:exist_user_home?).with(test3).and_return(exist_home)
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path)
+              .and_return(exist_home)
           end
 
           context "and the home was created" do
@@ -685,7 +691,7 @@ describe Y2Users::Linux::UsersWriter do
 
         context "and the user home exists" do
           before do
-            allow(subject).to receive(:exist_user_home?).with(test3).and_return(true)
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path).and_return(true)
           end
 
           it "performs the action for setting the authorized keys" do
@@ -707,7 +713,7 @@ describe Y2Users::Linux::UsersWriter do
 
         context "and the user home does not exist" do
           before do
-            allow(subject).to receive(:exist_user_home?).with(test3).and_return(false)
+            allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path).and_return(false)
           end
 
           it "does not perform the action for setting the authorized keys" do

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -93,6 +93,7 @@ describe Y2Users::Linux::UsersWriter do
     end
 
     before do
+      allow(Yast::Execute).to receive(:on_target!)
       # Prevent to perform real actions into the system
       allow_any_instance_of(Y2Users::Linux::Action).to receive(:perform).and_return(success)
       allow(Yast::MailAliases).to receive(:SetRootAlias)
@@ -172,8 +173,7 @@ describe Y2Users::Linux::UsersWriter do
         before do
           target_user.home.path = "/home/new_home"
 
-          allow(File).to receive(:exist?)
-          allow(File).to receive(:exist?).with("/home/new_home").and_return(true)
+          allow(subject).to receive(:exist_user_home?).with(target_user).and_return(true)
         end
 
         let(:commit_config) do
@@ -202,7 +202,7 @@ describe Y2Users::Linux::UsersWriter do
         before do
           mock_action(edit_user_action, success, initial_user, target_user)
 
-          allow(File).to receive(:exist?).and_call_original
+          allow(subject).to receive(:exist_user_home?).and_call_original
         end
 
         let(:commit_config) do
@@ -218,7 +218,7 @@ describe Y2Users::Linux::UsersWriter do
           let(:adapt_home_ownership) { true }
 
           before do
-            allow(File).to receive(:exist?).with(target_user.home.path).and_return(exist_home)
+            allow(subject).to receive(:exist_user_home?).with(target_user).and_return(exist_home)
           end
 
           context "and the user home exists" do
@@ -335,7 +335,7 @@ describe Y2Users::Linux::UsersWriter do
 
           context "and the user home exists" do
             before do
-              allow(File).to receive(:exist?).with(target_user.home.path).and_return(true)
+              allow(subject).to receive(:exist_user_home?).with(target_user).and_return(true)
             end
 
             it "performs the action for setting the authorized keys" do
@@ -369,7 +369,7 @@ describe Y2Users::Linux::UsersWriter do
 
           context "and the user home does not exist" do
             before do
-              allow(File).to receive(:exist?).with(target_user.home.path).and_return(false)
+              allow(subject).to receive(:exist_user_home?).with(target_user).and_return(false)
             end
 
             it "does not perform the action for setting the authorized keys" do
@@ -543,14 +543,14 @@ describe Y2Users::Linux::UsersWriter do
         let(:adapt_home_ownership) { nil }
 
         before do
-          allow(File).to receive(:exist?).and_call_original
+          allow(subject).to receive(:exist_user_home?).and_call_original
         end
 
         context "and the user home should be created without skel" do
           let(:home_without_skel) { true }
 
           before do
-            allow(File).to receive(:exist?).with(test3.home.path).and_return(exist_home)
+            allow(subject).to receive(:exist_user_home?).with(test3).and_return(exist_home)
           end
 
           context "and the home already existed on disk" do
@@ -568,7 +568,8 @@ describe Y2Users::Linux::UsersWriter do
 
             context "and the home was created" do
               before do
-                allow(File).to receive(:exist?).with(test3.home.path).and_return(exist_home, true)
+                allow(subject).to receive(:exist_user_home?).with(test3)
+                  .and_return(exist_home, true)
               end
 
               it "performs the action for removing the home content" do
@@ -604,7 +605,7 @@ describe Y2Users::Linux::UsersWriter do
           let(:adapt_home_ownership) { true }
 
           before do
-            allow(File).to receive(:exist?).with(test3.home.path).and_return(exist_home)
+            allow(subject).to receive(:exist_user_home?).with(test3).and_return(exist_home)
           end
 
           context "and the home was created" do
@@ -684,7 +685,7 @@ describe Y2Users::Linux::UsersWriter do
 
         context "and the user home exists" do
           before do
-            allow(File).to receive(:exist?).with(test3.home.path).and_return(true)
+            allow(subject).to receive(:exist_user_home?).with(test3).and_return(true)
           end
 
           it "performs the action for setting the authorized keys" do
@@ -706,7 +707,7 @@ describe Y2Users::Linux::UsersWriter do
 
         context "and the user home does not exist" do
           before do
-            allow(File).to receive(:exist?).with(test3.home.path).and_return(false)
+            allow(subject).to receive(:exist_user_home?).with(test3).and_return(false)
           end
 
           it "does not perform the action for setting the authorized keys" do


### PR DESCRIPTION
## Problem

When installing via an AutoYaST profile setting [`<authorized_keys>`](https://doc.opensuse.org/projects/autoyast/#id-1.9.5.2.34.3.9.14) for users the system is installed without provided SSH public keys, as reported in http://bugzilla.suse.com/show_bug.cgi?id=1192178.

The problem is in the [check for user home existence](https://github.com/yast/yast-users/blob/f6d4a583ee13c16201145bf68e2f2028e55d9e76/src/lib/y2users/linux/users_writer.rb#L328-L332), which is looking at `/home/<username>` instead `/mnt/home<username>` during installation.

## Solution

~~Use `Yast::Execute.on_target!` and `stat` from [GNU core utils](https://github.com/coreutils/coreutils) command instead of [File.exist?](https://ruby-doc.org/core-3.0.2/File.html#method-c-exist-3F) Ruby method.~~

Use [Yast::FileUtils.IsDirectory](https://github.com/yast/yast-yast2/blob/25a8bb990c4b9e81d2af2c4a699288dd95f90900/library/general/src/modules/FileUtils.rb#L61-L76) instead of [File.exist?](https://ruby-doc.org/core-3.0.2/File.html#method-c-exist-3F) Ruby method. (see https://github.com/yast/yast-users/pull/352#discussion_r741873179)

## Tests

* Unit test adapted
* Tested manually