### PR TITLE
Do not support group passwords

### DIFF
--- a/src/autoyast-rnc/users.rnc
+++ b/src/autoyast-rnc/users.rnc
@@ -19,6 +19,9 @@ groups =
     LIST,
     gr_group*
   }
+
+# TODO: group_password and encrypted are no longer supported by YaST. We should
+# remove them from the schema at some point.
 gr_group = element group {
   MAP,
   (

--- a/src/autoyast-rnc/users.rnc
+++ b/src/autoyast-rnc/users.rnc
@@ -20,8 +20,8 @@ groups =
     gr_group*
   }
 
-# TODO: group_password and encrypted are no longer supported by YaST. We should
-# remove them from the schema at some point.
+# TODO: "group_password" is no longer supported by YaST. We should remove it
+# along with "encrypted" from the schema at some point.
 gr_group = element group {
   MAP,
   (

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -5655,22 +5655,8 @@ sub ImportGroup {
 	    }
 	}
     }
-    my $encrypted	= $group{"encrypted"};
-    $encrypted		= YaST::YCP::Boolean (1) if !defined $encrypted;
-    if (defined $encrypted && ref ($encrypted) ne "YaST::YCP::Boolean") {
-	$encrypted	= YaST::YCP::Boolean ($encrypted);
-    }
-    my $pass		= $group{"group_password"};
-    if ((!defined $encrypted || !bool ($encrypted)) &&
-	(defined $pass) && !Mode->config ())
-    {
-	$pass 		= $self->CryptPassword ($pass, $type);
-	$encrypted	= YaST::YCP::Boolean (1);
-    }
 
     my %ret		= (
-	"userPassword"	=> $pass,
-	"encrypted"	=> $encrypted,
         "cn"		=> $groupname,
         "gidNumber"	=> $gid,
         "userlist"	=> \%userlist,

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -6149,15 +6149,6 @@ sub ExportGroup {
     {
 	$ret{"gid"}		= $group->{"gidNumber"};
     }
-    if (defined $group->{"userPassword"}) {
-
-    	my $encrypted	= bool ($group->{"encrypted"});
-    	if (!defined $group->{"encrypted"}) {
-	    $encrypted	= 1;
-	}
-	$ret{"encrypted"}	= YaST::YCP::Boolean ($encrypted);
-	$ret{"group_password"}	= $group->{"userPassword"};
-    }
 
     return \%ret;
 }

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -513,7 +513,7 @@ describe Y2Users::Autoinst::Reader do
       end
     end
 
-    context "when a group has a group password" do
+    context "when a group has a password" do
       let(:group_password) { "s3cr3T" }
       let(:profile) do
         {

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -512,5 +512,42 @@ describe Y2Users::Autoinst::Reader do
         expect(issue.location.to_s).to eq("autoyast:groups,0:groupname")
       end
     end
+
+    context "when a group has a group password" do
+      let(:group_password) { "s3cr3T" }
+      let(:profile) do
+        {
+          "groups" => [
+            { "groupname" => "root", "gid" => "100" },
+            { "groupname" => "passworded-group", "group_password" => group_password }
+          ]
+        }
+      end
+
+      it "registers an issue" do
+        result = subject.read
+        issue = result.issues.first
+        expect(issue).to be_a(Y2Issues::Issue)
+        expect(issue.location.to_s).to eq("autoyast:groups,1:group_password")
+      end
+
+      context "but it is empty (which means no password)" do
+        let(:group_password) { "" }
+
+        it "does not register an issue" do
+          result = subject.read
+          expect(result.issues).to be_empty
+        end
+      end
+
+      context "but it is 'x' (which means no password)" do
+        let(:group_password) { "x" }
+
+        it "does not register an issue" do
+          result = subject.read
+          expect(result.issues).to be_empty
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

The [not so widespread](https://unix.stackexchange.com/questions/93123/typical-use-case-for-a-group-password) _passworded_ group feature is considered

> _an inherent security problem since more than one person is permitted to know the password._ — https://www.man7.org/linux/man-pages/man1/gpasswd.1.html

Thus, the support for it in yast2-users will be dropped in the [new code base relying on shadow tools](https://github.com/yast/yast-users/pull/349).

## Solution

Stop supporting it in the new yast2-users code base, for which the below actions have been taken

* Do not export either, `<group_password>` or `<encrypted>` tags to the AutoYaST profile.
* Do not look for those values while importing groups.
* Be compatible with old generated profiles holding group passwords by creating the group **without** password AND warning the user about it (see screenshot below).

## Screenshot

![Screenshot_opensusetumbleweed-2_2021-11-08_09:38:13](https://user-images.githubusercontent.com/1691872/140934172-f6c62f08-0569-4078-8ffd-73a5074e4948.png)

<p align="center"><em>A warning during an AutoYaST installation using a profile with a passworded group.</em></p>

## Tests 

* Added unit tests
* Tested manually both, during installation (import) and in a running system (export)

## Related PR

* https://github.com/SUSE/doc-sle/pull/1003

## Other links

* https://trello.com/c/lPsu4nb7/ (internal link).
