### PR TITLE
Flush deleted users and groups after each write

### DIFF
--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4428,7 +4428,7 @@ sub Write {
 
     # Reset lists of removed elements
     %removed_users      = ();
-    %removed_groups	= ();
+    %removed_groups     = ();
 
     return $ret;
 }

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4426,6 +4426,10 @@ sub Write {
     $users_modified	= 0;
     $groups_modified	= 0;
 
+    # Reset lists of removed elements
+    %removed_users      = ();
+    %removed_groups	= ();
+
     return $ret;
 }
 


### PR DESCRIPTION
## Problem

The [Users module](https://github.com/yast/yast-users/blob/39c07e262368c52110024a513c81c9504f9d3fae/src/modules/Users.pm) was not reseting its internal data structure for removed elements after each write action.

With previous code writing the _/etc/passwd_ and _/etc/groups_ files directly, this was not a problem. It simply didn't write the elements marked as deleted to those files. Now that [new code](#349) is running a `userdel` and `groupdel` commands to remove them, an error for the first previously deleted element is prompted after running a "Write Changes Now" action.

It happens because those removed lists are used by the new readers (see [here]( https://github.com/yast/yast-users/blob/39c07e262368c52110024a513c81c9504f9d3fae/src/lib/y2users/users_module/reader.rb#L118-L124) and [here](https://github.com/yast/yast-users/blob/39c07e262368c52110024a513c81c9504f9d3fae/src/lib/y2users/users_module/reader.rb#L141-L147)) at the time to create the _system config_. That way, the writer can know which elements must be removed when [calculating differences with the _target config_](https://github.com/yast/yast-users/blob/39c07e262368c52110024a513c81c9504f9d3fae/src/lib/y2users/linux/users_writer.rb#L185-L190).

<details>
<summary>Click to show/hide screencasts</summary>

---

| Writing changes after deleting users | Writing changes after deleting groups |
| - | - |
| <p>https://user-images.githubusercontent.com/1691872/141103204-e314c2cb-f2d1-4c79-bf48-5f56549a6412.mp4</p> |  <p>https://user-images.githubusercontent.com/1691872/141102086-1766bafe-067b-48c1-bbac-ef103bab83b6.mp4</p> |

</details>

## Solution

Reset "removed" lists internally at the end of each #Write action.


<details>
<summary>Click to show/hide screencasts</summary>

---

| Writing changes after deleting users | Writing changes after deleting groups |
| - | - |
| <p>https://user-images.githubusercontent.com/1691872/141103648-fa0aa3b7-3997-40d6-9d69-184c9caf20cd.mp4</p> | <p>https://user-images.githubusercontent.com/1691872/141103674-48704e53-9db3-4b3c-b771-e5b7884cb4c2.mp4</p> |

</details>

## Tests

Minor change in old Perl code, only tested manually.

## Related links

*  Trello card: https://trello.com/c/jS4xjUY6/2724-problem-with-write-changes-now-and-deleted-users (internal link)