### PR TITLE
Always create home

### DIFF
--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1418,6 +1418,12 @@ module Yast
               focus_tab.call(current, :home)
               next
             end
+            if new_home.empty?
+              Report.Error(_("Home cannot be empty."))
+              UI.ChangeWidget(Id(:home), :Value, home)
+              focus_tab.call(current, :home)
+              next
+            end
             failed = false
             begin
               error_map = Users.CheckHomeUI(new_i_uid, new_home, ui_map)

--- a/src/lib/y2users/config.rb
+++ b/src/lib/y2users/config.rb
@@ -48,6 +48,11 @@ module Y2Users
     # @return [LoginConfig, nil] nil if not defined (unknown)
     attr_accessor :login
 
+    # Useradd configuration to be applied to the system before creating the users
+    #
+    # @return [UseraddConfig, nil] nil if the configuration is unknown
+    attr_accessor :useradd
+
     # Constructor
     #
     # @see UsersCollection
@@ -143,11 +148,6 @@ module Y2Users
 
       self
     end
-
-    # Useradd configuration to be applied to the system before creating the users
-    #
-    # @return [UseraddConfig, nil] nil if the configuration is unknown
-    attr_accessor :useradd
 
   private
 

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -111,22 +111,32 @@ module Y2Users
 
       # Generates options for `useradd` about how to deal with home
       #
-      # The home is not created if explicitly requested with `:skip_hope` param or the user has no
-      # home path.
+      # The home is created in the given home path. If the home path is unknown, then the home is
+      # created in the default path indicated by the useradd defaults configuration.
       #
-      # Note that `useradd` will not try to create the home if the path already exists, it does not
-      # matter whether --create-home is passed.
+      # The home is not created if explicitly requested with `:skip_hope` param.
+      #
+      # Note that `useradd` will not try to create the home if the given path already exists, it
+      # does not matter whether --create-home is passed.
       #
       # @param skip_home [Boolean]
       # @return [Array<String>]
       def home_options(skip_home: false)
         return [] if user.system?
 
-        return ["--no-create-home"] if skip_home || !user.home&.path
+        return ["--no-create-home"] if skip_home
 
-        opts = ["--create-home", "--home-dir", user.home.path]
-        opts << "--btrfs-subvolume-home" if user.home.btrfs_subvol?
-        opts << "--key" << "HOME_MODE=#{user.home.permissions}" if user.home.permissions
+        create_home_options
+      end
+
+      # Options when the home has to be created
+      #
+      # @return [Array<String>]
+      def create_home_options
+        opts = ["--create-home"]
+        opts += ["--home-dir", user.home.path] if user.home&.path && !user.home.path.empty?
+        opts += ["--btrfs-subvolume-home"] if user.home&.btrfs_subvol?
+        opts += ["--key", "HOME_MODE=#{user.home.permissions}"] if user.home&.permissions
         opts
       end
     end

--- a/src/lib/y2users/user.rb
+++ b/src/lib/y2users/user.rb
@@ -73,6 +73,9 @@ module Y2Users
 
     # User home
     #
+    # @note If home is unknown, then the {Linux::Writer} will create the default home according to
+    #   the useradd defaults configuration.
+    #
     # @return [Home, nil] nil if unknown
     attr_accessor :home
 
@@ -131,32 +134,20 @@ module Y2Users
 
     # Constructor
     #
-    # This creates a local user with its default home. See also {User.create_system} for
-    # specifically creating a system user.
+    # This creates a local user. See also {User.create_system} for creating a system user.
     #
     # @param name [String]
     def initialize(name)
       super()
 
       @name = name
-      @home = default_home
-      # TODO: GECOS
+      @home = Home.new
       @gecos = []
       @authorized_keys = []
       @source = :unknown
 
       # See #system?
       @system = false
-    end
-
-    # Default home for the user
-    #
-    # Generates a new {Home} object with the default user home path. The attributes of the current
-    # home object associated to the user are not copied.
-    #
-    # @return [Home]
-    def default_home
-      Home.new("/home/#{name}")
     end
 
     # Primary group for the user

--- a/test/lib/users/dialogs/inst_user_first_test.rb
+++ b/test/lib/users/dialogs/inst_user_first_test.rb
@@ -184,7 +184,6 @@ describe Yast::InstUserFirstDialog do
           subject.next_handler
 
           expect(config.users.by_name("test")).to_not be_nil
-          expect(config.users.by_name("test").home.path).to eq("/home/test")
         end
 
         it "configures the autologin" do
@@ -192,6 +191,34 @@ describe Yast::InstUserFirstDialog do
 
           expect(config.login).to_not be_nil
           expect(config.login.autologin?).to eq(true)
+        end
+
+        context "when the user name has changed" do
+          let(:user) { Y2Users::User.new("oldname") }
+
+          context "and the user has a home path" do
+            before do
+              user.home.path = "/home/oldname"
+            end
+
+            it "updates the home path according to the new user name" do
+              subject.next_handler
+
+              expect(user.home.path).to eq("/home/test")
+            end
+          end
+
+          context "and the user has no home path" do
+            before do
+              user.home.path = nil
+            end
+
+            it "does not set a home path" do
+              subject.next_handler
+
+              expect(user.home.path).to be_nil
+            end
+          end
         end
 
         context "when the option \"use passwor for root\" is selected" do

--- a/test/lib/y2users/linux/create_user_action_test.rb
+++ b/test/lib/y2users/linux/create_user_action_test.rb
@@ -36,7 +36,6 @@ describe Y2Users::Linux::CreateUserAction do
   end
 
   describe "#perform" do
-
     it "creates user with useradd" do
       expect(Yast::Execute).to receive(:on_target!) do |cmd, *_args|
         expect(cmd).to eq "/usr/sbin/useradd"
@@ -73,17 +72,6 @@ describe Y2Users::Linux::CreateUserAction do
       expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|
         expect(args).to include "--shell"
         expect(args).to include "bash"
-      end
-
-      action.perform
-    end
-
-    it "passes --home-dir parameter" do
-      user.home.path = "/home/test5"
-
-      expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|
-        expect(args).to include "--home-dir"
-        expect(args).to include "/home/test5"
       end
 
       action.perform
@@ -139,10 +127,24 @@ describe Y2Users::Linux::CreateUserAction do
       action.perform
     end
 
-    context "non-system users" do
+    context "for a local user" do
       it "passes --create-home parameter" do
         expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|
-          expect(args).to include "--create-home"
+          expect(args).to include("--create-home")
+          expect(args).to_not include("--home-dir")
+          expect(args).to_not include("--btrfs-subvolume-home")
+          expect(args).to_not include("--key")
+        end
+
+        action.perform
+      end
+
+      it "passes --home-dir parameter if the home path is known" do
+        user.home.path = "/home/test"
+
+        expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|
+          expect(args).to include("--home-dir")
+          expect(args).to include("/home/test")
         end
 
         action.perform

--- a/test/lib/y2users/linux/set_auth_keys_action_test.rb
+++ b/test/lib/y2users/linux/set_auth_keys_action_test.rb
@@ -27,7 +27,12 @@ require "y2users/user"
 
 describe Y2Users::Linux::SetAuthKeysAction do
   subject(:action) { described_class.new(user, commit_config) }
-  let(:user) { Y2Users::User.new("test").tap { |u| u.authorized_keys = ["test"] } }
+  let(:user) do
+    Y2Users::User.new("test").tap do |user|
+      user.home.path = "/home/test"
+      user.authorized_keys = ["test"]
+    end
+  end
   let(:commit_config) { nil }
 
   describe "#perform" do

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -47,9 +47,9 @@ describe Y2Users::Linux::UsersWriter do
 
   let(:users) { [test1, test2] }
 
-  let(:test1) { Y2Users::User.new("test1") }
+  let(:test1) { Y2Users::User.new("test1").tap { |u| u.home.path = "/home/test1" } }
 
-  let(:test2) { Y2Users::User.new("test2") }
+  let(:test2) { Y2Users::User.new("test2").tap { |u| u.home.path = "/home/test2" } }
 
   let(:commit_config) { Y2Users::CommitConfig.new }
 
@@ -507,7 +507,7 @@ describe Y2Users::Linux::UsersWriter do
     end
 
     context "when a user is added to the target config" do
-      let(:test3) { Y2Users::User.new("test3") }
+      let(:test3) { Y2Users::User.new("test3").tap { |u| u.home.path = "/home/test3" } }
 
       before do
         target_config.attach(test3)

--- a/test/lib/y2users/user_test.rb
+++ b/test/lib/y2users/user_test.rb
@@ -61,10 +61,10 @@ describe Y2Users::User do
       expect(user.system?).to eq(false)
     end
 
-    it "creates the user with the default home" do
+    it "creates the user with unknown home path" do
       user = described_class.new("test")
 
-      expect(user.home.path).to eq("/home/test")
+      expect(user.home.path).to be_nil
     end
   end
 
@@ -90,6 +90,8 @@ describe Y2Users::User do
     end
 
     it "generates a copy with a duplicated home" do
+      subject.home.path = "/home/test"
+
       other = subject.copy
       other.home.path = "/home/other"
 
@@ -119,15 +121,6 @@ describe Y2Users::User do
     it "returns an array holding authorized keys" do
       expect(subject.authorized_keys).to be_an(Array)
       expect(subject.authorized_keys).to contain_exactly("ssh-rsa auth-key")
-    end
-  end
-
-  describe "#default_home" do
-    it "returns a home with the default path for the home user" do
-      home = subject.default_home
-
-      expect(home).to be_a(Y2Users::Home)
-      expect(home.path).to eq("/home/test")
     end
   end
 


### PR DESCRIPTION
## Problem

In the *YaST users* client, leaving the "Home Directory" field as empty leads to a weird behavior. The old code really left the field empty in */etc/passwd* and skipped the creation of the directory. But that behavior was probably fully unintended since the empty "Home Directory" field was automatically re-filled with the default data on every tab switch. Note that leaving the */etc/passwd* field empty doesn't seem to be fully correct - the possibility is not mentioned in the man page for */etc/passwd* and `su` complains saying the entry is incomplete.

Currently, `Y2Users::Linux::Writer` does not create the home directory for a local user if the home path is unknown. But `useradd` always adds the default home path to */etc/passwd*. Because of that, the current behaviour of *YaST users* client is slightly different when the "Home Directory" is set to empty.

Moreover, AutoYaST is expected to create the default home directory when no home path is indicated in the profile. Right now, the home is only created if the path is known. 

* https://trello.com/c/E3wYL0ob/2723-2-do-not-allow-home-directory-to-be-empty
* https://trello.com/c/l5mmMzXQ/2735-fix-autoyast-import-of-home-dir

## Solution

Now, the default home directory is always created for local users when the home path is unknown. Moreover, *YaST users* validates the "Home Directory" in order to avoid setting it as empty. In that case, the user is alerted with a popup and the previous value is restored.

https://user-images.githubusercontent.com/1112304/141127881-a505892f-5ada-48a0-a542-bfcb247d1338.mp4


### Testing

* Added unit tests.
* Manually tested.  
 