### PR TITLE
Fix UsersModule::Reader

### DIFF
--- a/src/lib/y2users/users_module/reader.rb
+++ b/src/lib/y2users/users_module/reader.rb
@@ -104,7 +104,7 @@ module Y2Users
         all_local = Yast::Users.GetUsers("uid", "local").values +
           Yast::Users.GetUsers("uid", "system").values
         all_local.each do |user_hash|
-          if user_hash["what"] == "add_user" # new user
+          if user_hash["modified"] == "added" # new user
             target_config.attach(user(user_hash, target_config))
           else # everything else is edit of different kinds
             # at first create original user
@@ -127,7 +127,7 @@ module Y2Users
         all_local = Yast::Users.GetGroups("cn", "local").values +
           Yast::Users.GetGroups("cn", "system").values
         all_local.each do |group_hash|
-          if group_hash["what"] == "add_group" # new group
+          if group_hash["modified"] == "added" # new group
             target_config.attach(group(group_hash))
           else # everything else is edit of different kinds
             # at first create original group

--- a/test/lib/y2users/users_module/reader_test.rb
+++ b/test/lib/y2users/users_module/reader_test.rb
@@ -32,22 +32,22 @@ describe Y2Users::UsersModule::Reader do
         "addit_data"        => "",
         "btrfs_subvolume"   => true,
         "chown_home"        => true,
-        "cn"                => "test5",
+        "cn"                => "test1",
         "create_home"       => true,
         "encrypted"         => true,
         "gidNumber"         => 100,
         "givenName"         => "",
         "grouplist"         => {
-          "wheel" => 1
+          "test2" => 1
         },
         "groupname"         => "users",
-        "homeDirectory"     => "/home/test5",
+        "homeDirectory"     => "/home/test1",
         "home_mode"         => "755",
         "loginShell"        => "/bin/bash",
         "modified"          => "added",
         "no_skeleton"       => true,
-        "org_homeDirectory" => "/home/test5",
-        "org_uid"           => "test5",
+        "org_homeDirectory" => "/home/test1",
+        "org_uid"           => "test1",
         "org_uidNumber"     => 1002,
         "plugins"           => [],
         "shadowExpire"      => "",
@@ -60,11 +60,11 @@ describe Y2Users::UsersModule::Reader do
         "sn"                => "",
         "text_userpassword" => "test",
         "type"              => "local",
-        "uid"               => "test5",
+        "uid"               => "test1",
         "uidNumber"         => 1002,
         "userPassword"      => "$6$CIrJOmyF8WBnHsAn$Sh.pjryO9CD.Dfm9KzDdVYYXblxiTw05b9b0GVpMbckbU" \
           "gK/fFvn7nM.ipqooa3Ks5fGgzV.6gPBGG1l8hs7L.",
-        "what"              => "add_user"
+        "what"              => "group_change"
       },
       {
         "addit_data"        => "",
@@ -81,29 +81,29 @@ describe Y2Users::UsersModule::Reader do
           "video" => 1
         },
         "groupname"         => "users",
-        "homeDirectory"     => "/home/test",
+        "homeDirectory"     => "/home/test2",
         "home_mode"         => "755",
         "loginShell"        => "/bin/bash",
         "modified"          => "edited",
         "no_skeleton"       => false,
-        "org_homeDirectory" => "/home/test",
-        "org_uid"           => "test",
+        "org_homeDirectory" => "/home/test2",
+        "org_uid"           => "test2",
         "org_uidNumber"     => 1001,
         "org_user"          => {
           "addit_data"       => "",
           "authorized_keys"  => [],
           "chown_home"       => true,
-          "cn"               => "test",
+          "cn"               => "test2",
           "create_home"      => true,
           "enabled"          => false,
           "encrypted"        => true,
           "gidNumber"        => "100",
           "grouplist"        => {
             "video" => 1,
-            "wheel" => 1
+            "test2" => 1
           },
           "groupname"        => "users",
-          "homeDirectory"    => "/home/test",
+          "homeDirectory"    => "/home/test2",
           "loginShell"       => "/bin/bash",
           "shadowExpire"     => "",
           "shadowFlag"       => "",
@@ -113,14 +113,14 @@ describe Y2Users::UsersModule::Reader do
           "shadowMin"        => "0",
           "shadowWarning"    => "7",
           "type"             => "local",
-          "uid"              => "test",
+          "uid"              => "test2",
           "uidNumber"        => 1001,
           "userPassword"     => "!$6$7CgeIaVsqcVd2OXq$T9ObPbjPCOm7E3U730S8ZLJ82GBBi9XXYJM4iUNadk" \
             "gfpZ3CU/cXe.hdaGhdutqhixtFuZ2hrhEIZvlTcKgSc."
         },
         "plugins"           => [],
         "removed_grouplist" => {
-          "wheel" => 1
+          "test2" => 1
         },
         "shadowExpire"      => "",
         "shadowFlag"        => "",
@@ -131,7 +131,7 @@ describe Y2Users::UsersModule::Reader do
         "shadowWarning"     => "7",
         "sn"                => "",
         "type"              => "local",
-        "uid"               => "test",
+        "uid"               => "test2",
         "uidNumber"         => 1001,
         "userPassword"      => "!$6$7CgeIaVsqcVd2OXq$T9ObPbjPCOm7E3U730S8ZLJ82GBBi9XXYJM4iUNadkg" \
           "fpZ3CU/cXe.hdaGhdutqhixtFuZ2hrhEIZvlTcKgSc.",
@@ -140,33 +140,94 @@ describe Y2Users::UsersModule::Reader do
     ]
   end
 
+  let(:removed_users) do
+    {
+      "local" => {
+        "test3" => {
+          "addit_data"       => "",
+          "authorized_keys"  => [],
+          "cn"               => "test3",
+          "delete_home"      => false,
+          "gidNumber"        => "100",
+          "grouplist"        => {},
+          "groupname"        => "users",
+          "homeDirectory"    => "/home/test3",
+          "loginShell"       => "/bin/bash",
+          "modified"         => "deleted",
+          "plugins"          => [],
+          "shadowExpire"     => "",
+          "shadowFlag"       => "",
+          "shadowInactive"   => "",
+          "shadowLastChange" => "18899",
+          "shadowMax"        => "99999",
+          "shadowMin"        => "0",
+          "shadowWarning"    => "7",
+          "type"             => "local",
+          "uid"              => "test3",
+          "uidNumber"        => 1001,
+          "userPassword"     => "$6$jap/4cvK4.veohli$0JPqLC3sheKRTv79PoiW1fBtbudBad04hWKrUdfOMyzA" \
+            "tVoGCUZ1KZivJqq1bIFUlJUJPXIbwFOqxNU1wrpZ8/",
+          "what"             => "delete_user"
+        },
+        "test4" => {
+          "addit_data"       => "",
+          "authorized_keys"  => [],
+          "cn"               => "test4",
+          "delete_home"      => true,
+          "gidNumber"        => "100",
+          "grouplist"        => {},
+          "groupname"        => "users",
+          "homeDirectory"    => "/home/test4",
+          "loginShell"       => "/bin/bash",
+          "modified"         => "deleted",
+          "org_user"         => {},
+          "plugins"          => [],
+          "shadowExpire"     => "",
+          "shadowFlag"       => "",
+          "shadowInactive"   => "",
+          "shadowLastChange" => "18899",
+          "shadowMax"        => "99999",
+          "shadowMin"        => "0",
+          "shadowWarning"    => "7",
+          "type"             => "local",
+          "uid"              => "test4",
+          "uidNumber"        => 1002,
+          "userPassword"     => "!$6$yRZunFQ0DSZghYQ4$7K2cLQ/XrhucUZr4btKmUbfMuUmbDmRX7msfs6VQGKE" \
+            "fb2nkrbNn0c2d3mNmG.MGfFgmYyv.540Yaq2GtpVaK1",
+          "what"             => "delete_user"
+        }
+      }
+    }
+  end
+
   let(:sys_groups) do
     [
       # real data with data dumper from perl after modifications in UI
       {
-        "cn"            => "users",
+        "cn"            => "test1",
         "gidNumber"     => "100",
         "more_users"    => {},
-        "org_cn"        => "users",
+        "org_cn"        => "test1",
         "org_gidNumber" => 100,
         "type"          => "local",
         "userlist"      => {}
       },
+      # test2 is a new group (only in target)
       {
-        "cn"            => "wheel",
+        "cn"            => "test2",
         "gidNumber"     => 497,
-        "modified"      => "edited",
+        "modified"      => "added",
         "more_users"    => {},
-        "org_cn"        => "wheel",
+        "org_cn"        => "test2",
         "org_gidNumber" => 497,
         "type"          => "system",
         "userlist"      => {
-          "test5" => 1
+          "test1" => 1
         },
         "what"          => "user_change"
       },
       {
-        "cn"         => "test",
+        "cn"         => "test3",
         "gidNumber"  => "",
         "more_users" => {},
         "type"       => "system",
@@ -178,20 +239,35 @@ describe Y2Users::UsersModule::Reader do
   let(:local_groups) do
     [
       {
-        "cn"            => "testing",
+        "cn"            => "test4",
         "gidNumber"     => 1000,
-        "modified"      => "added",
         "more_users"    => {},
-        "org_cn"        => "testing",
+        "org_cn"        => "test4",
         "org_gidNumber" => 1000,
         "plugins"       => [],
         "type"          => "local",
         "userlist"      => {
           "test2" => 1
-        },
-        "what"          => "add_group"
+        }
       }
     ]
+  end
+
+  let(:removed_groups) do
+    {
+      "local" => {
+        "test5" => {
+          "cn"           => "test5",
+          "gidNumber"    => 1000,
+          "modified"     => "deleted",
+          "more_users"   => {},
+          "type"         => "local",
+          "userPassword" => "x",
+          "userlist"     => {},
+          "what"         => "delete_group"
+        }
+      }
+    }
   end
 
   let(:login_config) do
@@ -207,83 +283,6 @@ describe Y2Users::UsersModule::Reader do
     }
   end
 
-  let(:removed_users) do
-    {
-      "local" => {
-        "test6" => {
-          "addit_data"       => "",
-          "authorized_keys"  => [],
-          "cn"               => "test6",
-          "delete_home"      => false,
-          "gidNumber"        => "100",
-          "grouplist"        => {},
-          "groupname"        => "users",
-          "homeDirectory"    => "/home/test6",
-          "loginShell"       => "/bin/bash",
-          "modified"         => "deleted",
-          "plugins"          => [],
-          "shadowExpire"     => "",
-          "shadowFlag"       => "",
-          "shadowInactive"   => "",
-          "shadowLastChange" => "18899",
-          "shadowMax"        => "99999",
-          "shadowMin"        => "0",
-          "shadowWarning"    => "7",
-          "type"             => "local",
-          "uid"              => "test6",
-          "uidNumber"        => 1001,
-          "userPassword"     => "$6$jap/4cvK4.veohli$0JPqLC3sheKRTv79PoiW1fBtbudBad04hWKrUdfOMyzA" \
-            "tVoGCUZ1KZivJqq1bIFUlJUJPXIbwFOqxNU1wrpZ8/",
-          "what"             => "delete_user"
-        },
-        "test7" => {
-          "addit_data"       => "",
-          "authorized_keys"  => [],
-          "cn"               => "test7",
-          "delete_home"      => true,
-          "gidNumber"        => "100",
-          "grouplist"        => {},
-          "groupname"        => "users",
-          "homeDirectory"    => "/home/test7",
-          "loginShell"       => "/bin/bash",
-          "modified"         => "deleted",
-          "org_user"         => {},
-          "plugins"          => [],
-          "shadowExpire"     => "",
-          "shadowFlag"       => "",
-          "shadowInactive"   => "",
-          "shadowLastChange" => "18899",
-          "shadowMax"        => "99999",
-          "shadowMin"        => "0",
-          "shadowWarning"    => "7",
-          "type"             => "local",
-          "uid"              => "test7",
-          "uidNumber"        => 1002,
-          "userPassword"     => "!$6$yRZunFQ0DSZghYQ4$7K2cLQ/XrhucUZr4btKmUbfMuUmbDmRX7msfs6VQGKE" \
-            "fb2nkrbNn0c2d3mNmG.MGfFgmYyv.540Yaq2GtpVaK1",
-          "what"             => "delete_user"
-        }
-      }
-    }
-  end
-
-  let(:removed_groups) do
-    {
-      "local" => {
-        "testing" => {
-          "cn"           => "testing",
-          "gidNumber"    => 1000,
-          "modified"     => "deleted",
-          "more_users"   => {},
-          "type"         => "local",
-          "userPassword" => "x",
-          "userlist"     => {},
-          "what"         => "delete_group"
-        }
-      }
-    }
-  end
-
   before do
     allow(Yast::Users).to receive(:GetLoginDefaults).and_return(login_config)
     mapped_users = Hash[users.map { |u| [u["uid"], u] }]
@@ -293,58 +292,66 @@ describe Y2Users::UsersModule::Reader do
     allow(Yast::Users).to receive(:GetGroups).and_return(mapped_sys_groups, mapped_local_groups)
     allow(Yast::Users).to receive(:RemovedUsers).and_return(removed_users)
     allow(Yast::Users).to receive(:RemovedGroups).and_return(removed_groups)
-    allow(Yast::Users).to receive(:GetRootAliases).and_return("test5" => 1)
+    allow(Yast::Users).to receive(:GetRootAliases).and_return("test1" => 1)
   end
 
+  # Scenario:
+  #
+  # New users: test1
+  # Existing users: test2
+  # Removed users. test3, test4
+  #
+  # New Groups: test2
+  # Existing groups: test1, test3, test4
+  # Removed groups: test5
   describe "#read" do
     it "generates the system and target config" do
       system_config, target_config = subject.read
 
+      # System config check
+
+      expect(system_config).to be_a(Y2Users::Config)
+      expect(system_config.users.map(&:name)).to contain_exactly("test2", "test3", "test4")
+      expect(system_config.groups.map(&:name))
+        .to contain_exactly("test1", "test3", "test4", "test5")
+
+      # Target config check
+
       expect(target_config).to be_a(Y2Users::Config)
+      expect(target_config.users.map(&:name)).to contain_exactly("test1", "test2")
 
-      expect(target_config.users.size).to eq 2
-      expect(target_config.groups.size).to eq 4
-
-      test_user = target_config.users.by_name("test5")
+      test_user = target_config.users.by_name("test1")
       expect(test_user.uid).to eq "1002"
       expect(test_user.home).to be_a(Y2Users::Home)
-      expect(test_user.home.path).to eq "/home/test5"
+      expect(test_user.home.path).to eq "/home/test1"
       expect(test_user.home.btrfs_subvol?).to eq true
       expect(test_user.home.permissions).to eq "0755"
       expect(test_user.shell).to eq "/bin/bash"
-      expect(test_user.primary_group.name).to eq "users"
+      expect(test_user.primary_group.name).to eq "test1"
       expect(test_user.receive_system_mail?).to eq true
       expect(test_user.password.value.encrypted?).to eq true
       expect(test_user.password.value.content).to match(/^\$6\$CI/)
       expect(test_user.password.aging.content).to eq("18887")
       expect(test_user.password.account_expiration.content).to eq("")
 
-      test_group = target_config.groups.by_name("wheel")
-      expect(test_group.gid).to eq "497"
-      expect(test_group.users.map(&:name)).to eq(["test5"])
+      expect(target_config.groups.map(&:name))
+        .to contain_exactly("test1", "test2", "test3", "test4")
 
-      test_group = target_config.groups.by_name("test")
+      test_group = target_config.groups.by_name("test2")
+      expect(test_group.gid).to eq "497"
+      expect(test_group.users.map(&:name)).to eq(["test1"])
       expect(test_group.system?).to eq(true)
+
+      test_group = target_config.groups.by_name("test4")
+      expect(test_group.system?).to eq(false)
+
+      # useradd config check
 
       useradd = target_config.useradd
       expect(useradd.group).to eq "100"
       expect(useradd.expiration).to eq ""
       expect(useradd.inactivity_period).to eq(-1)
       expect(useradd.umask).to eq "022"
-
-      expect(system_config).to be_a(Y2Users::Config)
-
-      expect(system_config.users.size).to eq 3
-      expect(system_config.groups.size).to eq 4
-
-      added_user = system_config.users.by_name("test5")
-      expect(added_user).to eq nil
-
-      removed_user = system_config.users.by_name("test6")
-      expect(removed_user).to be_a(Y2Users::User)
-
-      removed_user = system_config.groups.by_name("testing")
-      expect(removed_user).to be_a(Y2Users::Group)
     end
   end
 end


### PR DESCRIPTION
## Problem

There are issues when a user is added in the "YaST client" and the option "Write Changes Now" is used to save the changes into the system:
* The next time that `Linux::Writer` is called (i.e., by clicking "Ok" or "Write Changes Now"), it tries to create the new users and groups again.
* When editing a group to add a user to its list, the writer complains if the user does not exist in the system yet (i.e., the user is new).

## Solution

The detection of new users and groups by `UsersModule::Reader` was wrong. It was based on the *what* attribute, which usually contains "add_user" or "add_group" when the user/group is new. But that is not always true. In some cases, for example when a user is added to a group, the "what" attribute contains other values like "group_change". Because of that, the `UsersModule::Reader` could consider new users as existing ones.

Moreover, after using  "Write Changes Now", the "what" attribute is not refreshed, so the new users and groups are still considered as new elements the next time that changes are written to the system.

The solution was to use the "modified" attribute instead of "what". The "modified" attribute always contains "added" when the element is new. After using "Write Changes Now", the attribute is properly updated in order to not consider the element as new again.

## Testing

* Adapted unit tests.
* Manually tested.
