### PR TITLE
AutoYaST: Improve ignored group passwords

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 30 20:40:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- AutoYaST: do not warning about deprecated <group_password>
+  when found a blank one (related to jsc#SLE-20592).
+- 4.4.9
+
+-------------------------------------------------------------------
 Tue Oct 19 10:36:08 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Users client uses the shadow tools to write changes into the

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -2,7 +2,7 @@
 Tue Nov 30 20:40:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - AutoYaST: do not warning about deprecated <group_password>
-  when found a blank one (related to jsc#SLE-20592).
+  when it is empty, "x", "!", or "*" (related to jsc#SLE-20592).
 - 4.4.9
 
 -------------------------------------------------------------------

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2users/autoinst/reader.rb
+++ b/src/lib/y2users/autoinst/reader.rb
@@ -107,6 +107,16 @@ module Y2Users
 
     private
 
+      # Group password values that actually means "no password".
+      #
+      # Although YaST does not support group passwords anymore and ignores them when importing the
+      # profile, the user receives a warning about it ONLY when found a `<group_password>` with none
+      # of these values, which means *no password*.
+      #
+      # @see #check_group_password
+      BLANK_GROUP_PASSWORD = ["", "x", "*", "!"].freeze
+      private_constant :BLANK_GROUP_PASSWORD
+
       # Profile section describing the users
       #
       # @return [AutoinstProfile::UsersSection]
@@ -232,18 +242,14 @@ module Y2Users
         false
       end
 
-      # Check if given group contains a group password for warning about
-      # ignoring it
-      #
-      # @note empty or "x" password actually means no password and the user
-      #   will be not warned about it.
+      # Check if given group contains a group password for warning about ignoring it
       #
       # @param group_section [Installation::AutoinstProfile::GroupSection]
       # @param issues [Y2Issues::List] Issues list
       def check_group_password(group_section, issues)
         group_password = group_section.group_password.to_s
 
-        return if group_password.empty? || group_password == "x"
+        return if BLANK_GROUP_PASSWORD.include?(group_password)
 
         issues << Y2Issues::Issue.new(
           _("Attribute no longer supported by YaST. Ignoring it."),

--- a/test/lib/y2users/autoinst/reader_test.rb
+++ b/test/lib/y2users/autoinst/reader_test.rb
@@ -548,6 +548,24 @@ describe Y2Users::Autoinst::Reader do
           expect(result.issues).to be_empty
         end
       end
+
+      context "but it is '!' (which means no password)" do
+        let(:group_password) { "!" }
+
+        it "does not register an issue" do
+          result = subject.read
+          expect(result.issues).to be_empty
+        end
+      end
+
+      context "but it is '*' (which means no password)" do
+        let(:group_password) { "*" }
+
+        it "does not register an issue" do
+          result = subject.read
+          expect(result.issues).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Although YaST [does not support group passwords anymore](https://github.com/yast/yast-users/pull/353) and ignores them when importing the profile, the user receives a warning about it ONLY when the found `<group_password>` does not mean "no password". I.e, when the value is neither, empty nor `x`.

However, other values like `!` and `*` are used to express the absence of the group password too BUT we are warning the user about ignoring such a _no password_. See https://openqa.suse.de/tests/7757865#step/installation/48 (if it has not expired yet)


<table>
  <thead>
    <tr>
      <th>The AutoYaST profile excerpt</th>
      <th>The wrong/not needed warning</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>

   ```xml
    <group>
      <encrypted config:type="boolean">true</encrypted>
      <gid>483</gid>
      <group_password>x</group_password>
      <groupname>systemd-timesync</groupname>
      <userlist/>
    </group>
    <group>
      <encrypted config:type="boolean">true</encrypted>
      <gid>498</gid>
      <group_password>!</group_password>
      <groupname>mail</groupname>
      <userlist>postfix</userlist>
    </group>
    <group>
      <encrypted config:type="boolean">true</encrypted>
      <gid>476</gid>
      <group_password>x</group_password>
      <groupname>vnc</groupname>
      <userlist/>
    </group>
   ```
   </td>
   <td>

  ![Not needed warning](https://user-images.githubusercontent.com/1691872/144126355-7a98825e-c568-42d5-bbdb-52e2c7f9927a.png)

   </td>
    </tr>
  </tbody>
</table>

## Solution

Group all of them on a list of _blank_ password values to be ignored.

## Tests

  * Unit tests updated.