### PR TITLE
Fix import users

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 22 15:25:03 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Fix import users: do not fail if the group does not exist
+  (bsc#1197040).
+- 4.4.11
+
+-------------------------------------------------------------------
 Mon Dec  6 13:43:07 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Prepare code for ruby3 (bsc#1193192)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2users/group.rb
+++ b/src/lib/y2users/group.rb
@@ -26,7 +26,7 @@ module Y2Users
   #
   # @example
   #   group = Group.new("admins")
-  #   group.gid = 110
+  #   group.gid = "110"
   #   group.attached? #=> false
   #   group.id #=> 1
   #


### PR DESCRIPTION
## Problem

Now, YaST relys on the shadow tools for creating users and groups. The `useradd` command fails if the given *gid* does not exist. This situation could happen when importing users from a previous installation. It worked with the old code because *gid* was sanitized before writing the *passwd* file, falling back to a default *gid*.

* https://bugzilla.suse.com/show_bug.cgi?id=1197040
* https://trello.com/c/O0yWuGtg/2787-2-importing-a-user-with-unknown-gid

![Screenshot_deeping-test_2021-11-10_16_15_48](https://user-images.githubusercontent.com/1112304/159662477-a55411ee-677c-4144-91e8-5ede277de042.png)


## Solution

Remove *gid* from the imported users when such a group is not present in the configuration. Note that `useradd` will assign the default group according to the */etc/default/useradd* config.

NOTE: this PR will be merged into *pre-SLE-15-SP4* branch. That branch will be merged into master after branching SLE-15-SP4.

## Testing

- Added a new unit test
- Tested manually

