### PR TITLE
Fix ssh keys nohome

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 19 08:37:53 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- AY: Fix writing ssh keys for user without specified home
+  (bsc#1201185)
+- 4.4.11
+
+-------------------------------------------------------------------
 Mon Dec  6 13:43:07 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Prepare code for ruby3 (bsc#1193192)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -116,7 +116,9 @@ module Y2Users
         @users_to_write_ssh_keys.each_pair do |user, old_keys|
           system_user = system_users.by_name(user.name)
           if !system_user
-            issues << Y2Issues::Issue.new(_("Failed to find user with name '#{user.name}'"))
+            issues << Y2Issues::Issue.new(
+              format(_("Failed to find user with name '%s'"), user.name)
+            )
             log.error("Failed to find user with name #{user.name}")
             next
           end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -121,6 +121,7 @@ module Y2Users
             next
           end
 
+          system_user.authorized_keys = user.authorized_keys
           write_user_auth_keys(system_user, old_keys)
         end
       end
@@ -168,9 +169,9 @@ module Y2Users
         edit_password(target_user) if initial_user.password != target_user.password
 
         previous_keys = initial_user.authorized_keys || []
-        if previous_keys != target_user.authorized_keys
-          @users_to_write_ssh_keys[target_user] = previous_keys
-        end
+        return if previous_keys == target_user.authorized_keys
+
+        @users_to_write_ssh_keys[target_user] = previous_keys
       end
 
       # Updates root aliases

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -30,6 +30,7 @@ require "y2users/linux/remove_home_content_action"
 require "y2users/linux/set_home_ownership_action"
 require "y2users/linux/set_auth_keys_action"
 require "y2users/linux/delete_user_action"
+require "y2users/linux/reader"
 
 Yast.import "MailAliases"
 
@@ -54,6 +55,7 @@ module Y2Users
         @initial_config = initial_config
         @target_config = target_config
         @commit_configs = commit_configs
+        @users_to_write_ssh_keys = {}
       end
 
     private
@@ -89,6 +91,7 @@ module Y2Users
         edit_users
         add_users
         write_root_aliases
+        write_ssh_auth_keys
       end
 
       # Deletes users
@@ -102,6 +105,24 @@ module Y2Users
       # Creates the new users
       def add_users
         new_users.each { |u| add_user(u) }
+      end
+
+      def write_ssh_auth_keys
+        # we need to re-read system users as for some newly created users
+        # the default home can be used and it depends on useradd and login
+        # defaults. So instead of mimic useradd behavior just read what
+        # useradd creates. (bsc#1201185)
+        system_users = Reader.new.read.users
+        @users_to_write_ssh_keys.each_pair do |user, old_keys|
+          system_user = system_users.by_name(user.name)
+          if !system_user
+            issues << Y2Issues::Issue.new(_("Failed to find user with name '#{user.name}'"))
+            log.error("Failed to find user with name #{user.name}")
+            next
+          end
+
+          write_user_auth_keys(system_user, old_keys)
+        end
       end
 
       # Performs all needed actions in order to create and configure a new user (create user, set
@@ -119,7 +140,7 @@ module Y2Users
         remove_home_content(user) if !reusing_home && commit_config.home_without_skel?
         adapt_home_ownership(user) if commit_config.adapt_home_ownership?
         write_password(user) if user.password
-        write_auth_keys(user)
+        @users_to_write_ssh_keys[user] = []
       end
 
       # Edits users
@@ -147,7 +168,9 @@ module Y2Users
         edit_password(target_user) if initial_user.password != target_user.password
 
         previous_keys = initial_user.authorized_keys || []
-        write_auth_keys(target_user, previous_keys) if previous_keys != target_user.authorized_keys
+        if previous_keys != target_user.authorized_keys
+          @users_to_write_ssh_keys[target_user] = previous_keys
+        end
       end
 
       # Updates root aliases
@@ -293,9 +316,7 @@ module Y2Users
       # @param user [User]
       # @param previous_keys [Array<String>] previous auth keys for given user, if any
       # @return [Boolean] true on success
-      def write_auth_keys(user, previous_keys = [])
-        return true unless exist_user_home?(user)
-
+      def write_user_auth_keys(user, previous_keys = [])
         action = SetAuthKeysAction.new(user, commit_config(user), previous_keys)
 
         perform_action(action)

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -685,7 +685,7 @@ describe Y2Users::Linux::UsersWriter do
 
         context "and the user home exists" do
           let(:system_user) { test3.copy }
-          let(:system_config) { Y2Users::Config.new.tap { |c| c.attach([system_user]) }}
+          let(:system_config) { Y2Users::Config.new.tap { |c| c.attach([system_user]) } }
 
           before do
             allow(Yast::FileUtils).to receive(:IsDirectory).with(test3.home.path).and_return(true)

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -56,7 +56,8 @@ describe Y2Users::Linux::UsersWriter do
   let(:system_config) { initial_config }
 
   before do
-    allow(Y2Users::Linux::Reader).to receive(:new).and_return(double(read: system_config))
+    allow(Y2Users::Linux::Reader).to receive(:new)
+      .and_return(instance_double(Y2Users::Linux::Reader, read: system_config))
   end
 
   describe "#write" do
@@ -343,8 +344,9 @@ describe Y2Users::Linux::UsersWriter do
             target_user.authorized_keys = ["new-key"]
             # cannot overwrite here system_config as we need to have there recent
             # target user which is modified in `before` code
-            system_config = Y2Users::Config.new.tap { |c| c.attach([system_user]) }
-            allow(Y2Users::Linux::Reader).to receive(:new).and_return(double(read: system_config))
+            system_config = Y2Users::Config.new.tap { |c| c.attach(system_user) }
+            allow(Y2Users::Linux::Reader).to receive(:new)
+              .and_return(instance_double(Y2Users::Linux::Reader, read: system_config))
             allow(Yast::FileUtils).to receive(:IsDirectory).with(target_user.home.path)
               .and_return(true)
           end


### PR DESCRIPTION
## Problem

When in autoyast profile home path is not specied, then ssh keys are not written.

- https://bugzilla.suse.com/show_bug.cgi?id=1201185


## Solution

Read system users again before writting ssh keys to know its home paths.


## Testing

- *Unit tests adapted*
- *Tested manually*
