### PR TITLE
Create home for system users

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Sep  1 13:34:19 UTC 2022 - José Iván López González <jlopez@suse.com>
 
-- Fix creation of home for system users (bsc#1202974).
+- AutoYaST: Fix creation of home for system users (bsc#1202974).
 - 4.4.12
 
 -------------------------------------------------------------------

--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep  1 13:34:19 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Fix creation of home for system users (bsc#1202974).
+- 4.4.12
+
+-------------------------------------------------------------------
 Fri Aug 19 08:37:53 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - AY: Fix writing ssh keys for user without specified home

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2users/home.rb
+++ b/src/lib/y2users/home.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -55,6 +55,13 @@ module Y2Users
     # @return [Boolean]
     def btrfs_subvol?
       !!@btrfs_subvol
+    end
+
+    # Whether home has a defined path
+    #
+    # @return [Boolean]
+    def path?
+      !path.to_s.empty?
     end
   end
 end

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -122,7 +122,10 @@ module Y2Users
       # @param skip_home [Boolean]
       # @return [Array<String>]
       def home_options(skip_home: false)
-        return [] if user.system?
+        # If a home is configured for a system user (e.g., with AutoYaST), then its home should be
+        # created (bsc#1202974).
+        home_dir = user.home&.path.to_s
+        return [] if user.system? && home_dir.empty?
 
         return ["--no-create-home"] if skip_home
 

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -124,8 +124,7 @@ module Y2Users
       def home_options(skip_home: false)
         # If a home is configured for a system user (e.g., with AutoYaST), then its home should be
         # created (bsc#1202974).
-        home_dir = user.home&.path.to_s
-        return [] if user.system? && home_dir.empty?
+        return [] if user.system? && !user.home&.path?
 
         return ["--no-create-home"] if skip_home
 

--- a/test/lib/y2users/home_test.rb
+++ b/test/lib/y2users/home_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -97,6 +97,36 @@ describe Y2Users::Home do
 
       it "returns false" do
         expect(subject == other).to eq(false)
+      end
+    end
+  end
+
+  describe "path?" do
+    before do
+      subject.path = path
+    end
+
+    context "if the path is nil" do
+      let(:path) { nil }
+
+      it "returns false" do
+        expect(subject.path?).to eq(false)
+      end
+    end
+
+    context "if the path is empty" do
+      let(:path) { "" }
+
+      it "returns false" do
+        expect(subject.path?).to eq(false)
+      end
+    end
+
+    context "if the path is not empty" do
+      let(:path) { "/home/test" }
+
+      it "returns true" do
+        expect(subject.path?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
## Problem

The home directory is not created for the system users (uid <= SYS_MAX_UID) even though a home dir is indicated in the AutoYaST profile.

The bug was introduced in the *yast-users* code refactoring for relying on the shadow tools (SLE-15-SP4).

* https://trello.com/c/z0nqzV8t/3076-sles15-sp4-p2-1202974-l3-setting-of-users-home-directory-ignored-by-autoyast-in-sles15-sp4
* https://bugzilla.suse.com/show_bug.cgi?id=1202974


## Solution

Create home directory for system users if a home dir is indicated.


## Testing

- Added new unit tests
- Tested manually

