### PR TITLE
Use Fallback for CHARACTER_CLASS

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  8 15:26:35 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use a fallback if CHARACTER_CLASS cannot be read from /etc/login.defs
+  or /usr/etc/login.defs (bsc#1205783)
+- 4.5.3
+
+-------------------------------------------------------------------
 Fri Aug 19 08:37:53 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - AY: Fix writing ssh keys for user without specified home

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -169,7 +169,8 @@ my $encryption_method		= "sha512";
 my $group_encryption_method	= "sha512";
 
 # User/group names must match the following regex expression. (/etc/login.defs)
-my $character_class 		= "[[:alpha:]_][[:alnum:]_.-]*[[:alnum:]_.\$-]\\?";
+my $character_class_fallback	= "[[:alpha:]_][[:alnum:]_.-]*[[:alnum:]_.\$-]\\?";
+my $character_class             = $character_class_fallback;
 
 # the +/- entries in config files:
 my @pluses_passwd		= ();
@@ -1343,9 +1344,11 @@ sub ReadSystemDefaults {
     }
 
     $character_class = ShadowConfig->fetch("CHARACTER_CLASS");
-    if ($character_class) {
-        UsersSimple->SetCharacterClass ($character_class);
+    if (!$character_class) {
+        $character_class = $character_class_fallback;
+        y2warning ("Couldn't read CHARACTER_CLASS from login.defs, using fallback: $character_class")
     }
+    UsersSimple->SetCharacterClass ($character_class);
 
     my %max_lengths		= %{Security->PasswordMaxLengths ()};
     if (defined $max_lengths{$encryption_method}) {

--- a/test/lib/users/local_password_test.rb
+++ b/test/lib/users/local_password_test.rb
@@ -60,7 +60,7 @@ describe Users::LocalPassword do
 
       it "calls UsersSimple with the expected arguments" do
         expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with("uid" => "root", "userPassword" => "", "type" => "system")
+          .with({ "uid" => "root", "userPassword" => "", "type" => "system" })
         subject.errors
       end
 
@@ -118,7 +118,7 @@ describe Users::LocalPassword do
 
       it "calls UsersSimple with the expected arguments" do
         expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with("uid" => "user", "userPassword" => "", "type" => "local", "root" => true)
+          .with({ "uid" => "user", "userPassword" => "", "type" => "local", "root" => true })
         subject.errors
       end
 
@@ -176,7 +176,7 @@ describe Users::LocalPassword do
 
       it "calls UsersSimple with the expected arguments" do
         expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with("uid" => "user", "userPassword" => "", "type" => "local", "root" => false)
+          .with({ "uid" => "user", "userPassword" => "", "type" => "local", "root" => false })
         subject.errors
       end
 

--- a/test/lib/users/local_password_test.rb
+++ b/test/lib/users/local_password_test.rb
@@ -59,8 +59,8 @@ describe Users::LocalPassword do
       subject { Users::LocalPassword.new(username: "root") }
 
       it "calls UsersSimple with the expected arguments" do
-        expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with({ "uid" => "root", "userPassword" => "", "type" => "system" })
+        args = { "uid" => "root", "userPassword" => "", "type" => "system" }
+        expect(Yast::UsersSimple).to receive(:CheckPasswordUI).with(args)
         subject.errors
       end
 
@@ -117,8 +117,8 @@ describe Users::LocalPassword do
       subject { Users::LocalPassword.new(username: "user", also_for_root: true) }
 
       it "calls UsersSimple with the expected arguments" do
-        expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with({ "uid" => "user", "userPassword" => "", "type" => "local", "root" => true })
+        args = { "uid" => "user", "userPassword" => "", "type" => "local", "root" => true }
+        expect(Yast::UsersSimple).to receive(:CheckPasswordUI).with(args)
         subject.errors
       end
 
@@ -175,8 +175,8 @@ describe Users::LocalPassword do
       subject { Users::LocalPassword.new(username: "user", also_for_root: false) }
 
       it "calls UsersSimple with the expected arguments" do
-        expect(Yast::UsersSimple).to receive(:CheckPasswordUI)
-          .with({ "uid" => "user", "userPassword" => "", "type" => "local", "root" => false })
+        args = { "uid" => "user", "userPassword" => "", "type" => "local", "root" => false }
+        expect(Yast::UsersSimple).to receive(:CheckPasswordUI).with(args)
         subject.errors
       end
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1205783


## Trello

https://trello.com/c/IEHa2Ffx/


## Problem

When trying to create a new user group on a newly installed Tumbleweed, you always get an error popup about the permitted characters for the group name:

```
The name of the group may only contain letters, digits, 
"-", ".", and "_" and must start with a letter.

Please try again.
```

Even though that group name fullfilled those criteria.


## Cause

The `/usr/etc/login.defs` or `/etc/login.defs` file on Tumbleweed now no longer contains a CHARACTER_CLASS field. The code, however, just overwrote the internal variable holding the contents of that field, and if nothing could be read, it would remain empty; and comparing the group name that the user entered against that always failed.


## Fix

Handle that case gracefully: Fall back to a predefined character class if it can't be read from file.