### PR TITLE
Stop using Dir.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 11 13:14:46 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using Dir.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.5.4
+
+-------------------------------------------------------------------
 Thu Dec  8 15:26:35 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use a fallback if CHARACTER_CLASS cannot be read from /etc/login.defs

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1326,7 +1326,7 @@ module Yast
 
         # inside Details dialog
         if current == :details && ret == :browse
-          start_dir = Dir.exists?(home) ? home : Users.GetDefaultHome(new_type)
+          start_dir = Dir.exist?(home) ? home : Users.GetDefaultHome(new_type)
           selected_dir = cleanpath(UI.AskForExistingDirectory(start_dir, ""))
           UI.ChangeWidget(Id(:home), :Value, selected_dir) unless selected_dir.empty?
         end


### PR DESCRIPTION
## Problem

Ruby 3.2 removed `Dir.exists?` which has been long deprecated in favor of `Dir.exist?`

BTW this is the only module where it occurs for `Dir`, not `File`

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419
- build monitor: https://build.opensuse.org/project/monitor/openSUSE:Factory:Staging:H?arch_x86_64=1&defaults=0&failed=1&repo_standard=1
- first PR of this kind, to be used as collection point: https://github.com/yast/yast-country/pull/302


## Solution

The solution is a one-character diff.

## Testing

No tests so far have caught it, I hope openQA eventually would

- [ ] see if we can add some unit tests to that method. it only has 1500 lines

## Screenshots

N/A
