### PR TITLE
Support for alternative YPPWD_SRCDIR

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 24 13:21:21 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Allow to edit the NIS master server databases instead of the
+  local ones, relying on the --prefix argument added to several
+  commands in the "shadow" package (bsc#1206627).
+- 4.4.15
+
+-------------------------------------------------------------------
 Wed Jun  7 16:22:59 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Write the users when using AutoYaST on an installed system

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.14
+Version:        4.4.15
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,8 +109,8 @@ ylib_y2users_DATA = \
   lib/y2users/groups_collection.rb \
   lib/y2users/read_result.rb \
   lib/y2users/home.rb \
-  lib/y2users/commit_config.rb \
-  lib/y2users/commit_config_collection.rb
+  lib/y2users/user_commit_config.rb \
+  lib/y2users/user_commit_config_collection.rb
 
 ylib_y2users_clientsdir = @ylibdir@/y2users/clients
 ylib_y2users_clients_DATA = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,8 @@ ylib_y2users_linux_DATA = \
   lib/y2users/linux/create_group_action.rb \
   lib/y2users/linux/action.rb \
   lib/y2users/linux/action_result.rb \
+  lib/y2users/linux/root_path.rb \
+  lib/y2users/linux/temporary_root.rb \
   lib/y2users/linux/useradd_config_writer.rb \
   lib/y2users/linux/login_config_writer.rb \
   lib/y2users/linux/action_writer.rb \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ ylib_y2users_DATA = \
   lib/y2users/groups_collection.rb \
   lib/y2users/read_result.rb \
   lib/y2users/home.rb \
+  lib/y2users/commit_config.rb \
   lib/y2users/user_commit_config.rb \
   lib/y2users/user_commit_config_collection.rb
 

--- a/src/lib/y2users/commit_config.rb
+++ b/src/lib/y2users/commit_config.rb
@@ -26,6 +26,11 @@ module Y2Users
   # For example, a writer can use the commit config to check whether the content of the home
   # directory of a specific user should be moved or not.
   class CommitConfig
+    # Directory where the files passwd, shadow and group are located
+    #
+    # @return [String, nil] nil to use the default directory
+    attr_accessor :target_dir
+
     # Configuration for each user
     #
     # @return [UserCommitConfigCollection]

--- a/src/lib/y2users/commit_config.rb
+++ b/src/lib/y2users/commit_config.rb
@@ -1,0 +1,39 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2users/user_commit_config_collection"
+
+module Y2Users
+  # Class for configuring the commit actions
+  #
+  # Writers can receive an object of this class in order to decide what actions to perform and how.
+  # For example, a writer can use the commit config to check whether the content of the home
+  # directory of a specific user should be moved or not.
+  class CommitConfig
+    # Configuration for each user
+    #
+    # @return [UserCommitConfigCollection]
+    attr_reader :user_configs
+
+    # Constructor
+    def initialize
+      @user_configs = UserCommitConfigCollection.new
+    end
+  end
+end

--- a/src/lib/y2users/linux/action.rb
+++ b/src/lib/y2users/linux/action.rb
@@ -43,10 +43,8 @@ module Y2Users
       # Constructor
       #
       # @param action_element [Object] object to perform the action (e.g., a user)
-      # @param commit_config [UserCommitConfig, nil] optional configuration for the commit
-      def initialize(action_element, commit_config = nil)
+      def initialize(action_element)
         @action_element = action_element
-        @commit_config = commit_config
       end
 
       # Performs the action
@@ -62,9 +60,6 @@ module Y2Users
 
       # @return [Object]
       attr_reader :action_element
-
-      # @return [UserCommitConfig]
-      attr_reader :commit_config
 
       # Issues generated while performing the action
       #

--- a/src/lib/y2users/linux/action.rb
+++ b/src/lib/y2users/linux/action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -43,7 +43,7 @@ module Y2Users
       # Constructor
       #
       # @param action_element [Object] object to perform the action (e.g., a user)
-      # @param commit_config [CommitConfig, nil] optional configuration for the commit
+      # @param commit_config [UserCommitConfig, nil] optional configuration for the commit
       def initialize(action_element, commit_config = nil)
         @action_element = action_element
         @commit_config = commit_config
@@ -63,7 +63,7 @@ module Y2Users
       # @return [Object]
       attr_reader :action_element
 
-      # @return [CommitConfig]
+      # @return [UserCommitConfig]
       attr_reader :commit_config
 
       # Issues generated while performing the action

--- a/src/lib/y2users/linux/create_group_action.rb
+++ b/src/lib/y2users/linux/create_group_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,7 +33,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(group, commit_config = nil)
+      def initialize(group)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/create_group_action.rb
+++ b/src/lib/y2users/linux/create_group_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,14 +30,16 @@ module Y2Users
     class CreateGroupAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(group)
+      def initialize(group, root_path: nil)
         textdomain "users"
 
-        super
+        super(group)
+        @root_path = root_path
       end
 
     private
@@ -66,7 +69,7 @@ module Y2Users
       #
       # @return [Array<String>]
       def groupadd_options
-        opts = []
+        opts = root_path_options
         opts += ["--non-unique", "--gid", group.gid] if group.gid
         opts << "--system" if group.system?
         opts << group.name

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,14 +30,16 @@ module Y2Users
     class CreateUserAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(user)
+      def initialize(user, root_path: nil)
         textdomain "users"
 
-        super
+        super(user)
+        @root_path = root_path
       end
 
     private
@@ -84,7 +87,7 @@ module Y2Users
       # @param skip_home [Boolean] whether the home creation should be explicitly skip
       # @return [Array<String>]
       def useradd_options(skip_home: false)
-        user_options + home_options(skip_home: skip_home) + [user.name]
+        root_path_options + user_options + home_options(skip_home: skip_home) + [user.name]
       end
 
       # Options from user attributes

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021-2022] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,7 +33,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      def initialize(user)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/delete_group_action.rb
+++ b/src/lib/y2users/linux/delete_group_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,7 +33,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(group, commit_config = nil)
+      def initialize(group)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/delete_group_action.rb
+++ b/src/lib/y2users/linux/delete_group_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,14 +30,16 @@ module Y2Users
     class DeleteGroupAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(group)
+      def initialize(group, root_path: nil)
         textdomain "users"
 
-        super
+        super(group)
+        @root_path = root_path
       end
 
     private
@@ -51,7 +54,7 @@ module Y2Users
       #
       # Issues are generated when the group cannot be deleted.
       def run_action
-        Yast::Execute.on_target!(GROUPDEL, group.name)
+        Yast::Execute.on_target!(GROUPDEL, *root_path_options, group.name)
         true
       rescue Cheetah::ExecutionFailed => e
         issues << Y2Issues::Issue.new(

--- a/src/lib/y2users/linux/delete_user_action.rb
+++ b/src/lib/y2users/linux/delete_user_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,15 +33,24 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      # @see #remove_home?
+      def initialize(user, remove_home: true)
         textdomain "users"
 
-        super
+        super(user)
+        @remove_home = remove_home
       end
 
     private
 
       alias_method :user, :action_element
+
+      # Whether to also remove the user home directory
+      #
+      # @return [Boolean]
+      def remove_home?
+        !!@remove_home
+      end
 
       # Command for deleting a user
       USERDEL = "/usr/sbin/userdel".freeze
@@ -63,7 +72,7 @@ module Y2Users
       # @return [Array<String>]
       def userdel_options
         options = []
-        options << "--remove" if commit_config&.remove_home?
+        options << "--remove" if remove_home?
 
         options
       end

--- a/src/lib/y2users/linux/delete_user_action.rb
+++ b/src/lib/y2users/linux/delete_user_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,16 +30,18 @@ module Y2Users
     class DeleteUserAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
       # @see #remove_home?
-      def initialize(user, remove_home: true)
+      def initialize(user, remove_home: true, root_path: nil)
         textdomain "users"
 
         super(user)
         @remove_home = remove_home
+        @root_path = root_path
       end
 
     private
@@ -71,7 +74,7 @@ module Y2Users
       #
       # @return [Array<String>]
       def userdel_options
-        options = []
+        options = root_path_options
         options << "--remove" if remove_home?
 
         options

--- a/src/lib/y2users/linux/delete_user_password_action.rb
+++ b/src/lib/y2users/linux/delete_user_password_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,14 +30,16 @@ module Y2Users
     class DeleteUserPasswordAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(user)
+      def initialize(user, root_path: nil)
         textdomain "users"
 
-        super
+        super(user)
+        @root_path = root_path
       end
 
     private
@@ -51,7 +54,7 @@ module Y2Users
       #
       # Issues are generated when the password cannot be deleted
       def run_action
-        Yast::Execute.on_target!(PASSWD, "--delete", user.name)
+        Yast::Execute.on_target!(PASSWD, "--delete", *root_path_options, user.name)
         true
       rescue Cheetah::ExecutionFailed => e
         issues << Y2Issues::Issue.new(

--- a/src/lib/y2users/linux/delete_user_password_action.rb
+++ b/src/lib/y2users/linux/delete_user_password_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,7 +33,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      def initialize(user)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/edit_group_action.rb
+++ b/src/lib/y2users/linux/edit_group_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,16 +30,18 @@ module Y2Users
     class EditGroupAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(initial_group, target_group)
+      def initialize(initial_group, target_group, root_path: nil)
         textdomain "users"
 
         super(target_group)
 
         @initial_group = initial_group
+        @root_path = root_path
       end
 
     private
@@ -76,7 +79,7 @@ module Y2Users
       #
       # @return [Array<String>]
       def groupmod_options
-        opts = []
+        opts = root_path_options
         opts += ["--new-name", group.name] if group.name && group.name != initial_group.name
         opts += ["--gid", group.gid] if group.gid && group.gid != initial_group.gid
 

--- a/src/lib/y2users/linux/edit_group_action.rb
+++ b/src/lib/y2users/linux/edit_group_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,10 +33,10 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(initial_group, target_group, commit_config = nil)
+      def initialize(initial_group, target_group)
         textdomain "users"
 
-        super(target_group, commit_config)
+        super(target_group)
 
         @initial_group = initial_group
       end

--- a/src/lib/y2users/linux/edit_user_action.rb
+++ b/src/lib/y2users/linux/edit_user_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,17 +30,19 @@ module Y2Users
     class EditUserAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
 
       # Constructor
       #
       # @see Action
-      def initialize(initial_user, target_user, move_home: false)
+      def initialize(initial_user, target_user, move_home: false, root_path: nil)
         textdomain "users"
 
         super(target_user)
 
         @initial_user = initial_user
         @move_home = move_home
+        @root_path = root_path
       end
 
     private
@@ -84,7 +87,7 @@ module Y2Users
       #
       # @return [Array<String>]
       def usermod_options
-        user_options + home_options
+        root_path_options + user_options + home_options
       end
 
       # Options from the user attributes

--- a/src/lib/y2users/linux/edit_user_action.rb
+++ b/src/lib/y2users/linux/edit_user_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,12 +33,13 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(initial_user, target_user, commit_config = nil)
+      def initialize(initial_user, target_user, move_home: false)
         textdomain "users"
 
-        super(target_user, commit_config)
+        super(target_user)
 
         @initial_user = initial_user
+        @move_home = move_home
       end
 
     private
@@ -55,6 +56,14 @@ module Y2Users
       # Command for modifying users
       USERMOD = "/usr/sbin/usermod".freeze
       private_constant :USERMOD
+
+      # For cases in which the location of the home directory changed, whether to move the content
+      # of the current home to the new one
+      #
+      # @return [Boolean]
+      def move_home?
+        !!@move_home
+      end
 
       # @see Action#run_action
       #
@@ -118,7 +127,7 @@ module Y2Users
         # will be created only if the old home directory exists. Otherwise, the user will continue
         # without a home directory. Also note that if the new home already exists, then the content
         # of the old home is not moved neither.
-        opts << "--move-home" if commit_config&.move_home? && opts.include?("--home")
+        opts << "--move-home" if move_home? && opts.include?("--home")
 
         opts
       end

--- a/src/lib/y2users/linux/remove_home_content_action.rb
+++ b/src/lib/y2users/linux/remove_home_content_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,7 +37,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      def initialize(user)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/root_path.rb
+++ b/src/lib/y2users/linux/root_path.rb
@@ -26,10 +26,9 @@ module Y2Users
     # allow to define the path to what would be the root directory of a system. That implies the
     # tools always assume an extra ./etc directory within the provided path.
     #
-    # Some shadow commands provide both a --prefix argument and a --root one to specify such a root
-    # directory. Other commands provide only the --root one. Since --prefix is more convenient for
-    # the YaST purposes, that will be used by default unless another one is configured for the class
-    # using the provided macro root_path_option.
+    # The shadow commands provide both a --prefix argument and a --root one to specify such a root
+    # directory. YaST uses --prefix because the argument --root assumes the root directory contains
+    # a full system in which the commands may even try to authenticate.
     #
     # For more information, see bsc#1206627
     #
@@ -39,11 +38,6 @@ module Y2Users
     # Hopefully, this mixin will disappear (maybe substituted by a similar one) once the shadow
     # tools gain the ability to specify the exact location of the passwd, shadow and groups files.
     module RootPath
-      def self.included(base)
-        base.extend(ClassMethods)
-        base.root_path_option :prefix
-      end
-
       # Directory containing a ./etc subdirectory with the files to be modified by the command(s)
       #
       # @return [String, nil] nil to use the default location
@@ -55,21 +49,7 @@ module Y2Users
       def root_path_options
         return [] if root_path.nil? || root_path.empty?
 
-        ["--#{self.class.root_path_argument}", root_path]
-      end
-
-      # Class methods to be added
-      module ClassMethods
-        # Macro to redefine the name of the argument used to set the root path in the associated
-        # command(s). Needed because some of the shadow tools do not provide a --prefix argument.
-        #
-        # @param name [String] name of the argument, typically :prefix or :root
-        def root_path_option(name)
-          @root_path_argument = name
-        end
-
-        # @see #root_path_option
-        attr_reader :root_path_argument
+        ["--prefix", root_path]
       end
     end
   end

--- a/src/lib/y2users/linux/root_path.rb
+++ b/src/lib/y2users/linux/root_path.rb
@@ -1,0 +1,76 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Users
+  module Linux
+    # Mixin for actions that may need to execute shadow commands (useradd, chpasswd, etc.) on files
+    # (passwd, shadow and groups) located at an alternative path.
+    #
+    # Currently the shadow tools do not allow to set the exact location of the files. Instead, they
+    # allow to define the path to what would be the root directory of a system. That implies the
+    # tools always assume an extra ./etc directory within the provided path.
+    #
+    # Some shadow commands provide both a --prefix argument and a --root one to specify such a root
+    # directory. Other commands provide only the --root one. Since --prefix is more convenient for
+    # the YaST purposes, that will be used by default unless another one is configured for the class
+    # using the provided macro root_path_option.
+    #
+    # For more information, see bsc#1206627
+    #
+    # The user of the mixin is expected to set its instance variable @root_path to a non-null value
+    # in order to indicate that the commands should indeed act on that non-default location.
+    #
+    # Hopefully, this mixin will disappear (maybe substituted by a similar one) once the shadow
+    # tools gain the ability to specify the exact location of the passwd, shadow and groups files.
+    module RootPath
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.root_path_option :prefix
+      end
+
+      # Directory containing a ./etc subdirectory with the files to be modified by the command(s)
+      #
+      # @return [String, nil] nil to use the default location
+      attr_reader :root_path
+
+      # Options to be included in the list of arguments passed to the command(s)
+      #
+      # @return [Array<String>] an empty array if #root_path is set to nil
+      def root_path_options
+        return [] if root_path.nil? || root_path.empty?
+
+        ["--#{self.class.root_path_argument}", root_path]
+      end
+
+      # Class methods to be added
+      module ClassMethods
+        # Macro to redefine the name of the argument used to set the root path in the associated
+        # command(s). Needed because some of the shadow tools do not provide a --prefix argument.
+        #
+        # @param name [String] name of the argument, typically :prefix or :root
+        def root_path_option(name)
+          @root_path_argument = name
+        end
+
+        # @see #root_path_option
+        attr_reader :root_path_argument
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/set_auth_keys_action.rb
+++ b/src/lib/y2users/linux/set_auth_keys_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,7 +34,7 @@ module Y2Users
       #
       # @see Action
       # @param user [User] user to perform the action
-      # @param commit_config [CommitConfig, nil] optional configuration for the commit
+      # @param commit_config [UserCommitConfig, nil] optional configuration for the commit
       # @param previous_keys [Array<String>] optional collection holding previous SSH keys, if any
       def initialize(user, commit_config = nil, previous_keys = [])
         textdomain "users"

--- a/src/lib/y2users/linux/set_auth_keys_action.rb
+++ b/src/lib/y2users/linux/set_auth_keys_action.rb
@@ -34,12 +34,11 @@ module Y2Users
       #
       # @see Action
       # @param user [User] user to perform the action
-      # @param commit_config [UserCommitConfig, nil] optional configuration for the commit
       # @param previous_keys [Array<String>] optional collection holding previous SSH keys, if any
-      def initialize(user, commit_config = nil, previous_keys = [])
+      def initialize(user, previous_keys = [])
         textdomain "users"
 
-        super(user, commit_config)
+        super(user)
         @previous_keys = previous_keys || []
       end
 

--- a/src/lib/y2users/linux/set_home_ownership_action.rb
+++ b/src/lib/y2users/linux/set_home_ownership_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -36,7 +36,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      def initialize(user)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/set_user_password_action.rb
+++ b/src/lib/y2users/linux/set_user_password_action.rb
@@ -32,8 +32,6 @@ module Y2Users
       include Yast::Logger
       include RootPath
 
-      root_path_option :root
-
       # Constructor
       #
       # @see Action

--- a/src/lib/y2users/linux/set_user_password_action.rb
+++ b/src/lib/y2users/linux/set_user_password_action.rb
@@ -22,6 +22,7 @@ require "yast/i18n"
 require "yast2/execute"
 require "y2issues/issue"
 require "y2users/linux/action"
+require "y2users/linux/root_path"
 
 module Y2Users
   module Linux
@@ -29,14 +30,18 @@ module Y2Users
     class SetUserPasswordAction < Action
       include Yast::I18n
       include Yast::Logger
+      include RootPath
+
+      root_path_option :root
 
       # Constructor
       #
       # @see Action
-      def initialize(user)
+      def initialize(user, root_path: nil)
         textdomain "users"
 
-        super
+        super(user)
+        @root_path = root_path
       end
 
     private
@@ -107,7 +112,7 @@ module Y2Users
       def chpasswd_options
         return [] unless user.password&.value
 
-        opts = []
+        opts = root_path_options
         opts << "-e" if user.password&.value&.encrypted?
         opts << {
           stdin:    [user.name, user.password_content].join(":"),
@@ -122,7 +127,15 @@ module Y2Users
       def chage_options
         return [] unless user.password
 
-        opts = {
+        opts = chage_options_hash.reject { |_, v| v.nil? }.flatten
+        return [] if opts.empty?
+
+        opts + root_path_options
+      end
+
+      # @see #chage_options
+      def chage_options_hash
+        {
           "--mindays"    => chage_value(user.password.minimum_age),
           "--maxdays"    => chage_value(user.password.maximum_age),
           "--warndays"   => chage_value(user.password.warning_period),
@@ -130,8 +143,6 @@ module Y2Users
           "--expiredate" => chage_value(user.password.account_expiration),
           "--lastday"    => chage_value(user.password.aging)
         }
-
-        opts.reject { |_, v| v.nil? }.flatten
       end
 
       # Returns the right value for a given `chage` option value

--- a/src/lib/y2users/linux/set_user_password_action.rb
+++ b/src/lib/y2users/linux/set_user_password_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,7 +33,7 @@ module Y2Users
       # Constructor
       #
       # @see Action
-      def initialize(user, commit_config = nil)
+      def initialize(user)
         textdomain "users"
 
         super

--- a/src/lib/y2users/linux/temporary_root.rb
+++ b/src/lib/y2users/linux/temporary_root.rb
@@ -1,0 +1,58 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "tempfile"
+
+module Y2Users
+  module Linux
+    # Mixin for writers that may need to create a temporary directory containing a ./etc
+    # subdirectory with the shadow files (passwd, shadow and groups) as a hacky and indirect
+    # way to point to the real location of those files.
+    #
+    # For the rationale, see the documentation of {RootPath} and bsc#1206627.
+    #
+    # This mixin will disappear once the shadow tools gain the ability to specify the exact
+    # location of the passwd, shadow and groups files.
+    module TemporaryRoot
+      # Path of the existing temporary directory
+      #
+      # @return [String, nil] nil if the temporary directory doesn't exist because it was not
+      #   needed or because it was already deleted
+      attr_reader :temporary_root
+
+      # Creates a temporary directory with a ./etc symlink pointing to the given path and executes
+      # the given block
+      #
+      # @param real_path [String] directory with the content of the simulated /etc
+      def with_temporary_root(real_path, &block)
+        if real_path.nil? || real_path.empty?
+          block.call
+        else
+          Dir.mktmpdir do |dir|
+            @temporary_root = dir
+            File.symlink(real_path, File.join(dir, "etc"))
+            block.call
+          end
+        end
+      ensure
+        @temporary_root = nil
+      end
+    end
+  end
+end

--- a/src/lib/y2users/linux/users_writer.rb
+++ b/src/lib/y2users/linux/users_writer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,7 +20,7 @@
 require "yast"
 require "yast/i18n"
 require "y2issues/issue"
-require "y2users/commit_config"
+require "y2users/user_commit_config"
 require "y2users/linux/action_writer"
 require "y2users/linux/create_user_action"
 require "y2users/linux/edit_user_action"
@@ -48,7 +48,7 @@ module Y2Users
       #
       # @param target_config [Config] see #target_config
       # @param initial_config [Config] see #initial_config
-      # @param commit_configs [CommitConfigCollection]
+      # @param commit_configs [UserCommitConfigCollection]
       def initialize(target_config, initial_config, commit_configs)
         textdomain "users"
 
@@ -73,7 +73,7 @@ module Y2Users
 
       # Collection of commit configs to address the commit actions to perform for each user
       #
-      # @return [CommitConfigCollection]
+      # @return [UserCommitConfigCollection]
       attr_reader :commit_configs
 
       # Issues generated during the process
@@ -83,7 +83,7 @@ module Y2Users
 
       # Performs the changes in the system in order to create, edit or delete users according to
       # the differences between the initial and the target configs. Commit actions can be addressed
-      # with the commit configs, see {CommitConfig}. Root mail aliases are also updated.
+      # with the commit configs, see {UserCommitConfig}. Root mail aliases are also updated.
       #
       # @see ActionWriter
       def actions
@@ -339,10 +339,10 @@ module Y2Users
       #
       # @param user [User] Note that the commit config of a user is found by the user name. Due to
       #   the user name can change, always use the user from the target config.
-      # @return [CommitConfig] commit config for the given user or a new commit config if there is
-      #   no config for that user.
+      # @return [UserCommitConfig] commit config for the given user or a new configuration if
+      #   there is none for that user.
       def commit_config(user)
-        commit_configs.by_username(user.name) || CommitConfig.new
+        commit_configs.by_username(user.name) || UserCommitConfig.new
       end
 
       # Whether the home directory/subvolume of the given user exists on disk

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -18,7 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2users/user_commit_config_collection"
+require "y2users/commit_config"
 require "y2issues/with_issues"
 require "y2users/linux/useradd_config_writer"
 require "y2users/linux/login_config_writer"
@@ -84,11 +84,11 @@ module Y2Users
       #
       # @param config [Config] see #config
       # @param initial_config [Config] see #initial_config
-      # @param commit_configs [UserCommitConfigCollection] configuration to address the commit process
-      def initialize(config, initial_config, commit_configs = nil)
+      # @param commit_config [CommitConfig] configuration to address the commit process
+      def initialize(config, initial_config, commit_config = nil)
         @config = config
         @initial_config = initial_config
-        @commit_configs = commit_configs || UserCommitConfigCollection.new
+        @commit_config = commit_config || CommitConfig.new
       end
 
       # Performs the changes in the system
@@ -151,10 +151,10 @@ module Y2Users
       # @return [Config]
       attr_reader :initial_config
 
-      # Collection of commit configs to address the commit actions for each user
+      # Commit config to address the commit actions
       #
-      # @return [UserCommitConfigCollection]
-      attr_reader :commit_configs
+      # @return [CommitConfig]
+      attr_reader :commit_config
 
       # Writes the useradd configuration to the system
       #
@@ -181,7 +181,7 @@ module Y2Users
       #
       # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
       def write_users
-        UsersWriter.new(config, initial_config, commit_configs).write
+        UsersWriter.new(config, initial_config, commit_config).write
       end
     end
   end

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -174,7 +174,7 @@ module Y2Users
       #
       # @return [Y2Issues::List] the list of issues found while writing changes; empty when none
       def write_groups
-        GroupsWriter.new(config, initial_config).write
+        GroupsWriter.new(config, initial_config, commit_config).write
       end
 
       # Writes (creates, edits or deletes) users according to the configs

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,7 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2users/commit_config_collection"
+require "y2users/user_commit_config_collection"
 require "y2issues/with_issues"
 require "y2users/linux/useradd_config_writer"
 require "y2users/linux/login_config_writer"
@@ -84,11 +84,11 @@ module Y2Users
       #
       # @param config [Config] see #config
       # @param initial_config [Config] see #initial_config
-      # @param commit_configs [CommitConfigCollection] configuration to address the commit process
+      # @param commit_configs [UserCommitConfigCollection] configuration to address the commit process
       def initialize(config, initial_config, commit_configs = nil)
         @config = config
         @initial_config = initial_config
-        @commit_configs = commit_configs || CommitConfigCollection.new
+        @commit_configs = commit_configs || UserCommitConfigCollection.new
       end
 
       # Performs the changes in the system
@@ -153,7 +153,7 @@ module Y2Users
 
       # Collection of commit configs to address the commit actions for each user
       #
-      # @return [CommitConfigCollection]
+      # @return [UserCommitConfigCollection]
       attr_reader :commit_configs
 
       # Writes the useradd configuration to the system

--- a/src/lib/y2users/linux/writer.rb
+++ b/src/lib/y2users/linux/writer.rb
@@ -30,8 +30,6 @@ module Y2Users
     # Writes users and groups to the system using Yast2::Execute and standard
     # linux tools.
     #
-    # NOTE: Removing or fully modifying users is still not covered.
-    #
     # A brief history of the differences with the Yast::Users (perl) module:
     #
     # Both useradd and YaST::Users call the helper script useradd.local which

--- a/src/lib/y2users/user_commit_config.rb
+++ b/src/lib/y2users/user_commit_config.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,12 +20,12 @@
 module Y2Users
   # Class for configuring the commit action for a user
   #
-  # Writers can receive a collection of objects of this class (see {CommitConfigCollection}) in
+  # Writers can receive a collection of objects of this class (see {UserCommitConfigCollection}) in
   # order to decide what actions to perform over the user. For example, a writer can use the commit
   # config to check whether the content of the home directory should be moved or not.
   # TODO: It is confusing to have config for different commit actions, so for future it makes sense
   # to split it
-  class CommitConfig
+  class UserCommitConfig
     # Name of the user this commit config applies to
     #
     # @return [String]

--- a/src/lib/y2users/user_commit_config.rb
+++ b/src/lib/y2users/user_commit_config.rb
@@ -20,13 +20,13 @@
 module Y2Users
   # Class for configuring the commit action for a user
   #
-  # Writers can receive a collection of objects of this class (see {UserCommitConfigCollection}) in
-  # order to decide what actions to perform over the user. For example, a writer can use the commit
-  # config to check whether the content of the home directory should be moved or not.
-  # TODO: It is confusing to have config for different commit actions, so for future it makes sense
-  # to split it
+  # @see CommitConfig
+  #
+  # TODO: It has been mentioned that it is confusing to have a single class to define the
+  # configuration of the different actions that can be performed on a user. In the future we could
+  # consider to split it.
   class UserCommitConfig
-    # Name of the user this commit config applies to
+    # Name of the user this configuration applies to
     #
     # @return [String]
     attr_accessor :username

--- a/src/lib/y2users/user_commit_config_collection.rb
+++ b/src/lib/y2users/user_commit_config_collection.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,22 +20,22 @@
 require "y2users/collection"
 
 module Y2Users
-  # Collection of commit configs
+  # Collection of user commit configs
   #
-  # @see CommitConfig
-  class CommitConfigCollection < Collection
+  # @see UserCommitConfig
+  class UserCommitConfigCollection < Collection
     # Constructor
     #
-    # @param commit_configs [Array<CommitConfig>]
-    def initialize(commit_configs = [])
+    # @param configs [Array<UserCommitConfig>]
+    def initialize(configs = [])
       super
     end
 
     # Commit config for the given user
     #
     # @param value [String] username
-    # @return [CommitConfig, nil] nil if the collection does not include a commit config for the
-    #   given username
+    # @return [UserCommitConfig, nil] nil if the collection does not include a configuration for
+    #   the given username
     def by_username(value)
       find { |c| c.username == value }
     end

--- a/src/lib/y2users/users_module/commit_config_reader.rb
+++ b/src/lib/y2users/users_module/commit_config_reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "pathname"
 require "y2users/commit_config"
 require "y2users/user_commit_config"
 
@@ -34,6 +35,7 @@ module Y2Users
       # @return [CommitConfig]
       def read
         CommitConfig.new.tap do |config|
+          config.target_dir = target_dir
           users.each do |user|
             config.user_configs.add(user_config(user))
           end
@@ -116,6 +118,22 @@ module Y2Users
         return nil if value == ""
 
         value
+      end
+
+      # Default value for Yast::Users.GetBaseDirectory()
+      DEFAULT_BASE_DIR = "/etc".freeze
+      private_constant :DEFAULT_BASE_DIR
+
+      # Value for CommitConfig#target_dir
+      #
+      # See bsc#1206627
+      #
+      # @return [String, nil]
+      def target_dir
+        base_dir = Pathname.new(Yast::Users.GetBaseDirectory()).cleanpath.to_s
+        return nil if base_dir == DEFAULT_BASE_DIR
+
+        base_dir
       end
     end
   end

--- a/src/lib/y2users/users_module/commit_config_reader.rb
+++ b/src/lib/y2users/users_module/commit_config_reader.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,8 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2users/commit_config_collection"
-require "y2users/commit_config"
+require "y2users/user_commit_config_collection"
+require "y2users/user_commit_config"
 
 Yast.import "Users"
 
@@ -27,13 +27,13 @@ module Y2Users
   module UsersModule
     # Class for reading the commit configs from Yast::Users module
     #
-    # @see CommitConfig
+    # @see UserCommitConfig
     class CommitConfigReader
       # Generates a collection of commit configs with the information from YaST::Users module
       #
-      # @return [CommitConfigCollection]
+      # @return [UserCommitConfigCollection]
       def read
-        CommitConfigCollection.new.tap do |collection|
+        UserCommitConfigCollection.new.tap do |collection|
           users.each do |user|
             collection.add(commit_config(user))
           end
@@ -66,7 +66,7 @@ module Y2Users
         name = user["uid"]
         config = collection.by_username(name)
         if !config
-          config = CommitConfig.new
+          config = UserCommitConfig.new
           config.username = name
           collection.add(config)
         end
@@ -79,9 +79,9 @@ module Y2Users
       # Generates a commit config from the given user
       #
       # @param user [Hash] a user representation in the format used by Yast::Users
-      # @return [CommitConfig]
+      # @return [UserCommitConfig]
       def commit_config(user)
-        CommitConfig.new.tap do |config|
+        UserCommitConfig.new.tap do |config|
           config.username = user["uid"]
           config.home_without_skel = user["no_skeleton"]
           config.move_home = move_home?(user)

--- a/src/lib/y2users/users_module/commit_config_reader.rb
+++ b/src/lib/y2users/users_module/commit_config_reader.rb
@@ -18,7 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2users/user_commit_config_collection"
+require "y2users/commit_config"
 require "y2users/user_commit_config"
 
 Yast.import "Users"
@@ -27,18 +27,18 @@ module Y2Users
   module UsersModule
     # Class for reading the commit configs from Yast::Users module
     #
-    # @see UserCommitConfig
+    # @see CommitConfig
     class CommitConfigReader
-      # Generates a collection of commit configs with the information from YaST::Users module
+      # Generates a commit config with the information from YaST::Users module
       #
-      # @return [UserCommitConfigCollection]
+      # @return [CommitConfig]
       def read
-        UserCommitConfigCollection.new.tap do |collection|
+        CommitConfig.new.tap do |config|
           users.each do |user|
-            collection.add(commit_config(user))
+            config.user_configs.add(user_config(user))
           end
           removed_users.each do |user|
-            update_user(user, collection)
+            update_user(user, config.user_configs)
           end
         end
       end
@@ -80,7 +80,7 @@ module Y2Users
       #
       # @param user [Hash] a user representation in the format used by Yast::Users
       # @return [UserCommitConfig]
-      def commit_config(user)
+      def user_config(user)
         UserCommitConfig.new.tap do |config|
           config.username = user["uid"]
           config.home_without_skel = user["no_skeleton"]

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -43,8 +43,8 @@ TESTS = \
   lib/y2users/linux/users_writer_test.rb \
   lib/y2users/linux/writer_test.rb \
   lib/y2users/home_test.rb \
-  lib/y2users/commit_config_test.rb \
-  lib/y2users/commit_config_collection_test.rb \
+  lib/y2users/user_commit_config_test.rb \
+  lib/y2users/user_commit_config_collection_test.rb \
   lib/y2users/users_module/reader_test.rb \
   lib/y2users/users_module/commit_config_reader_test.rb \
   lib/y2users/autoinst/config_merger_test.rb \

--- a/test/lib/y2users/linux/create_group_action_test.rb
+++ b/test/lib/y2users/linux/create_group_action_test.rb
@@ -108,6 +108,18 @@ describe Y2Users::Linux::CreateGroupAction do
       end
     end
 
+    context "if an alternative root_path is passed" do
+      subject { described_class.new(group, root_path: "/tmp/root") }
+
+      it "calls groupadd with the corresponding --prefix option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/groupadd/, any_args) do |*args|
+          expect(args.join(" ")).to include "--prefix /tmp/root"
+        end
+
+        subject.perform
+      end
+    end
+
     context "when the command for creating the group successes" do
       it "returns a successful result" do
         result = subject.perform

--- a/test/lib/y2users/linux/create_user_action_test.rb
+++ b/test/lib/y2users/linux/create_user_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021-2022] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,7 +24,6 @@ require_relative "../test_helper"
 require "date"
 require "y2users/user"
 require "y2users/linux/create_user_action"
-require "y2users/commit_config"
 
 describe Y2Users::Linux::CreateUserAction do
   subject(:action) { described_class.new(user, commit_config) }

--- a/test/lib/y2users/linux/create_user_action_test.rb
+++ b/test/lib/y2users/linux/create_user_action_test.rb
@@ -26,9 +26,8 @@ require "y2users/user"
 require "y2users/linux/create_user_action"
 
 describe Y2Users::Linux::CreateUserAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user) }
   let(:user) { Y2Users::User.new("test") }
-  let(:commit_config) { nil }
 
   before do
     allow(Yast::Execute).to receive(:on_target!)

--- a/test/lib/y2users/linux/create_user_action_test.rb
+++ b/test/lib/y2users/linux/create_user_action_test.rb
@@ -253,5 +253,17 @@ describe Y2Users::Linux::CreateUserAction do
 
       include_examples "home creation failed"
     end
+
+    context "if an alternative root_path is passed" do
+      subject { described_class.new(user, root_path: "/tmp/root") }
+
+      it "calls useradd with the corresponding --prefix option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/useradd/, any_args) do |*args|
+          expect(args.join(" ")).to include "--prefix /tmp/root"
+        end
+
+        subject.perform
+      end
+    end
   end
 end

--- a/test/lib/y2users/linux/delete_user_action_test.rb
+++ b/test/lib/y2users/linux/delete_user_action_test.rb
@@ -23,12 +23,11 @@ require_relative "../test_helper"
 
 require "y2users/user"
 require "y2users/linux/delete_user_action"
-require "y2users/user_commit_config"
 
 describe Y2Users::Linux::DeleteUserAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user, remove_home: remove_home) }
   let(:user) { Y2Users::User.new("test") }
-  let(:commit_config) { nil }
+  let(:remove_home) { false }
 
   before do
     allow(Yast::Execute).to receive(:on_target!)
@@ -52,7 +51,7 @@ describe Y2Users::Linux::DeleteUserAction do
     end
 
     context "commit config contain remove_home" do
-      let(:commit_config) { Y2Users::UserCommitConfig.new.tap { |c| c.remove_home = true } }
+      let(:remove_home) { true }
 
       it "passes --remove parameter" do
         expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|

--- a/test/lib/y2users/linux/delete_user_action_test.rb
+++ b/test/lib/y2users/linux/delete_user_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,7 +23,7 @@ require_relative "../test_helper"
 
 require "y2users/user"
 require "y2users/linux/delete_user_action"
-require "y2users/commit_config"
+require "y2users/user_commit_config"
 
 describe Y2Users::Linux::DeleteUserAction do
   subject(:action) { described_class.new(user, commit_config) }
@@ -52,7 +52,7 @@ describe Y2Users::Linux::DeleteUserAction do
     end
 
     context "commit config contain remove_home" do
-      let(:commit_config) { Y2Users::CommitConfig.new.tap { |c| c.remove_home = true } }
+      let(:commit_config) { Y2Users::UserCommitConfig.new.tap { |c| c.remove_home = true } }
 
       it "passes --remove parameter" do
         expect(Yast::Execute).to receive(:on_target!) do |_cmd, *args|

--- a/test/lib/y2users/linux/delete_user_password_action_test.rb
+++ b/test/lib/y2users/linux/delete_user_password_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,7 +23,6 @@ require_relative "../test_helper"
 
 require "y2users/user"
 require "y2users/linux/delete_user_password_action"
-require "y2users/commit_config"
 
 describe Y2Users::Linux::DeleteUserPasswordAction do
   subject(:action) { described_class.new(user, commit_config) }

--- a/test/lib/y2users/linux/delete_user_password_action_test.rb
+++ b/test/lib/y2users/linux/delete_user_password_action_test.rb
@@ -25,9 +25,8 @@ require "y2users/user"
 require "y2users/linux/delete_user_password_action"
 
 describe Y2Users::Linux::DeleteUserPasswordAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user) }
   let(:user) { Y2Users::User.new("test") }
-  let(:commit_config) { nil }
 
   before do
     allow(Yast::Execute).to receive(:on_target!)

--- a/test/lib/y2users/linux/edit_user_action_test.rb
+++ b/test/lib/y2users/linux/edit_user_action_test.rb
@@ -24,13 +24,12 @@ require_relative "../test_helper"
 require "date"
 require "y2users/user"
 require "y2users/linux/edit_user_action"
-require "y2users/user_commit_config"
 
 describe Y2Users::Linux::EditUserAction do
-  subject(:action) { described_class.new(old_user, new_user, commit_config) }
+  subject(:action) { described_class.new(old_user, new_user, move_home: move_home) }
   let(:old_user) { Y2Users::User.new("test") }
   let(:new_user) { Y2Users::User.new("test2").tap { |u| u.assign_internal_id(old_user.id) } }
-  let(:commit_config) { nil }
+  let(:move_home) { false }
 
   before do
     allow(Yast::Execute).to receive(:on_target!)
@@ -125,7 +124,7 @@ describe Y2Users::Linux::EditUserAction do
     end
 
     context "commit config contain move_home" do
-      let(:commit_config) { Y2Users::UserCommitConfig.new.tap { |c| c.move_home = true } }
+      let(:move_home) { true }
 
       it "passes --move-home parameter" do
         new_user.home.path = "/home/test5"

--- a/test/lib/y2users/linux/edit_user_action_test.rb
+++ b/test/lib/y2users/linux/edit_user_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,7 +24,7 @@ require_relative "../test_helper"
 require "date"
 require "y2users/user"
 require "y2users/linux/edit_user_action"
-require "y2users/commit_config"
+require "y2users/user_commit_config"
 
 describe Y2Users::Linux::EditUserAction do
   subject(:action) { described_class.new(old_user, new_user, commit_config) }
@@ -125,7 +125,7 @@ describe Y2Users::Linux::EditUserAction do
     end
 
     context "commit config contain move_home" do
-      let(:commit_config) { Y2Users::CommitConfig.new.tap { |c| c.move_home = true } }
+      let(:commit_config) { Y2Users::UserCommitConfig.new.tap { |c| c.move_home = true } }
 
       it "passes --move-home parameter" do
         new_user.home.path = "/home/test5"

--- a/test/lib/y2users/linux/groups_writer_test.rb
+++ b/test/lib/y2users/linux/groups_writer_test.rb
@@ -24,9 +24,10 @@ require_relative "../test_helper"
 require "y2users/linux/groups_writer"
 require "y2users/config"
 require "y2users/group"
+require "y2users/commit_config"
 
 describe Y2Users::Linux::GroupsWriter do
-  subject { described_class.new(target_config, initial_config) }
+  subject { described_class.new(target_config, initial_config, commit_config) }
 
   let(:initial_config) { Y2Users::Config.new.tap { |c| c.attach(groups) } }
 
@@ -38,6 +39,14 @@ describe Y2Users::Linux::GroupsWriter do
 
   let(:groups) { [test1, test2] }
 
+  let(:commit_config) do
+    config = Y2Users::CommitConfig.new
+    config.target_dir = target_dir
+    config
+  end
+
+  let(:target_dir) { nil }
+
   describe "#write" do
     let(:create_group_action) { Y2Users::Linux::CreateGroupAction }
 
@@ -48,7 +57,7 @@ describe Y2Users::Linux::GroupsWriter do
     def mock_action(action, result, *groups)
       action_instance = instance_double(action, perform: result)
 
-      allow(action).to receive(:new).with(*groups).and_return(action_instance)
+      allow(action).to receive(:new).with(*groups, any_args).and_return(action_instance)
 
       action_instance
     end

--- a/test/lib/y2users/linux/remove_home_content_action_test.rb
+++ b/test/lib/y2users/linux/remove_home_content_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,7 +24,6 @@ require_relative "../test_helper"
 require "date"
 require "y2users/user"
 require "y2users/linux/remove_home_content_action"
-require "y2users/commit_config"
 
 describe Y2Users::Linux::RemoveHomeContentAction do
   subject(:action) { described_class.new(user, commit_config) }

--- a/test/lib/y2users/linux/remove_home_content_action_test.rb
+++ b/test/lib/y2users/linux/remove_home_content_action_test.rb
@@ -26,9 +26,8 @@ require "y2users/user"
 require "y2users/linux/remove_home_content_action"
 
 describe Y2Users::Linux::RemoveHomeContentAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user) }
   let(:user) { Y2Users::User.new("test") }
-  let(:commit_config) { nil }
 
   before do
     allow(Yast::Execute).to receive(:on_target!)

--- a/test/lib/y2users/linux/set_auth_keys_action_test.rb
+++ b/test/lib/y2users/linux/set_auth_keys_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,7 +22,6 @@
 require_relative "../test_helper"
 
 require "y2users/linux/set_auth_keys_action"
-require "y2users/commit_config"
 require "y2users/user"
 
 describe Y2Users::Linux::SetAuthKeysAction do

--- a/test/lib/y2users/linux/set_auth_keys_action_test.rb
+++ b/test/lib/y2users/linux/set_auth_keys_action_test.rb
@@ -25,14 +25,13 @@ require "y2users/linux/set_auth_keys_action"
 require "y2users/user"
 
 describe Y2Users::Linux::SetAuthKeysAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user) }
   let(:user) do
     Y2Users::User.new("test").tap do |user|
       user.home.path = "/home/test"
       user.authorized_keys = ["test"]
     end
   end
-  let(:commit_config) { nil }
 
   describe "#perform" do
     it "calls SSHAuthorizedKeyring#write_keys" do

--- a/test/lib/y2users/linux/set_home_ownership_action_test.rb
+++ b/test/lib/y2users/linux/set_home_ownership_action_test.rb
@@ -25,14 +25,13 @@ require "y2users/linux/set_home_ownership_action"
 require "y2users/user"
 
 describe Y2Users::Linux::SetHomeOwnershipAction do
-  subject(:action) { described_class.new(user, commit_config) }
+  subject(:action) { described_class.new(user) }
   let(:user) do
     Y2Users::User.new("test").tap do |u|
       u.gid = "100"
       u.home.path = "/tmp/home"
     end
   end
-  let(:commit_config) { nil }
 
   describe "#perform" do
     it "calls chown on user home" do

--- a/test/lib/y2users/linux/set_home_ownership_action_test.rb
+++ b/test/lib/y2users/linux/set_home_ownership_action_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,7 +22,6 @@
 require_relative "../test_helper"
 
 require "y2users/linux/set_home_ownership_action"
-require "y2users/commit_config"
 require "y2users/user"
 
 describe Y2Users::Linux::SetHomeOwnershipAction do

--- a/test/lib/y2users/linux/set_user_password_action_test.rb
+++ b/test/lib/y2users/linux/set_user_password_action_test.rb
@@ -262,17 +262,17 @@ describe Y2Users::Linux::SetUserPasswordAction do
       subject { described_class.new(user, root_path: "/tmp/root") }
       let(:minimum_age) { "10" }
 
-      it "executes chage with the corresponding --root option" do
+      it "executes chage with the corresponding --prefix option" do
         expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
-          expect(args.join(" ")).to include "--root /tmp/root"
+          expect(args.join(" ")).to include "--prefix /tmp/root"
         end
 
         subject.perform
       end
 
-      it "executes chpasswd with the corresponding --root option" do
+      it "executes chpasswd with the corresponding --prefix option" do
         expect(Yast::Execute).to receive(:on_target!).with(/chpasswd/, any_args) do |*args|
-          expect(args.join(" ")).to include "--root /tmp/root"
+          expect(args.join(" ")).to include "--prefix /tmp/root"
         end
 
         subject.perform

--- a/test/lib/y2users/linux/set_user_password_action_test.rb
+++ b/test/lib/y2users/linux/set_user_password_action_test.rb
@@ -258,6 +258,27 @@ describe Y2Users::Linux::SetUserPasswordAction do
       end
     end
 
+    context "if an alternative root_path is passed" do
+      subject { described_class.new(user, root_path: "/tmp/root") }
+      let(:minimum_age) { "10" }
+
+      it "executes chage with the corresponding --root option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/chage/, any_args) do |*args|
+          expect(args.join(" ")).to include "--root /tmp/root"
+        end
+
+        subject.perform
+      end
+
+      it "executes chpasswd with the corresponding --root option" do
+        expect(Yast::Execute).to receive(:on_target!).with(/chpasswd/, any_args) do |*args|
+          expect(args.join(" ")).to include "--root /tmp/root"
+        end
+
+        subject.perform
+      end
+    end
+
     it "returns result without success and with issues if chpasswd failed" do
       expect(Yast::Execute).to receive(:on_target!).with(/chpasswd/, any_args)
         .and_raise(Cheetah::ExecutionFailed.new(nil, double(exitstatus: 1), nil, nil))

--- a/test/lib/y2users/linux/users_writer_test.rb
+++ b/test/lib/y2users/linux/users_writer_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,8 +25,8 @@ require "y2issues/list"
 require "y2issues/issue"
 require "y2users/linux/users_writer"
 require "y2users/config"
-require "y2users/commit_config_collection"
-require "y2users/commit_config"
+require "y2users/user_commit_config_collection"
+require "y2users/user_commit_config"
 require "y2users/user"
 require "y2users/password"
 require "y2users/linux/delete_user_action"
@@ -43,7 +43,7 @@ describe Y2Users::Linux::UsersWriter do
 
   let(:target_config) { initial_config.copy }
 
-  let(:commit_configs) { Y2Users::CommitConfigCollection.new([commit_config]) }
+  let(:commit_configs) { Y2Users::UserCommitConfigCollection.new([commit_config]) }
 
   let(:users) { [test1, test2] }
 
@@ -51,7 +51,7 @@ describe Y2Users::Linux::UsersWriter do
 
   let(:test2) { Y2Users::User.new("test2").tap { |u| u.home.path = "/home/test2" } }
 
-  let(:commit_config) { Y2Users::CommitConfig.new }
+  let(:commit_config) { Y2Users::UserCommitConfig.new }
 
   let(:system_config) { initial_config }
 
@@ -185,7 +185,7 @@ describe Y2Users::Linux::UsersWriter do
         end
 
         let(:commit_config) do
-          Y2Users::CommitConfig.new.tap do |config|
+          Y2Users::UserCommitConfig.new.tap do |config|
             config.username = target_user.name
             config.move_home = true
           end
@@ -214,7 +214,7 @@ describe Y2Users::Linux::UsersWriter do
         end
 
         let(:commit_config) do
-          Y2Users::CommitConfig.new.tap do |config|
+          Y2Users::UserCommitConfig.new.tap do |config|
             config.username = target_user.name
             config.adapt_home_ownership = adapt_home_ownership
           end
@@ -531,7 +531,7 @@ describe Y2Users::Linux::UsersWriter do
         end
 
         let(:commit_config) do
-          Y2Users::CommitConfig.new.tap do |config|
+          Y2Users::UserCommitConfig.new.tap do |config|
             config.username = test3.name
             config.home_without_skel = home_without_skel
             config.adapt_home_ownership = adapt_home_ownership

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -24,18 +24,18 @@ require_relative "../test_helper"
 require "y2users/linux/writer"
 require "y2users/config"
 require "y2users/login_config"
-require "y2users/user_commit_config_collection"
+require "y2users/commit_config"
 require "y2issues/list"
 require "y2issues/issue"
 
 describe Y2Users::Linux::Writer do
-  subject { described_class.new(target_config, initial_config, commit_configs) }
+  subject { described_class.new(target_config, initial_config, commit_config) }
 
   let(:initial_config) { Y2Users::Config.new }
 
   let(:target_config) { initial_config.copy }
 
-  let(:commit_configs) { Y2Users::UserCommitConfigCollection.new }
+  let(:commit_config) { Y2Users::CommitConfig.new }
 
   describe "#write" do
     before do
@@ -46,7 +46,7 @@ describe Y2Users::Linux::Writer do
         .with(target_config, initial_config).and_return(useradd_writer)
 
       allow(Y2Users::Linux::UsersWriter).to receive(:new)
-        .with(target_config, initial_config, commit_configs).and_return(users_writer)
+        .with(target_config, initial_config, commit_config).and_return(users_writer)
 
       allow(Y2Users::Linux::LoginConfigWriter).to receive(:new)
         .with(login_config).and_return(login_writer)

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,7 +24,7 @@ require_relative "../test_helper"
 require "y2users/linux/writer"
 require "y2users/config"
 require "y2users/login_config"
-require "y2users/commit_config_collection"
+require "y2users/user_commit_config_collection"
 require "y2issues/list"
 require "y2issues/issue"
 
@@ -35,7 +35,7 @@ describe Y2Users::Linux::Writer do
 
   let(:target_config) { initial_config.copy }
 
-  let(:commit_configs) { Y2Users::CommitConfigCollection.new }
+  let(:commit_configs) { Y2Users::UserCommitConfigCollection.new }
 
   describe "#write" do
     before do

--- a/test/lib/y2users/linux/writer_test.rb
+++ b/test/lib/y2users/linux/writer_test.rb
@@ -40,7 +40,7 @@ describe Y2Users::Linux::Writer do
   describe "#write" do
     before do
       allow(Y2Users::Linux::GroupsWriter).to receive(:new)
-        .with(target_config, initial_config).and_return(groups_writer)
+        .with(target_config, initial_config, commit_config).and_return(groups_writer)
 
       allow(Y2Users::Linux::UseraddConfigWriter).to receive(:new)
         .with(target_config, initial_config).and_return(useradd_writer)

--- a/test/lib/y2users/user_commit_config_collection_test.rb
+++ b/test/lib/y2users/user_commit_config_collection_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,14 +20,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "test_helper"
-require "y2users/commit_config_collection"
-require "y2users/commit_config"
+require "y2users/user_commit_config_collection"
+require "y2users/user_commit_config"
 
-describe Y2Users::CommitConfigCollection do
+describe Y2Users::UserCommitConfigCollection do
   subject { described_class.new(elements) }
 
-  let(:commit_config1) { Y2Users::CommitConfig.new.tap { |c| c.username = "test1" } }
-  let(:commit_config2) { Y2Users::CommitConfig.new.tap { |c| c.username = "test2" } }
+  let(:commit_config1) { Y2Users::UserCommitConfig.new.tap { |c| c.username = "test1" } }
+  let(:commit_config2) { Y2Users::UserCommitConfig.new.tap { |c| c.username = "test2" } }
 
   describe "#by_username" do
     context "if the collection contains a commit config for the given username" do

--- a/test/lib/y2users/user_commit_config_test.rb
+++ b/test/lib/y2users/user_commit_config_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,9 +20,9 @@
 # find current contact information at www.suse.com.
 
 require_relative "test_helper"
-require "y2users/commit_config"
+require "y2users/user_commit_config"
 
-describe Y2Users::CommitConfig do
+describe Y2Users::UserCommitConfig do
   subject { described_class.new }
 
   describe "#home_without_skel?" do

--- a/test/lib/y2users/users_module/commit_config_reader_test.rb
+++ b/test/lib/y2users/users_module/commit_config_reader_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -122,7 +122,7 @@ describe Y2Users::UsersModule::CommitConfigReader do
     it "generates a commit config collection with the read data" do
       commit_configs = subject.read
 
-      expect(commit_configs).to be_a(Y2Users::CommitConfigCollection)
+      expect(commit_configs).to be_a(Y2Users::UserCommitConfigCollection)
 
       expect(commit_configs.size).to eq(3)
 

--- a/test/lib/y2users/users_module/commit_config_reader_test.rb
+++ b/test/lib/y2users/users_module/commit_config_reader_test.rb
@@ -119,27 +119,28 @@ describe Y2Users::UsersModule::CommitConfigReader do
       allow(Yast::Users).to receive(:RemovedUsers).and_return(removed_users)
     end
 
-    it "generates a commit config collection with the read data" do
-      commit_configs = subject.read
+    it "generates a commit config with the read data" do
+      commit_config = subject.read
 
-      expect(commit_configs).to be_a(Y2Users::UserCommitConfigCollection)
+      expect(commit_config).to be_a(Y2Users::CommitConfig)
 
-      expect(commit_configs.size).to eq(3)
+      user_configs = commit_config.user_configs
+      expect(user_configs.size).to eq(3)
 
-      commit_config1 = commit_configs.by_username("test1")
+      commit_config1 = user_configs.by_username("test1")
       expect(commit_config1.username).to eq("test1")
       expect(commit_config1.home_without_skel?).to eq(true)
       expect(commit_config1.move_home?).to eq(true)
       expect(commit_config1.adapt_home_ownership?).to eq(true)
 
-      commit_config2 = commit_configs.by_username("test2")
+      commit_config2 = user_configs.by_username("test2")
       expect(commit_config2.username).to eq("test2")
       expect(commit_config2.home_without_skel?).to eq(false)
       expect(commit_config2.move_home?).to eq(false)
       expect(commit_config2.adapt_home_ownership?).to eq(false)
       expect(commit_config2.remove_home?).to eq(true)
 
-      commit_config3 = commit_configs.by_username("test6")
+      commit_config3 = user_configs.by_username("test6")
       expect(commit_config3.username).to eq("test6")
       expect(commit_config3.remove_home?).to eq(false)
     end

--- a/test/lib/y2users/users_module/commit_config_reader_test.rb
+++ b/test/lib/y2users/users_module/commit_config_reader_test.rb
@@ -124,6 +124,8 @@ describe Y2Users::UsersModule::CommitConfigReader do
 
       expect(commit_config).to be_a(Y2Users::CommitConfig)
 
+      expect(commit_config.target_dir).to be_nil
+
       user_configs = commit_config.user_configs
       expect(user_configs.size).to eq(3)
 
@@ -143,6 +145,19 @@ describe Y2Users::UsersModule::CommitConfigReader do
       commit_config3 = user_configs.by_username("test6")
       expect(commit_config3.username).to eq("test6")
       expect(commit_config3.remove_home?).to eq(false)
+    end
+
+    context "if base_dir is set to a non-default value" do
+      before do
+        allow(Yast::Users).to receive(:GetBaseDirectory).and_return "/var/yp/yp_etc"
+      end
+
+      it "generates a commit config with the corresponding #target_dir" do
+        commit_config = subject.read
+        expect(commit_config).to be_a(Y2Users::CommitConfig)
+        expect(commit_config.target_dir).to eq "/var/yp/yp_etc"
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Problem

In a NIS master server, there is a setting stored at `/etc/sysconfig/ypserv` and called `YPPWD_SRCDIR` that specifies where are the `passwd`, `shadow` and `group` files that NIS should export. By default this points to `/etc`. So in a typical NIS master server, managing the users and groups of the NIS domain is fully equivalent to managing the local users and groups in the system.

But what happens if that setting is set to a non default value?

When YaST Users runs in a system that is a NIS master server with `YPPWD_SRCDIR` pointing to an alternative location, it allows the user to select which set of "local users" should be managed in that execution of YaST - the one stored at `/etc` or the one stored at the location pointed by `YPPWD_SRCDIR`.

![01_start_yast2_users](https://user-images.githubusercontent.com/3638289/212464661-27fe29e5-223c-40a8-a923-0664dd6ad27c.png)

Unfortunately, when rewriting YaST Users to rely on the `shadow` tools (`useradd` and friends) we were not aware of that circumstance and YaST always modifies the files under `/etc`.

See https://bugzilla.suse.com/show_bug.cgi?id=1206627

## Solution

First step. Make `Linux::Writer` more configurable so it can be instructed to write the changes to the files in the directory pointed by `YPPWD_SRCDIR`

Second step. Modify `Linux::Writer` and its action to execute the corresponding commands using the `--prefix` argument (for all commands `useradd`, `userdel`, `usermod`, `groupadd`, `groupdel`, `groupmod`, `passwd`, `chpasswd` and `chage`).

## Note for reviewer

This involved a previous refactoring to make easier to add new values to the `Linux::Writer` configuration. Review commit by commit if you want to easily follow the rationale of that refactoring.

## Testing

- Tested manually.
- Added a few unit tests.
- Also verified by the L3 reporter (incident closed).
