### PR TITLE
[SP4] Stop mangling btrfs_subvolume as boolean at Users.EditUser

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 23 14:04:54 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Stop mangling the value of "Create as Btrfs Subvolume" for new
+  users when clicking on "Edit -> Details" (bsc#1209377).
+- 4.4.13
+
+-------------------------------------------------------------------
 Thu Sep  1 13:34:19 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: Fix creation of home for system users (bsc#1202974).

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -2325,7 +2325,7 @@ sub EditUser {
 	    }
 	}
 	if ($key eq "create_home" || $key eq "delete_home" ||
-	    $key eq "chown_home" ||
+	    $key eq "chown_home" || $key eq "btrfs_subvolume" ||
 	    $key eq "encrypted" ||$key eq "no_skeleton" ||
 	    $key eq "disabled" || $key eq "enabled") {
 	    if (ref $data{$key} eq "YaST::YCP::Boolean") {


### PR DESCRIPTION
## Problem

YaST offers the option "Create as Btrfs Subvolume" when creating a new user. Of course, this is optional and only possible when the home directory of the new user is part of a Btrfs file system.

As reported at [bsc#1209377](https://bugzilla.suse.com/show_bug.cgi?id=1209377), this sequence of actions caused that flag to be set, even if didn't make sense for the affected users.

1) Open YaST Users
2) In the tab "Users" click "Add" and enter the information for a new user
3) When back to the list of users, click in that new user and choose "Edit"
4) Visit the tab "details" without making any change
5) Click "ok" -> "ok" to save the changes and quit YaST.

In the best case, the home was created as a Btrfs subvolume when not really wanted. In the worst case (system not using Btrfs), the creation of the home failed.

The problem was caused by the legacy `Users.EditUser` Perl subroutine. In that piece of code, boolean attributes need some special handling. The attribute `btrfs_subvolume` was excluded from that. So it was finally passed to the new Ruby part (the one that actually performs the changes in the system) with a value of `"0"` instead of `false`.

## Solution

Process `btrfs_subvolume` as the rest of boolean attributes.

## Testing

Tested manually.