### PR TITLE
[SP5] Stop mangling btrfs_subvolume as boolean at Users.EditUser

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Thu Mar 23 14:04:54 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Stop mangling the value of "Create as Btrfs Subvolume" for new
+  users when clicking on "Edit -> Details" (bsc#1209377).
+- 4.5.4
+
+-------------------------------------------------------------------
+Thu Mar 23 14:00:00 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: Fix creation of home for system users (bsc#1202974).
+
+-------------------------------------------------------------------
 Thu Dec  8 15:26:35 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use a fallback if CHARACTER_CLASS cannot be read from /etc/login.defs

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2users/home.rb
+++ b/src/lib/y2users/home.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -55,6 +55,13 @@ module Y2Users
     # @return [Boolean]
     def btrfs_subvol?
       !!@btrfs_subvol
+    end
+
+    # Whether home has a defined path
+    #
+    # @return [Boolean]
+    def path?
+      !path.to_s.empty?
     end
   end
 end

--- a/src/lib/y2users/linux/create_user_action.rb
+++ b/src/lib/y2users/linux/create_user_action.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -122,7 +122,9 @@ module Y2Users
       # @param skip_home [Boolean]
       # @return [Array<String>]
       def home_options(skip_home: false)
-        return [] if user.system?
+        # If a home is configured for a system user (e.g., with AutoYaST), then its home should be
+        # created (bsc#1202974).
+        return [] if user.system? && !user.home&.path?
 
         return ["--no-create-home"] if skip_home
 

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -2328,7 +2328,7 @@ sub EditUser {
 	    }
 	}
 	if ($key eq "create_home" || $key eq "delete_home" ||
-	    $key eq "chown_home" ||
+	    $key eq "chown_home" || $key eq "btrfs_subvolume" ||
 	    $key eq "encrypted" ||$key eq "no_skeleton" ||
 	    $key eq "disabled" || $key eq "enabled") {
 	    if (ref $data{$key} eq "YaST::YCP::Boolean") {

--- a/test/lib/y2users/home_test.rb
+++ b/test/lib/y2users/home_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -97,6 +97,36 @@ describe Y2Users::Home do
 
       it "returns false" do
         expect(subject == other).to eq(false)
+      end
+    end
+  end
+
+  describe "path?" do
+    before do
+      subject.path = path
+    end
+
+    context "if the path is nil" do
+      let(:path) { nil }
+
+      it "returns false" do
+        expect(subject.path?).to eq(false)
+      end
+    end
+
+    context "if the path is empty" do
+      let(:path) { "" }
+
+      it "returns false" do
+        expect(subject.path?).to eq(false)
+      end
+    end
+
+    context "if the path is not empty" do
+      let(:path) { "/home/test" }
+
+      it "returns true" do
+        expect(subject.path?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Merge of #376 (which fixes [bsc#1209377](https://bugzilla.suse.com/show_bug.cgi?id=1209377)), into the SLE-15-SP5 branch.

While doing so, I found that #370 was fixed only in SLE-15-SP4 and never merged to more modern branches. Since @joseivanlopez cannot remember a good reason for that, we guess it was simply overlooked. So I'm taking the opportunity to merge also that pull request (which fixed [bsc#1202974](https://bugzilla.suse.com/show_bug.cgi?id=1202974)).