### PR TITLE
Write users when running AutoYaST on an installed system

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  7 16:22:59 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Write the users when using AutoYaST on an installed system
+  (bsc#1211753).
+- 4.4.14
+
+-------------------------------------------------------------------
 Thu Mar 23 14:04:54 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Stop mangling the value of "Create as Btrfs Subvolume" for new

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/lib/users/clients/auto.rb
+++ b/src/lib/users/clients/auto.rb
@@ -22,6 +22,10 @@ require "installation/auto_client"
 require "y2users"
 require "y2users/autoinst/reader"
 require "y2issues"
+require "y2users/config_merger"
+require "y2users/config_manager"
+require "y2users/autoinst/reader"
+require "y2users/linux/writer"
 
 Yast.import "Users"
 Yast.import "Linuxrc"
@@ -90,15 +94,33 @@ module Y2Users
       end
 
       # @note This code is not executed during autoinstallation (instead, the
-      # users_finish is used). However, it is used when running ayast_setup.
+      # users_finish is used). However, it is used when running ayast_setup
+      # or using the AutoYaST UI.
+      #
+      # When working on an already installed system, the process of detecting
+      # which users/groups changed is tricky:
+      #
+      # * The approach followed by [Y2Users::UsersModule::Reader](https://github.com/yast/yast-users/blob/414b6c7373068c367c0a01be20a1399fbd0ef470/src/lib/y2users/users_module/reader.rb#L103),
+      #   checking the content of `org_user`, does not work because it is defined
+      #   only if the user was modified using the AutoYaST UI.
+      # * Directly comparing the users/groups from `system_config` and
+      #   `target_config` does not work because passwords are missing from the
+      #   `target_config` users.
+      #
+      # To overcome these limitations, we only consider those users/groups
+      # which 'modified' property is not nil, although it does not guarantee
+      # that they changed at all.
       #
       # @return [Boolean] true if configuration was changed; false otherwise.
       def write
-        Yast::Users.SetWriteOnly(true)
-        progress_orig = Yast::Progress.set(false)
-        ret = Yast::Users.Write == ""
-        Yast::Progress.set(progress_orig)
-        ret
+        system_config = Y2Users::ConfigManager.instance.system(force_read: true)
+        new_config = system_config.copy
+        _, target_config = Y2Users::UsersModule::Reader.new.read
+        remove_unchanged_elements(target_config)
+        Y2Users::ConfigMerger.new(new_config, target_config).merge
+        writer = Y2Users::Linux::Writer.new(new_config, system_config)
+        issues = writer.write
+        issues.empty?
       end
 
       def modified?
@@ -148,6 +170,23 @@ module Y2Users
         )
 
         root_user
+      end
+
+      # Clean users and groups that have not changed according to the 'modified' attributes
+      #
+      # @param config [Y2Users::Config] Configuration to clean
+      def remove_unchanged_elements(config)
+        all_users = Yast::Users.GetUsers("uid", "local").values +
+          Yast::Users.GetUsers("uid", "system").values
+        uids = all_users.select { |u| u["modified"] }.map { |u| u["uid"] }
+        users = config.users.reject { |u| uids.include?(u.name) }
+
+        all_groups = Yast::Users.GetGroups("cn", "local").values +
+          Yast::Users.GetGroups("cn", "system").values
+        gids = all_groups.select { |g| g["modified"] }.map { |g| g["cn"] }
+        groups = config.groups.reject { |g| gids.include?(g.name) }
+
+        (users + groups).each { |e| config.detach(e) }
       end
     end
   end


### PR DESCRIPTION
## Problem

* [bsc#1211753](https://bugzilla.suse.com/show_bug.cgi?id=1211753)

Users are not written when using AutoYaST on an already installed system, neither using `ayast_setup` nor the AutoYaST UI. In those scenarios, the process of detecting which users/groups changed is tricky:
                                                                                                                                                                                         
* The approach followed by [Y2Users::UsersModule::Reader](https://github.com/yast/yast-users/blob/414b6c7373068c367c0a01be20a1399fbd0ef470/src/lib/y2users/users_module/reader.rb#L103), checking the content of `org_user`, does not work because it is defined only if the user was modified using the AutoYaST UI.
* Directly comparing the users/groups from `system_config` and `target_config` does not work because passwords are missing from the `target_config` users.

```
{
  :class=>Y2Users::User, :name=>"systemd-timesync", :uid=>"496", :gid=>"496", :shell=>"/usr/sbin/nologin",
  :home=>#<Y2Users::Home:0x00005585a57372d0 @path="/", @permissions=nil, @btrfs_subvol=nil>,
  :gecos=>["systemd Time Synchronization"], :source=>:unknown, :password=>nil,
  :authorized_keys=>[], :receive_system_mail=>false, :secondary_groups_name=>[]
}
```

vs

```
{
  :class=>Y2Users::User, :name=>"systemd-timesync", :uid=>"496", :gid=>"496", :shell=>"/usr/sbin/nologin",
  :home=>#<Y2Users::Home:0x00005585a7bb4e78 @path="/">,
  :gecos=>["systemd Time Synchronization"], :source=>:unknown,
  :password=>#<Y2Users::Password:0x00005585a79f6730 @value=#Y2Users::PasswordEncryptedValue:0x00005585a79f67f8 @content=<secret>>, @aging=#<Y2Users::PasswordAging:0x00005585a79f66e0 @content="19515">, @minimum_age="", @maximum_age="", @warning_period="", @inactivity_period="", @account_expiration=#<Y2Users::AccountExpiration:0x00005585a79f66b8 @content="">>,
  :authorized_keys=>[], :receive_system_mail=>nil, :secondary_groups_name=>[]
}
```

## Solution
                                                                                                                                                                                      
To overcome these limitations, we only consider those users who 'modified'
property is not nil, although it does not guarantees that the user/group has
changed at all.



## Testing

- [x] Added a new unit test*
- Manually tested scenarios:
  - [x] AutoYaST UI importing a profile
  - [x] AutoYaST UI reading the users from the system (cloning)
  - [x] `yast2 clone_system`
  - [x] `yast2 ayast_setup setup filename=users.xml` (adding)
  - [x] `yast2 ayast_setup setup filename=users.xml` (editing a user)