### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.4
 
 -------------------------------------------------------------------
 Tue Jul 25 11:04:17 UTC 2023 - Michal Filka <mfilka@suse.com>

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.6.0
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.

## Solution

All fixes are already in SP5, so just update version to the latest in 4.6.X