### PR TITLE
Don't use Obsolete Method `Dir.exists?`

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 25 12:33:45 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't use obsolete method Dir.exists? (bsc#1215637)
+- 5.0.1 
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (#bsc1185510)

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/include/users/dialogs.rb
+++ b/src/include/users/dialogs.rb
@@ -1326,7 +1326,7 @@ module Yast
 
         # inside Details dialog
         if current == :details && ret == :browse
-          start_dir = Dir.exists?(home) ? home : Users.GetDefaultHome(new_type)
+          start_dir = Dir.exist?(home) ? home : Users.GetDefaultHome(new_type)
           selected_dir = cleanpath(UI.AskForExistingDirectory(start_dir, ""))
           UI.ChangeWidget(Id(:home), :Value, selected_dir) unless selected_dir.empty?
         end


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1215637

## Problem

Crash when trying to use the directory selector in the "Edit User" or "Add User" dialog with _"undefined method `exists?' for Dir:Class"_.


## Cause

`Dir.exists?` and `File.exists?` were deprecated long ago with Ruby 2.2, and now with Ruby 3.2 it was finally removed.

Both methods were just aliases for `Dir.exist?` and `File.exist?`, respectively (even though that's the usual Ruby slightly broken English).


## Fix

Now using `Dir.exist?` instead.


## What about Other Releases like SLE-15.x / Leap 15.x?

Those are still using Ruby 2.5 (SLE-15.5 / Leap 15.5) or older. No need to change it there as well.


## Test

Manual test on TW.