### PR TITLE
Drop obsolete comment documenting a feature that does not exist

### DIFF
--- a/src/lib/y2users/autoinst_profile/user_section.rb
+++ b/src/lib/y2users/autoinst_profile/user_section.rb
@@ -89,8 +89,7 @@ module Y2Users
       #   @return [String,nil] Default shell
       #
       # @!attribute user_password
-      #   @return [String,nil] User's password. If set to an exclamation mark ('!'),
-      #   a random password is generated. See #encrypted.
+      #   @return [String,nil] User's password.
       #
       # @!attribute encrypted
       #   @return [Boolean,nil] Determine whether #user_password is encrypted or not.


### PR DESCRIPTION
## Problem

While working on bsc#1216518 [*] where the SUSE docs implied the feature described by this comment existed I encountered this comment that confirmed the implication made by the docs. The docs should be hopefully fixed in the future but the existence of this comment is confusing as it implies this (now?) non-existent feature does exist.

[*] Not relevant to the comment itself so I did not mention the bug in the commit.

## Solution

Remove the part of the documenting comment that talks about the feature (random number being generated when '!' is used in the AutoYaST profile with the password declared as not encrypted).

Note: I also removed the second sentence referencing to the `encrypted` attribute. I did this because that attribute affects how the '!' password is interpreted and the reference was immediately after the removed part (rather than after the description of the `user_password` attribute) so I assumed the reference existed because of the random password feature. If it should remain, let me know and I will amend the commit.
