### PR TITLE
Relax Check in GECOS Field: Allow any Data except Colons [SLE-15-SP6]

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 21 13:21:10 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Relax check in GECOS field (bsc#1228149):
+  Allow any data except colons
+- 4.6.6
+
+-------------------------------------------------------------------
 Wed Aug 21 12:33:48 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Backport changes to avoid namespace collisions

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        4.6.5
+Version:        4.6.6
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/Users.pm
+++ b/src/modules/Users.pm
@@ -4659,14 +4659,6 @@ sub CheckGECOS {
 contain a colon (:).  Try again.");
     }
     
-    my @gecos_l = split (/,/, $gecos);
-    if (@gecos_l > 3 ) {
-	# error popup
-        return __("The \"Additional User Information\" entry can consist
-of up to three sections separated by commas.
-Remove the surplus.");
-    }
-    
     return "";
 }
 


### PR DESCRIPTION
## Target Branch

This is for **SLE-15-SP6**. A merge to Factory / TW will follow.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1228149


## Trello

https://trello.com/c/PLxx2iDV


## Problem

PAM in connection with some desktops like GNOME need an _umask_ specification to be set in the GECOS field (the comment / full user name field) in `/etc/passwd`.

But the YaST users module complains that only 3 fields separated by commas are permitted:

![y-users-gecos-error](https://github.com/user-attachments/assets/d4520c44-e17c-4c37-8d8b-00435306d8f9)

This is triggered when trying to leave that tab.


## Cause

There is an additional check in the ancient `Users.pm` Perl module that dates back to 2004. Why this check exists is unclear; there doesn't seem to be a reference why this limitation was introduced.


## Fix

Removed that check.


## Test

Manual test in a TW VM. After removing this check, it doesn't complain anymore, and `/etc/password` now contains the expected entry:

```console
% grep '^kilroy' /etc/passwd

kilroy:x:1001:100:Kilroy Anon,,,,UMASK=022:/home/kilroy:/bin/bash
```

## Further Reading

- `man 1 chfn`
- `man 8 pam_umask`

## Related PR

- Merge to Factory / TW:  _TBD_
