### PR TITLE
Drop Obsolete login.defs Scripts USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD, USERADD_CMD

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  1 13:31:05 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Removed obsolete USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD, 
+  GROUPADD_CMD (bsc#1231006)
+- 5.0.3 
+
+-------------------------------------------------------------------
 Wed Aug 21 13:21:10 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Relax check in GECOS field (bsc#1228149):

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/test/fixtures/root-missing-files/etc/login.defs
+++ b/test/fixtures/root-missing-files/etc/login.defs
@@ -217,8 +217,6 @@ DEFAULT_HOME	yes
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See USERDEL_PRECMD/POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
 
 #
@@ -263,25 +261,3 @@ CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][
 # new created group.
 #
 GROUPADD_CMD             /usr/sbin/groupadd.local
-
-#
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
-

--- a/test/fixtures/root-missing-files/etc/login.defs
+++ b/test/fixtures/root-missing-files/etc/login.defs
@@ -255,9 +255,3 @@ CREATE_HOME     no
 #CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
 CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?
 
-#
-# If defined, this command is run when adding a group.
-# It should rebuild any NIS database etc. to add the
-# new created group.
-#
-GROUPADD_CMD             /usr/sbin/groupadd.local

--- a/test/fixtures/root/etc/login.defs
+++ b/test/fixtures/root/etc/login.defs
@@ -217,8 +217,6 @@ DEFAULT_HOME	yes
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See USERDEL_PRECMD/POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
 
 #
@@ -263,25 +261,3 @@ CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][
 # new created group.
 #
 GROUPADD_CMD             /usr/sbin/groupadd.local
-
-#
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
-

--- a/test/fixtures/root/etc/login.defs
+++ b/test/fixtures/root/etc/login.defs
@@ -163,7 +163,7 @@ LOGIN_TIMEOUT		60
 # any combination of letters "frwh" (full name, room number, work
 # phone, home phone).  If not defined, no changes are allowed.
 # For backward compatibility, "yes" = "rwh" and "no" = "frwh".
-# 
+#
 CHFN_RESTRICT		rwh
 
 #
@@ -254,10 +254,3 @@ CREATE_HOME     no
 #
 #CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
 CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?
-
-#
-# If defined, this command is run when adding a group.
-# It should rebuild any NIS database etc. to add the
-# new created group.
-#
-GROUPADD_CMD             /usr/sbin/groupadd.local


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1231006


## Main PR

https://github.com/yast/yast-security/pull/160


## Details

This removes obsolete parameters from `/etc/login.defs`:

- USERADD_CMD
 - USERDEL_PRECMD
- USERDEL_POSTCMD
- USERADD_CMD

More details at the [main PR](https://github.com/yast/yast-security/pull/160).