### PR TITLE
Disable auto client unit tests

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul  4 15:47:36 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Temporarily disable Y2Users::Clients::Auto#run tests
+  (bsc#1245519).
+- 5.0.7
+
+-------------------------------------------------------------------
 Fri Jul  4 12:33:06 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Temporarily disable Users#Export tests (bsc#1245519).

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        5.0.5
+Version:        5.0.6
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/test/lib/users/clients/auto_test.rb
+++ b/test/lib/users/clients/auto_test.rb
@@ -11,7 +11,7 @@ Yast.import "Report"
 # defines exported users
 require_relative "../../../fixtures/users_export"
 
-describe Y2Users::Clients::Auto do
+xdescribe Y2Users::Clients::Auto do
   let(:mode) { "autoinstallation" }
   let(:args) { [func] }
 


### PR DESCRIPTION
Temporarly disable auto client tests.

Follow-up of #401.
