### PR TITLE
Fixed exiting check while creating home directory

### DIFF
--- a/package/yast2-users.changes
+++ b/package/yast2-users.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 13 14:09:17 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Fixed perl logic while creating home directory (belonging to bsc#1125779)
+- 5.0.7
+
+-------------------------------------------------------------------
 Fri Jul  4 15:47:36 UTC 2025 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Temporarily disable Y2Users::Clients::Auto#run tests

--- a/package/yast2-users.spec
+++ b/package/yast2-users.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-users
-Version:        5.0.6
+Version:        5.0.7
 Release:        0
 Summary:        YaST2 - User and Group Configuration
 License:        GPL-2.0-only

--- a/src/modules/UsersRoutines.pm
+++ b/src/modules/UsersRoutines.pm
@@ -126,7 +126,7 @@ sub CreateHome {
         return 0;
     }
 
-    if (!FileUtils->Exists ($home) > 0) {
+    if (!FileUtils->Exists ($home)) {
         # Create the home as btrfs subvolume
         if ($use_btrfs) {
 	    # checking Btrfs location of parent path


### PR DESCRIPTION

## Problem

Checking for existing home directory is wrong (since 6 years)

- https://bugzilla.opensuse.org/show_bug.cgi?id=112577

## Solution

Fixed check


## Testing

- *Tested manually*


